### PR TITLE
Remove ad capturing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.0 - 2020-12-18
+Completely remove reference to the AdSupport framework
+
 ## 1.1.0 - 2020-10-03
 Shift responsibility of IDFA collection to clients ([#5](https://github.com/PostHog/posthog-ios/pull/5))
 by removing any references to Apple's AdSupport framework from the library. In case you need to

--- a/PostHog.podspec
+++ b/PostHog.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PostHog"
-  s.version          = "1.1.0"
+  s.version          = "1.2.0"
   s.summary          = "The hassle-free way to add posthog to your iOS app."
 
   s.description      = <<-DESC

--- a/PostHog/Classes/Internal/PHGPostHogIntegration.m
+++ b/PostHog/Classes/Internal/PHGPostHogIntegration.m
@@ -22,7 +22,6 @@ NSString *const PHGPostHogDidSendRequestNotification = @"PostHogDidSendRequest";
 NSString *const PHGPostHogRequestDidSucceedNotification = @"PostHogRequestDidSucceed";
 NSString *const PHGPostHogRequestDidFailNotification = @"PostHogRequestDidFail";
 
-NSString *const PHGAdvertisingClassIdentifier = @"ASIdentifierManager";
 NSString *const PHGADClientClass = @"ADClient";
 
 NSString *const PHGDistinctIdKey = @"PHGDistinctId";
@@ -40,18 +39,6 @@ static NSString *GetDeviceModel()
     NSString *results = [NSString stringWithCString:result encoding:NSUTF8StringEncoding];
     return results;
 }
-
-static BOOL GetAdCapturingEnabled()
-{
-    BOOL result = NO;
-    Class advertisingManager = NSClassFromString(PHGAdvertisingClassIdentifier);
-    SEL sharedManagerSelector = NSSelectorFromString(@"sharedManager");
-    id sharedManager = ((id (*)(id, SEL))[advertisingManager methodForSelector:sharedManagerSelector])(advertisingManager, sharedManagerSelector);
-    SEL adTrackingEnabledSEL = NSSelectorFromString(@"isAdvertisingTrackingEnabled");
-    result = ((BOOL (*)(id, SEL))[sharedManager methodForSelector:adTrackingEnabledSEL])(sharedManager, adTrackingEnabledSEL);
-    return result;
-}
-
 
 @interface PHGPostHogIntegration ()
 
@@ -151,9 +138,6 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     dict[@"$device_model"] = GetDeviceModel();
     dict[@"$device_id"] = [[device identifierForVendor] UUIDString];
     dict[@"$device_name"] = [device model];
-    if (NSClassFromString(PHGAdvertisingClassIdentifier)) {
-        dict[@"$device_adCapturingEnabled"] = @(GetAdCapturingEnabled());
-    }
     if (self.configuration.enableAdvertisingCapturing && self.configuration.adSupportBlock != nil) {
         NSString *idfa = self.configuration.adSupportBlock();
         if (idfa.length) dict[@"$device_advertisingId"] = idfa;


### PR DESCRIPTION
According to issue #6, if you reference this old Apple ad framework in your code, your app won't be accepted to the app store. So this PR removes all references to it.

I pushed out version 1.2.0 with the change already as well.