### PR TITLE
Do not report dupe `Application Opened` event during the first time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- Do not report dupe `Application Opened` event during the first time [#75](https://github.com/PostHog/posthog-ios/pull/75)
+
 ## 3.0.0-beta.2 - 2024-01-09
 
 - Internal changes only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- Do not report dupe `Application Opened` event during the first time [#75](https://github.com/PostHog/posthog-ios/pull/75)
+- Do not report dupe `Application Opened` event during the first time [#95](https://github.com/PostHog/posthog-ios/pull/95)
 
 ## 3.0.0-beta.2 - 2024-01-09
 

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -41,6 +41,7 @@ let maxRetryDelay = 30.0
     private static var apiKeys = Set<String>()
     private var capturedAppInstalled = false
     private var appFromBackground = false
+    private var ignoreFirstAppFromBackground = true
 
     @objc public static let shared: PostHogSDK = {
         let instance = PostHogSDK(PostHogConfig(apiKey: ""))
@@ -738,6 +739,14 @@ let maxRetryDelay = 30.0
     }
 
     @objc func captureAppOpenedFromBackground() {
+        // when the app is opened for the first time, the OS sends 2 notifications, didFinishLaunchingNotification
+        // and willEnterForegroundNotification, but we only want to log one "Application Opened" event.
+        // All the following app opened from background events should be logged normally.
+        if ignoreFirstAppFromBackground {
+            ignoreFirstAppFromBackground = false
+            return
+        }
+
         var props: [String: Any] = [:]
         props["from_background"] = appFromBackground
 

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -641,7 +641,7 @@ let maxRetryDelay = 30.0
 
         #if os(iOS) || os(tvOS)
             defaultCenter.addObserver(self,
-                                      selector: #selector(captureAppLifecycle),
+                                      selector: #selector(captureAppInstallLifecycle),
                                       name: UIApplication.didFinishLaunchingNotification,
                                       object: nil)
             defaultCenter.addObserver(self,
@@ -649,7 +649,7 @@ let maxRetryDelay = 30.0
                                       name: UIApplication.didEnterBackgroundNotification,
                                       object: nil)
             defaultCenter.addObserver(self,
-                                      selector: #selector(captureAppOpenedFromBackground),
+                                      selector: #selector(captureAppOpened),
                                       name: UIApplication.didBecomeActiveNotification,
                                       object: nil)
         #endif
@@ -663,7 +663,11 @@ let maxRetryDelay = 30.0
         }
     }
 
-    func captureAppInstalled() {
+    @objc func captureAppInstallLifecycle() {
+        if !config.captureApplicationLifecycleEvents {
+            return
+        }
+
         let bundle = Bundle.main
 
         let versionName = bundle.infoDictionary?["CFBundleShortVersionString"] as? String
@@ -718,42 +722,27 @@ let maxRetryDelay = 30.0
         }
     }
 
-    func captureAppOpened() {
-        var props: [String: Any] = [:]
-        props["from_background"] = false
-
-        let bundle = Bundle.main
-
-        let versionName = bundle.infoDictionary?["CFBundleShortVersionString"] as? String
-        let versionCode = bundle.infoDictionary?["CFBundleVersion"] as? String
-
-        if versionName != nil {
-            props["version"] = versionName
-        }
-        if versionCode != nil {
-            props["build"] = versionCode
-        }
-
-        capture("Application Opened", properties: props)
-    }
-
-    @objc func captureAppOpenedFromBackground() {
+    @objc func captureAppOpened() {
         var props: [String: Any] = [:]
         props["from_background"] = appFromBackground
 
         if !appFromBackground {
+            let bundle = Bundle.main
+
+            let versionName = bundle.infoDictionary?["CFBundleShortVersionString"] as? String
+            let versionCode = bundle.infoDictionary?["CFBundleVersion"] as? String
+
+            if versionName != nil {
+                props["version"] = versionName
+            }
+            if versionCode != nil {
+                props["build"] = versionCode
+            }
+
             appFromBackground = true
         }
 
         capture("Application Opened", properties: props)
-    }
-
-    @objc private func captureAppLifecycle() {
-        if !config.captureApplicationLifecycleEvents {
-            return
-        }
-
-        captureAppInstalled()
     }
 
     @objc func captureAppBackgrounded() {

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -41,7 +41,6 @@ let maxRetryDelay = 30.0
     private static var apiKeys = Set<String>()
     private var capturedAppInstalled = false
     private var appFromBackground = false
-    private var ignoreFirstAppFromBackground = true
 
     @objc public static let shared: PostHogSDK = {
         let instance = PostHogSDK(PostHogConfig(apiKey: ""))
@@ -651,7 +650,7 @@ let maxRetryDelay = 30.0
                                       object: nil)
             defaultCenter.addObserver(self,
                                       selector: #selector(captureAppOpenedFromBackground),
-                                      name: UIApplication.willEnterForegroundNotification,
+                                      name: UIApplication.didBecomeActiveNotification,
                                       object: nil)
         #endif
     }
@@ -739,14 +738,6 @@ let maxRetryDelay = 30.0
     }
 
     @objc func captureAppOpenedFromBackground() {
-        // when the app is opened for the first time, the OS sends 2 notifications, didFinishLaunchingNotification
-        // and willEnterForegroundNotification, but we only want to log one "Application Opened" event.
-        // All the following app opened from background events should be logged normally.
-        if ignoreFirstAppFromBackground {
-            ignoreFirstAppFromBackground = false
-            return
-        }
-
         var props: [String: Any] = [:]
         props["from_background"] = appFromBackground
 
@@ -763,7 +754,6 @@ let maxRetryDelay = 30.0
         }
 
         captureAppInstalled()
-        captureAppOpened()
     }
 
     @objc func captureAppBackgrounded() {

--- a/PostHogExample/AppDelegate.swift
+++ b/PostHogExample/AppDelegate.swift
@@ -12,10 +12,12 @@ import UIKit
 class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         let config = PostHogConfig(
-            apiKey: "_6SG-F7I1vCuZ-HdJL3VZQqjBlaSb1_20hDPwqMNnGI"
+            apiKey: "phc_pQ70jJhZKHRvDIL5ruOErnPy6xiAiWCqlL4ayELj4X8"
         )
         // the ScreenViews for SwiftUI does not work, the names are not useful
         config.captureScreenViews = false
+        config.flushAt = 1
+        config.flushIntervalSeconds = 10
 
         PostHogSDK.shared.setup(config)
 //        PostHogSDK.shared.debug()

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -346,9 +346,7 @@ class PostHogSDKTest: QuickSpec {
 
             sut.captureAppOpenedFromBackground()
 
-            let events = getBatchedEvents(server)
-
-            expect(events.count) == 0
+            expect(server.batchRequests.count) == 0
 
             sut.reset()
             sut.close()

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -301,7 +301,7 @@ class PostHogSDKTest: QuickSpec {
         it("capture AppInstalled") {
             let sut = self.getSut()
 
-            sut.captureAppInstalled()
+            sut.captureAppInstallLifecycle()
 
             let events = getBatchedEvents(server)
 
@@ -324,7 +324,7 @@ class PostHogSDKTest: QuickSpec {
             userDefaults.setValue("1", forKey: "PHGBuildKeyV2")
             userDefaults.synchronize()
 
-            sut.captureAppInstalled()
+            sut.captureAppInstallLifecycle()
 
             let events = getBatchedEvents(server)
 
@@ -344,7 +344,7 @@ class PostHogSDKTest: QuickSpec {
         it("capture AppOpenedFromBackground from_background should be false") {
             let sut = self.getSut()
 
-            sut.captureAppOpenedFromBackground()
+            sut.captureAppOpened()
 
             let events = getBatchedEvents(server)
 
@@ -361,8 +361,8 @@ class PostHogSDKTest: QuickSpec {
         it("capture AppOpenedFromBackground from_background should be true") {
             let sut = self.getSut(flushAt: 2)
 
-            sut.captureAppOpenedFromBackground()
-            sut.captureAppOpenedFromBackground()
+            sut.captureAppOpened()
+            sut.captureAppOpened()
 
             let events = getBatchedEvents(server)
 

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -341,9 +341,24 @@ class PostHogSDKTest: QuickSpec {
             sut.close()
         }
 
-        it("capture AppOpenedFromBackground") {
+        it("ignore first AppOpenedFromBackground") {
             let sut = self.getSut()
 
+            sut.captureAppOpenedFromBackground()
+
+            let events = getBatchedEvents(server)
+
+            expect(events.count) == 0
+
+            sut.reset()
+            sut.close()
+        }
+
+        it("capture AppOpenedFromBackground from_background should be false") {
+            let sut = self.getSut()
+
+            // the first call is just to flip the ignoreFirstAppFromBackground flag
+            sut.captureAppOpenedFromBackground()
             sut.captureAppOpenedFromBackground()
 
             let events = getBatchedEvents(server)
@@ -358,9 +373,11 @@ class PostHogSDKTest: QuickSpec {
             sut.close()
         }
 
-        it("capture AppOpenedFromBackground") {
+        it("capture AppOpenedFromBackground from_background should be true") {
             let sut = self.getSut(flushAt: 2)
 
+            // the first call is just to flip the ignoreFirstAppFromBackground flag
+            sut.captureAppOpenedFromBackground()
             sut.captureAppOpenedFromBackground()
             sut.captureAppOpenedFromBackground()
 

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -341,22 +341,9 @@ class PostHogSDKTest: QuickSpec {
             sut.close()
         }
 
-        it("ignore first AppOpenedFromBackground") {
-            let sut = self.getSut()
-
-            sut.captureAppOpenedFromBackground()
-
-            expect(server.batchRequests.count) == 0
-
-            sut.reset()
-            sut.close()
-        }
-
         it("capture AppOpenedFromBackground from_background should be false") {
             let sut = self.getSut()
 
-            // the first call is just to flip the ignoreFirstAppFromBackground flag
-            sut.captureAppOpenedFromBackground()
             sut.captureAppOpenedFromBackground()
 
             let events = getBatchedEvents(server)
@@ -374,8 +361,6 @@ class PostHogSDKTest: QuickSpec {
         it("capture AppOpenedFromBackground from_background should be true") {
             let sut = self.getSut(flushAt: 2)
 
-            // the first call is just to flip the ignoreFirstAppFromBackground flag
-            sut.captureAppOpenedFromBackground()
             sut.captureAppOpenedFromBackground()
             sut.captureAppOpenedFromBackground()
 


### PR DESCRIPTION
## :bulb: Motivation and Context
`Application Opened` event was being reported twice when opening for the first time.
The OS sends 2 notifications and we were calling the method in both of them


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [X] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
