### PR TITLE
Remove invalid Exclude: option from Package config

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,6 @@ let package = Package(
             name: "PostHog",
             dependencies: [],
             path: "PostHog/",
-            exclude: ["SwiftSources"],
             sources: ["Classes",
                       "Internal",
                       "Vendor"],


### PR DESCRIPTION
<img width="1000" alt="Screen Shot 2021-09-17 at 9 50 54 AM" src="https://user-images.githubusercontent.com/944809/133817819-f9d8e235-805d-4369-9bae-90d4fd28dd08.png">

**What does this PR do?**
- Removes the exclude line from the swift package configuration which points to a directory/file that does not exist

**Where should the reviewer start?**
- This may be hard to test inside the posthog-ios project but if you setup another Xcode project that includes this package as a dependency then you should no longer see the warning

**How should this be manually tested?**

**Any background context you want to provide?**

**What are the relevant tickets?**

**Screenshots or screencasts (if UI/UX change)**

**Questions:**
- Does the docs need an update?
- Are there any security concerns?
- Do we need to update engineering / success?
