### PR TITLE
Fix release tag name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,11 @@ jobs:
         run: |
           echo "Tag name from github.ref_name: ${{ github.event.release.target_commitish }}"
           ./scripts/commit-code.sh ${{ github.event.release.target_commitish }}
+
+      - name: Commit & push
+        run: |
+          echo "Tag name from github.ref_name: ${{ github.event.release.target_commitish }}"
+          ./scripts/update-tag.sh ${{ github.event.release.target_commitish }}
   
       - name: Release
         run: make releaseCocoaPods

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           echo "Tag name from github.ref_name: ${{ github.event.release.target_commitish }}"
           ./scripts/commit-code.sh ${{ github.event.release.target_commitish }}
 
-      - name: Commit & push
+      - name: Update tag
         run: |
           echo "Tag name from github.ref_name: ${{ github.event.release.target_commitish }}"
           ./scripts/update-tag.sh ${{ github.event.release.target_commitish }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,16 +2,13 @@ Releasing
 =========
 
  1. Update the CHANGELOG.md with the version and date
- 2. Create a tag with the version number (e.g. `3.0.0`)
-    1. Preview releases follow the pattern `3.0.0-alpha.1`, `3.0.0-beta.1`, `3.0.0-RC.1`
-    2. `git tag -a 3.0.0 -m "3.0.0"`
-    3. `git push && git push --tags`
- 3. Go to [GH Releases](https://github.com/PostHog/posthog-ios/releases)
- 4. Choose a tag name (e.g. `3.0.0`), this is the tag of the release (From Step 2.).
- 5. Choose a release name (e.g. `3.0.0`), ideally it matches the above.
- 6. Write a description of the release.
- 7. Publish the release.
- 8. GH Action (release.yml) is doing everything else automatically.
+ 2. Go to [GH Releases](https://github.com/PostHog/posthog-ios/releases)
+ 3. Choose a tag name (e.g. `3.0.0`), this is the version number of the release.
+     1. Preview releases follow the pattern `3.0.0-alpha.1`, `3.0.0-beta.1`, `3.0.0-RC.1`
+ 4. Choose a release name (e.g. `3.0.0`), ideally it matches the above.
+ 5. Write a description of the release.
+ 6. Publish the release.
+ 7. GH Action (release.yml) is doing everything else automatically.
       1. SPM uses the tag name to determine the version, directly from the repo.
       2. CocoaPods are published.
- 9. Done.
+ 8. Done.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,14 +1,17 @@
 Releasing
 =========
 
- 1. Update the CHANGELOG.md with the version and date 
- 2. Go to [GH Releases](https://github.com/PostHog/posthog-ios/releases)
- 3. Choose a tag name (e.g. `3.0.0`), this is the version number of the release.
-     1. Preview releases follow the pattern `3.0.0-alpha.1`, `3.0.0-beta.1`, `3.0.0-RC.1`
- 4. Choose a release name (e.g. `3.0.0`), ideally it matches the above.
- 5. Write a description of the release.
- 6. Publish the release.
- 7. GH Action (release.yml) is doing everything else automatically.
+ 1. Update the CHANGELOG.md with the version and date
+ 2. Create a tag with the version number (e.g. `3.0.0`)
+    1. Preview releases follow the pattern `3.0.0-alpha.1`, `3.0.0-beta.1`, `3.0.0-RC.1`
+    2. `git tag -a 3.0.0 -m "3.0.0"`
+    3. `git push && git push --tags`
+ 3. Go to [GH Releases](https://github.com/PostHog/posthog-ios/releases)
+ 4. Choose a tag name (e.g. `3.0.0`), this is the tag of the release (From Step 2.).
+ 5. Choose a release name (e.g. `3.0.0`), ideally it matches the above.
+ 6. Write a description of the release.
+ 7. Publish the release.
+ 8. GH Action (release.yml) is doing everything else automatically.
       1. SPM uses the tag name to determine the version, directly from the repo.
       2. CocoaPods are published.
- 8. Done.
+ 9. Done.

--- a/scripts/update-tag.sh
+++ b/scripts/update-tag.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+CURRENT_TAG="$1"
+TEMP_TAG="${CURRENT_TAG}-temp"
+
+echo "Going to push the tag changes."
+git config --global user.name 'PostHog Github Bot'
+git config --global user.email 'github-bot@posthog.com'
+git fetch
+git checkout ${CURRENT_TAG}
+# Create new temporary tag after pushing the changes from the previous tag
+git tag -a ${TEMP_TAG} -m "${TEMP_TAG}"
+# Remove the old tag
+git tag -d ${CURRENT_TAG}
+# Remove old tag in remote machine
+git push --delete origin ${CURRENT_TAG}
+# Create new tag that points to the temporary tag
+git tag ${CURRENT_TAG} ${TEMP_TAG}
+# Remove temporary tag
+git tag -d ${TEMP_TAG}
+# Propapate new tag to remote machine
+git push --tags

--- a/scripts/update-tag.sh
+++ b/scripts/update-tag.sh
@@ -9,13 +9,13 @@ git config --global user.name 'PostHog Github Bot'
 git config --global user.email 'github-bot@posthog.com'
 git fetch
 git checkout ${CURRENT_TAG}
-# Create new temporary tag after pushing the changes from the previous tag
+# Create a new temporary tag after pushing the changes from the previous tag (bump version)
 git tag -a ${TEMP_TAG} -m "${TEMP_TAG}"
-# Remove the old tag
+# Remove the current tag
 git tag -d ${CURRENT_TAG}
-# Remove old tag in remote machine
+# Remove the current tag in remote machine
 git push --delete origin ${CURRENT_TAG}
-# Create new tag that points to the temporary tag
+# Create a new tag that points to the temporary tag
 git tag ${CURRENT_TAG} ${TEMP_TAG}
 # Remove temporary tag
 git tag -d ${TEMP_TAG}


### PR DESCRIPTION
## :bulb: Motivation and Context
The GH release creates the tag before triggering the action, so the tag is pointed out to the code before the `bump-version.sh` changes which is OK for Cocoapods since the code is uploaded after the changes, but not ok for SPM since SPM depends on the tag.
This commit updates the tag after the `bump-version.sh` is executed.

The side effect was that someone using `3.0.0-alpha.3` would be reported as `$lib_version=3.0.0-alpha.2`.

_#skip-changelog_


## :green_heart: How did you test it?
Locally.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
