### PR TITLE
Stop using UIScreen.mainScreen to fix accent color

### DIFF
--- a/PostHog/Internal/PHGPostHogIntegration.m
+++ b/PostHog/Internal/PHGPostHogIntegration.m
@@ -149,9 +149,13 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
     dict[@"$os_name"] = device.systemName;
     dict[@"$os_version"] = device.systemVersion;
 
-    CGSize screenSize = [UIScreen mainScreen].bounds.size;
-    dict[@"$screen_width"] = @(screenSize.width);
-    dict[@"$screen_height"] = @(screenSize.height);
+    // Access the screen via a window as UIScreen.mainScreen is deprecated
+    // and using it messes with the accent color in SwiftUI apps.
+    UIScreen *appScreen = UIApplication.sharedApplication.windows.firstObject.screen;
+    if (appScreen != nil) {
+        dict[@"$screen_width"] = @(appScreen.bounds.size.height);
+        dict[@"$screen_height"] = @(appScreen.bounds.size.width);
+    }
 
     return dict;
 }


### PR DESCRIPTION
**What does this PR do?**
`UIScreen.mainScreen` is deprecated and SwiftUI apps lose their accent colour if the screen is accessed this way before the app's body is evaluated. This PR switches to reading the screen size from the app's first window and fixes #53.

**Where should the reviewer start?**
Test it against a sample app.

**How should this be manually tested?**
Read the steps to reproduce the issue in #53 and test this PR against that.

**Any background context you want to provide?**
No

**What are the relevant tickets?**
#53

**Screenshots or screencasts (if UI/UX change)**

**Questions:**
- Does the docs need an update? No
- Are there any security concerns? No
- Do we need to update engineering / success? No
