### PR TITLE
Add option to getFeatureFlag and isFeatureEnabled

### DIFF
--- a/PostHog/Classes/PHGPostHog.h
+++ b/PostHog/Classes/PHGPostHog.h
@@ -131,7 +131,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)group:(NSString *)groupType groupKey:(NSString *)groupKey properties:(SERIALIZABLE_DICT _Nullable)properties;
 
 - (id)getFeatureFlag:(NSString *)flagKey;
+- (id)getFeatureFlag:(NSString *)flagKey options:(NSDictionary *)options;
 - (bool)isFeatureEnabled:(NSString *)flagKey;
+- (bool)isFeatureEnabled:(NSString *)flagKey options:(NSDictionary *)options;
 - (void)reloadFeatureFlags;
 - (NSString *)getFeatureFlagStringPayload:(NSString *)flagKey defaultValue:(NSString *)defaultValue;
 - (NSInteger)getFeatureFlagIntegerPayload:(NSString *)flagKey defaultValue:(NSInteger)defaultValue;

--- a/PostHog/Classes/PHGPostHog.m
+++ b/PostHog/Classes/PHGPostHog.m
@@ -282,31 +282,52 @@ NSString *const PHGBuildKeyV2 = @"PHGBuildKeyV2";
 
 - (id)getFeatureFlag:(NSString *)flagKey
 {
+    return [self getFeatureFlag:flagKey options:nil];
+}
+
+- (id)getFeatureFlag:(NSString *)flagKey options:(NSDictionary *)options
+{
     NSDictionary *variants = [self.payloadManager getFlagVariants];
     id variantValue = [variants valueForKey:flagKey];
-    NSMutableDictionary *properties = [NSMutableDictionary dictionary];
-    [properties setValue:flagKey forKey:@"$feature_flag"];
-    [properties setValue:variantValue forKey:@"$feature_flag_response"];
-    
-    [self run:PHGEventTypeCapture payload:
-                                    [[PHGCapturePayload alloc] initWithEvent:@"$feature_flag_called"
-                                                                  properties:PHGCoerceDictionary(properties)]];
+
+    id send_event = [options valueForKey:@"send_event"];
+
+    if (send_event == nil || [send_event boolValue] != false) {
+        NSMutableDictionary *properties = [NSMutableDictionary dictionary];
+        [properties setValue:flagKey forKey:@"$feature_flag"];
+        [properties setValue:variantValue forKey:@"$feature_flag_response"];
+        
+        
+        [self run:PHGEventTypeCapture payload:
+                                        [[PHGCapturePayload alloc] initWithEvent:@"$feature_flag_called"
+                                                                    properties:PHGCoerceDictionary(properties)]];
+    }
+
     return variantValue;
 }
 
 - (bool)isFeatureEnabled:(NSString *)flagKey
 {
+    return [self isFeatureEnabled:flagKey options:nil];
+}
+
+- (bool)isFeatureEnabled:(NSString *)flagKey options:(NSDictionary *)options
+{
     NSArray *keys = [self.payloadManager getFeatureFlags];
     BOOL isFlagEnabled = [keys containsObject: flagKey];
     
-    NSMutableDictionary *properties = [NSMutableDictionary dictionary];
-
-    [properties setValue:flagKey forKey:@"$feature_flag"];
-    [properties setValue:@(isFlagEnabled) forKey:@"$feature_flag_response"];
+    id send_event = [options valueForKey:@"send_event"];
     
-    [self run:PHGEventTypeCapture payload:
-                                    [[PHGCapturePayload alloc] initWithEvent:@"$feature_flag_called"
-                                                                  properties:PHGCoerceDictionary(properties)]];
+    if (send_event == nil || [send_event boolValue] != false) {
+        NSMutableDictionary *properties = [NSMutableDictionary dictionary];
+
+        [properties setValue:flagKey forKey:@"$feature_flag"];
+        [properties setValue:@(isFlagEnabled) forKey:@"$feature_flag_response"];
+        
+        [self run:PHGEventTypeCapture payload:
+                                        [[PHGCapturePayload alloc] initWithEvent:@"$feature_flag_called"
+                                                                    properties:PHGCoerceDictionary(properties)]];
+    }
     
     return isFlagEnabled;
 }


### PR DESCRIPTION
**What does this PR do?**
- getFeatureFlag and isFeatureEnabled will accept `options`. send_event option will toggle sending of $feature_flag_called events

**Where should the reviewer start?**

**How should this be manually tested?**

**Any background context you want to provide?**

**What are the relevant tickets?**

**Screenshots or screencasts (if UI/UX change)**

**Questions:**
- Does the docs need an update?
- Are there any security concerns?
- Do we need to update engineering / success?
