### PR TITLE
Ignore Info.plist in the Swift Package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
             name: "PostHog",
             dependencies: [],
             path: "PostHog/",
+            exclude: ["Info.plist"],
             sources: ["Classes",
                       "Internal",
                       "Vendor"],


### PR DESCRIPTION
<img width="849" alt="Screen Shot 2021-09-17 at 11 01 29 AM" src="https://user-images.githubusercontent.com/944809/133826588-11904fc2-0d96-4f77-bf92-6fb9bbf8cc61.png">

**What does this PR do?**
- Avoids generating a warning in a client's project when including the posthog-ios package

**Where should the reviewer start?**
- Setup another Xcode project that uses the posthog-ios package and verify you don't see the warning about the Info.plist file

**How should this be manually tested?**

**Any background context you want to provide?**

**What are the relevant tickets?**

**Screenshots or screencasts (if UI/UX change)**

**Questions:**
- Does the docs need an update?
- Are there any security concerns?
- Do we need to update engineering / success?
