### PR TITLE
Remove unnecessary adclient support

### DIFF
--- a/PostHog/Internal/PHGPostHogIntegration.m
+++ b/PostHog/Internal/PHGPostHogIntegration.m
@@ -23,8 +23,6 @@ NSString *const PHGPostHogDidSendRequestNotification = @"PostHogDidSendRequest";
 NSString *const PHGPostHogRequestDidSucceedNotification = @"PostHogRequestDidSucceed";
 NSString *const PHGPostHogRequestDidFailNotification = @"PostHogRequestDidFail";
 
-NSString *const PHGADClientClass = @"ADClient";
-
 NSString *const PHGDistinctIdKey = @"PHGDistinctId";
 NSString *const PHGQueueKey = @"PHGQueue";
 

--- a/PostHog/Internal/PHGPostHogIntegration.m
+++ b/PostHog/Internal/PHGPostHogIntegration.m
@@ -155,25 +155,26 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     dict[@"$screen_width"] = @(screenSize.width);
     dict[@"$screen_height"] = @(screenSize.height);
 
-#if !(TARGET_IPHONE_SIMULATOR)
-    Class adClient = NSClassFromString(PHGADClientClass);
-    if (adClient) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-        id sharedClient = [adClient performSelector:NSSelectorFromString(@"sharedClient")];
-#pragma clang diagnostic pop
-        void (^completionHandler)(BOOL iad) = ^(BOOL iad) {
-            if (iad) {
-                dict[@"$referrer_type"] = @"iad";
-            }
-        };
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-        [sharedClient performSelector:NSSelectorFromString(@"determineAppInstallationAttributionWithCompletionHandler:")
-                           withObject:completionHandler];
-#pragma clang diagnostic pop
-    }
-#endif
+// This bit below doesn't seem to be effective anymore.  Will investigate later.
+// #if !(TARGET_IPHONE_SIMULATOR)
+//     Class adClient = NSClassFromString(PHGADClientClass);
+//     if (adClient) {
+// #pragma clang diagnostic push
+// #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+//         id sharedClient = [adClient performSelector:NSSelectorFromString(@"sharedClient")];
+// #pragma clang diagnostic pop
+//         void (^completionHandler)(BOOL iad) = ^(BOOL iad) {
+//             if (iad) {
+//                 dict[@"$referrer_type"] = @"iad";
+//             }
+//         };
+// #pragma clang diagnostic push
+// #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+//         [sharedClient performSelector:NSSelectorFromString(@"determineAppInstallationAttributionWithCompletionHandler:")
+//                            withObject:completionHandler];
+// #pragma clang diagnostic pop
+//     }
+// #endif
 
     return dict;
 }

--- a/PostHog/Internal/PHGPostHogIntegration.m
+++ b/PostHog/Internal/PHGPostHogIntegration.m
@@ -155,27 +155,6 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     dict[@"$screen_width"] = @(screenSize.width);
     dict[@"$screen_height"] = @(screenSize.height);
 
-// This bit below doesn't seem to be effective anymore.  Will investigate later.
-// #if !(TARGET_IPHONE_SIMULATOR)
-//     Class adClient = NSClassFromString(PHGADClientClass);
-//     if (adClient) {
-// #pragma clang diagnostic push
-// #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-//         id sharedClient = [adClient performSelector:NSSelectorFromString(@"sharedClient")];
-// #pragma clang diagnostic pop
-//         void (^completionHandler)(BOOL iad) = ^(BOOL iad) {
-//             if (iad) {
-//                 dict[@"$referrer_type"] = @"iad";
-//             }
-//         };
-// #pragma clang diagnostic push
-// #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-//         [sharedClient performSelector:NSSelectorFromString(@"determineAppInstallationAttributionWithCompletionHandler:")
-//                            withObject:completionHandler];
-// #pragma clang diagnostic pop
-//     }
-// #endif
-
     return dict;
 }
 


### PR DESCRIPTION
`determineAppInstallationAttributionWithCompletionHandler` returns with warnings about usage of iOS private APIs and isn't really needed in general right now