### PR TITLE
Make enabled property public (readonly).

### DIFF
--- a/PostHog/Classes/PHGPostHog.h
+++ b/PostHog/Classes/PHGPostHog.h
@@ -14,6 +14,11 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PHGPostHog : NSObject
 
 /**
+ * Whether or not the posthog client is currently enabled.
+ */
+@property (nonatomic, assign, readonly) BOOL enabled;
+
+/**
  * Used by the posthog client to configure various options.
  */
 @property (nonatomic, strong, readonly) PHGPostHogConfiguration *configuration;


### PR DESCRIPTION
**What does this PR do?**
Currently you can call `enable` or `disable` on `PHGPostHog` but there is no way to inspect whether the client is actually enabled or not. Rather than requiring library users to keep track of this themselves, this makes the `enabled` property public (but read only) so it is easy to inspect.

**Edit:** I do wonder if it might be worth renaming the getter on this property to `isEnabled` is it's more obviously distinct from the `enable` method, happy to do so if you think this would be worthwhile.

**Where should the reviewer start?**
There's only 1 line changed :)

**How should this be manually tested?**
Create a client and then check the value after calling `enable`/`disable` on it.

**Any background context you want to provide?**
N/A

**What are the relevant tickets?**
N/A

**Screenshots or screencasts (if UI/UX change)**
N/A

**Questions:**
- Does the docs need an update? - Probably not.
- Are there any security concerns? - No
- Do we need to update engineering / success?
