### PR TITLE
Add Callback Support to `reloadFeatureFlags` Method

### DIFF
--- a/PostHog/Classes/PHGPostHog.h
+++ b/PostHog/Classes/PHGPostHog.h
@@ -135,6 +135,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (bool)isFeatureEnabled:(NSString *)flagKey;
 - (bool)isFeatureEnabled:(NSString *)flagKey options:(NSDictionary *_Nullable)options;
 - (void)reloadFeatureFlags;
+- (void)reloadFeatureFlagsWithCallback:(void(^)(void))callback;
 - (NSString *)getFeatureFlagStringPayload:(NSString *)flagKey defaultValue:(NSString *)defaultValue;
 - (NSInteger)getFeatureFlagIntegerPayload:(NSString *)flagKey defaultValue:(NSInteger)defaultValue;
 - (double)getFeatureFlagDoublePayload:(NSString *)flagKey defaultValue:(double)defaultValue;


### PR DESCRIPTION
**What does this PR do?**
This PR adds support for receiving a callback when fetching feature flags.

**Where should the reviewer start?**
I added a new method to the `PHGPostHog` class that allows the user to specify a callback when fetching feature flags.

**How should this be manually tested?**
Make sure that the user receives a callback when the feature flags are finished being fetched.

**Any background context you want to provide?**
We would like to be able to fetch feature flags at app launch and wait to proceed until they are guaranteed to be fetched.  The infrastructure appeared to be already in place, and I just hooked it up.

**What are the relevant tickets?**
N/A

**Screenshots or screencasts (if UI/UX change)**
<img width="1253" alt="Screenshot 2023-10-18 at 1 51 27 PM" src="https://github.com/PostHog/posthog-ios/assets/1508740/4e848e6d-26ef-42f7-b5f5-843a7aea4c23">


**Questions:**
- Does the docs need an update?
You may want to mention this functionality in your iOS SDK docs.
- Are there any security concerns?
No.
- Do we need to update engineering / success?
Probably not.
