### PR TITLE
adds PHGPostHogFeatureFlagsDidLoadNotification

### DIFF
--- a/PostHog/Classes/PHGNotificationNames.h
+++ b/PostHog/Classes/PHGNotificationNames.h
@@ -1,0 +1,16 @@
+//
+//  PHGNotificationNames.h
+//  
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ * NSNotification name, that is posted after integrations are loaded.
+ */
+extern NSString *_Nonnull PHGPostHogIntegrationDidStart;
+
+/**
+ * NSNotification name posted after feature flags have been successfully loaded.
+ */
+extern NSString *_Nonnull PHGPostHogFeatureFlagsDidLoadNotification;

--- a/PostHog/Classes/PHGNotificationNames.m
+++ b/PostHog/Classes/PHGNotificationNames.m
@@ -1,0 +1,10 @@
+//
+//  PHGNotificationNames.m
+//  
+//
+
+#import <Foundation/Foundation.h>
+
+NSString *PHGPostHogIntegrationDidStart = @"com.posthog.integration.did.start";
+
+NSString *PHGPostHogFeatureFlagsDidLoadNotification = @"com.posthog.featureFlags.did.load";

--- a/PostHog/Classes/PHGPayloadManager.h
+++ b/PostHog/Classes/PHGPayloadManager.h
@@ -1,13 +1,7 @@
 #import <Foundation/Foundation.h>
 #import "PHGMiddleware.h"
 
-/**
- * NSNotification name, that is posted after integrations are loaded.
- */
-extern NSString *_Nonnull PHGPostHogIntegrationDidStart;
-
 @class PHGPostHog;
-
 
 @interface PHGPayloadManager : NSObject
 

--- a/PostHog/Classes/PHGPayloadManager.m
+++ b/PostHog/Classes/PHGPayloadManager.m
@@ -8,11 +8,10 @@
 #import "PHGUserDefaultsStorage.h"
 #import "PHGPayloadManager.h"
 #import "PHGPostHogIntegration.h"
+#import "PHGNotificationNames.h"
 
-NSString *PHGPostHogIntegrationDidStart = @"com.posthog.integration.did.start";
 static NSString *const PHGAnonymousIdKey = @"PHGAnonymousId";
 static NSString *const kPHGAnonymousIdFilename = @"posthog.anonymousId";
-
 
 @interface PHGPayloadManager ()
 

--- a/PostHog/Internal/PHGPostHogIntegration.m
+++ b/PostHog/Internal/PHGPostHogIntegration.m
@@ -13,6 +13,7 @@
 #import "PHGScreenPayload.h"
 #import "PHGAliasPayload.h"
 #import "PHGGroupPayload.h"
+#import "PHGNotificationNames.h"
 
 #if TARGET_OS_IOS
 #import <CoreTelephony/CTCarrier.h>
@@ -623,6 +624,7 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
         [self.userDefaultsStorage setDictionary:flags forKey:PHGEnabledFeatureFlags];
 #else
         [self.fileStorage setDictionary:flags forKey:kPHGEnabledFeatureFlags];
+        [[NSNotificationCenter defaultCenter] postNotificationName: PHGPostHogFeatureFlagsDidLoadNotification object:nil];
 #endif
 }
 


### PR DESCRIPTION
Big fan, first time caller. I'm starting to use PostHog's experiments, and wanted an easy way to know which group users fell into. In my testing, all users were `control` at launch, and then were assigned to their groups some time later as data is fetched from the server.

**What does this PR do?**

Allows clients to delay checking for feature flags until they've loaded, as well as listen for relevant updates.

I tried to fit in with the current style of the project, but am glad to make any stylistic changes.

**Where should the reviewer start?**

**How should this be manually tested?**

On launch, or after calling `reloadFeatureFlags`, clients should expect the `PHGPostHogFeatureFlagsDidLoadNotification`.

**Any background context you want to provide?**

Questions: 

- do we want to do any kind of equality checking to only post this notification if there are changes to feature flags? If so, any suggestions?
- do we want to give the notification a prettier name for Swift clients
- if so, do we want to update or alias the `PHGPostHogIntegrationDidStart` notification to better match, for example providing a `Notification` suffix so the compiler automatically creates an NSNotification.Name for us.

**What are the relevant tickets?**

**Screenshots or screencasts (if UI/UX change)**

**Questions:**
- Does the docs need an update?

Perhaps—if you all agree with the change, it would be useful to let clients know to listen.

- Are there any security concerns?
- Do we need to update engineering / success?

