### PR TITLE
Shift responsibility of IDFA collection to clients

### DIFF
--- a/PostHog/Classes/Internal/PHGPostHogIntegration.m
+++ b/PostHog/Classes/Internal/PHGPostHogIntegration.m
@@ -154,8 +154,8 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     if (NSClassFromString(PHGAdvertisingClassIdentifier)) {
         dict[@"$device_adCapturingEnabled"] = @(GetAdCapturingEnabled());
     }
-    if (self.configuration.enableAdvertisingCapturing) {
-        NSString *idfa = PHGIDFA();
+    if (self.configuration.enableAdvertisingCapturing && self.configuration.adSupportBlock != nil) {
+        NSString *idfa = self.configuration.adSupportBlock();
         if (idfa.length) dict[@"$device_advertisingId"] = idfa;
     }
 

--- a/PostHog/Classes/Internal/PHGPostHogUtils.h
+++ b/PostHog/Classes/Internal/PHGPostHogUtils.h
@@ -32,8 +32,6 @@ void PHGLog(NSString *format, ...);
 
 JSON_DICT PHGCoerceDictionary(NSDictionary *_Nullable dict);
 
-NSString *_Nullable PHGIDFA(void);
-
 NSString *PHGEventNameForScreenTitle(NSString *title);
 
 // Deep copy and check NSCoding conformance

--- a/PostHog/Classes/Internal/PHGPostHogUtils.m
+++ b/PostHog/Classes/Internal/PHGPostHogUtils.m
@@ -1,5 +1,4 @@
 #import "PHGPostHogUtils.h"
-#import <AdSupport/ASIdentifierManager.h>
 
 static BOOL kPostHogLoggerShowLogs = NO;
 
@@ -162,27 +161,6 @@ NSDictionary *PHGCoerceDictionary(NSDictionary *dict)
     dict = [dict serializableDeepCopy];
     // coerce urls, and dates to the proper format
     return PHGCoerceJSONObject(dict);
-}
-
-NSString *PHGIDFA()
-{
-    NSString *idForAdvertiser = nil;
-    Class identifierManager = NSClassFromString(@"ASIdentifierManager");
-    if (identifierManager) {
-        SEL sharedManagerSelector = NSSelectorFromString(@"sharedManager");
-        id sharedManager =
-            ((id (*)(id, SEL))
-                 [identifierManager methodForSelector:sharedManagerSelector])(
-                identifierManager, sharedManagerSelector);
-        SEL advertisingIdentifierSelector =
-            NSSelectorFromString(@"advertisingIdentifier");
-        NSUUID *uuid =
-            ((NSUUID * (*)(id, SEL))
-                 [sharedManager methodForSelector:advertisingIdentifierSelector])(
-                sharedManager, advertisingIdentifierSelector);
-        idForAdvertiser = [uuid UUIDString];
-    }
-    return idForAdvertiser;
 }
 
 NSString *PHGEventNameForScreenTitle(NSString *title)

--- a/PostHog/Classes/PHGPostHogConfiguration.h
+++ b/PostHog/Classes/PHGPostHogConfiguration.h
@@ -73,6 +73,18 @@ typedef NSMutableURLRequest *_Nonnull (^PHGRequestFactory)(NSURL *_Nonnull);
 @property (nonatomic, assign) BOOL enableAdvertisingCapturing;
 
 /**
+ * Sets a block to be called when IDFA / AdSupport identifier is created.
+ * This is to allow for apps that do not want ad tracking to pass App Store guidelines in certain categories while
+ * still allowing apps that do ad tracking to continue to function.
+ *
+ * Example:
+ *      configuration.adSupportBlock = ^{
+ *          return [[ASIdentifierManager sharedManager] advertisingIdentifier];
+ *      }
+ */
+@property (nonatomic, copy, nullable) NSString * _Nonnull (^adSupportBlock)(void);
+
+/**
  * The number of queued events that the posthog client should flush at. Setting this to `1` will not queue any events and will use more battery. `20` by default.
  */
 @property (nonatomic, assign) NSUInteger flushAt;

--- a/PostHog/Classes/PHGPostHogConfiguration.m
+++ b/PostHog/Classes/PHGPostHogConfiguration.m
@@ -52,6 +52,7 @@
     if (self = [super init]) {
         self.shouldUseLocationServices = NO;
         self.enableAdvertisingCapturing = YES;
+        self.adSupportBlock = nil;
         self.shouldUseBluetooth = NO;
         self.flushAt = 20;
         self.flushInterval = 30;

--- a/PostHogTests/PostHogTests.swift
+++ b/PostHogTests/PostHogTests.swift
@@ -34,6 +34,7 @@ class PostHogTests: QuickSpec {
       expect(posthog.configuration.host) == URL(string: "https://app.posthog.com")
       expect(posthog.configuration.shouldUseLocationServices) == false
       expect(posthog.configuration.enableAdvertisingCapturing) == true
+      expect(posthog.configuration.adSupportBlock).to(beNil())
       expect(posthog.configuration.shouldUseBluetooth) == false
       expect(posthog.configuration.libraryName) == "posthog-ios"
       expect(posthog.configuration.libraryVersion) == PHGPostHog.version()
@@ -54,6 +55,7 @@ class PostHogTests: QuickSpec {
       expect(posthog.configuration.host) == URL(string: "https://testapp.posthog.test")
       expect(posthog.configuration.shouldUseLocationServices) == false
       expect(posthog.configuration.enableAdvertisingCapturing) == true
+      expect(posthog.configuration.adSupportBlock).to(beNil())
       expect(posthog.configuration.shouldUseBluetooth) == false
       expect(posthog.configuration.libraryVersion) == "posthog-ios-version"
       expect(posthog.configuration.libraryName) == "posthog-ios-test"


### PR DESCRIPTION
**What does this PR do?**
This is a backport from segmentio/analytics-ios (https://github.com/segmentio/analytics-ios/pull/892).

Any references to Apple's AdSupport framework might trip the App Store's static analysis, making it a bit unclear if SDK users can confidently say that their apps do not use the IDFA. By moving the responsibility to collect the IDFA out of the PostHog SDK and into the client app, the AdSupport references are gone and the question is easily answered.

**Where should the reviewer start?**
It's a pretty small PR, but note that the PHGIDFA() function is gone and the caller of that function now checks for and calls a block provided as part of the SDK initialization.

**How should this be manually tested?**
With no changes to a client app, trigger an event, and verify that `$device_advertisingId` no longer has any value.

Then modify the app to provide a block for `adSupportBlock` in the PostHog configuration. Triggering an event should now include the return value from this block as the value for `$device_advertisingId`.

**Any background context you want to provide?**

**What are the relevant tickets?**
#4 - Remove references to AdSupport framework

**Screenshots or screencasts (if UI/UX change)**
n/a

**Questions:**
- Does the docs need an update? Yes; if apps want to collect the IDFA from the user's device, merely setting `enableAdvertisingCapturing` is no longer sufficient.
- Are there any security concerns? No.
- Do we need to update engineering / success? No?