### PR TITLE
Add shouldSendDeviceID to PHGPostHogConfiguration.

### DIFF
--- a/PostHog/Classes/PHGPostHogConfiguration.h
+++ b/PostHog/Classes/PHGPostHogConfiguration.h
@@ -117,6 +117,13 @@ typedef NSMutableURLRequest *_Nonnull (^PHGRequestFactory)(NSURL *_Nonnull);
 @property (nonatomic, assign) BOOL captureDeepLinks;
 
 /**
+ * Whether the posthog client should include the `$device_id` property when sending events. When enabled, `UIDevice`'s `identifierForVendor` property is used.
+ * Changing the value of this property after initializing the client will have no effect.
+ * The default value is `YES`.
+ */
+@property (nonatomic, assign) BOOL shouldSendDeviceID;
+
+/**
  * Dictionary indicating the options the app was launched with.
  */
 @property (nonatomic, strong, nullable) NSDictionary *launchOptions;

--- a/PostHog/Classes/PHGPostHogConfiguration.m
+++ b/PostHog/Classes/PHGPostHogConfiguration.m
@@ -51,6 +51,7 @@
     if (self = [super init]) {
         self.shouldUseLocationServices = NO;
         self.shouldUseBluetooth = NO;
+        self.shouldSendDeviceID = YES;
         self.flushAt = 20;
         self.flushInterval = 30;
         self.maxQueueSize = 1000;

--- a/PostHog/Internal/PHGPostHogIntegration.m
+++ b/PostHog/Internal/PHGPostHogIntegration.m
@@ -136,7 +136,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     dict[@"$device_manufacturer"] = @"Apple";
     dict[@"$device_type"] = @"ios";
     dict[@"$device_model"] = GetDeviceModel();
-    dict[@"$device_id"] = [[device identifierForVendor] UUIDString];
+    dict[@"$device_id"] = self.configuration.shouldSendDeviceID ? [[device identifierForVendor] UUIDString] : nil;
     dict[@"$device_name"] = [device model];
 
     dict[@"$os_name"] = device.systemName;


### PR DESCRIPTION
**What does this PR do?**
Allows users of the library to opt out of sending a `$device_id` property by adding a `shouldSendDeviceID` to `PHGPostHogConfiguration`. The default value of this property is `YES` so there is no change to the standard behaviour.

**Where should the reviewer start?**
`PHGPostHogConfiguration.h`

**How should this be manually tested?**
Create a `PHGPostHogConfiguration` and set `shouldSendDeviceID` to `NO`/`false` before using it to create/setup the PostHog client. Observe that when disabled, no `$device_id` property is seen.

**Any background context you want to provide?**
I think it should be clear enough what I'm trying to do. Happy to rename if you have better suggestions (could be `disableDeviceID` perhaps).

**What are the relevant tickets?**
N/A

**Screenshots or screencasts (if UI/UX change)**
N/A

**Questions:**
- Does the docs need an update? - Would be helpful for other users looking to do this.
- Are there any security concerns? - Not that I can think of.
- Do we need to update engineering / success? - Probably an internal question?

Edit: This seems like the kind of change that would be useful to have a test for, however I don't have any experience using Quick/Nimble so haven't added one to the PR.
