### PR TITLE
chore: better macos support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- better macOS support with more event properties [#95](https://github.com/PostHog/posthog-ios/pull/95)
+
 ## 3.0.0-beta.3 - 2024-01-11
 
 - Do not report dupe `Application Opened` event during the first time [#95](https://github.com/PostHog/posthog-ios/pull/95)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- better macOS support with more event properties [#95](https://github.com/PostHog/posthog-ios/pull/95)
+- better macOS support with more event properties [#96](https://github.com/PostHog/posthog-ios/pull/96)
 
 ## 3.0.0-beta.3 - 2024-01-11
 

--- a/PostHog/PostHogContext.swift
+++ b/PostHog/PostHogContext.swift
@@ -9,6 +9,8 @@ import Foundation
 
 #if os(iOS) || os(tvOS)
     import UIKit
+#elseif os(macOS)
+    import AppKit
 #endif
 
 class PostHogContext {
@@ -35,13 +37,13 @@ class PostHogContext {
         if Bundle.main.bundleIdentifier != nil {
             properties["$app_namespace"] = Bundle.main.bundleIdentifier
         }
+        properties["$device_manufacturer"] = "Apple"
+        properties["$device_model"] = platform()
 
         #if os(iOS) || os(tvOS)
             let device = UIDevice.current
             // use https://github.com/devicekit/DeviceKit
-            properties["$device_model"] = platform()
             properties["$device_name"] = device.model
-            properties["$device_manufacturer"] = "Apple"
             properties["$os_name"] = device.systemName
             properties["$os_version"] = device.systemVersion
 
@@ -63,6 +65,16 @@ class PostHogContext {
             if deviceType != nil {
                 properties["$device_type"] = deviceType
             }
+        #elseif os(macOS)
+            let deviceName = Host.current().localizedName
+            if ((deviceName?.isEmpty) != nil) {
+                properties["$device_name"] = deviceName
+            }
+            let processInfo = ProcessInfo.processInfo
+            properties["$os_name"] = "macOS \(processInfo.operatingSystemVersionString)" // eg Version 14.2.1 (Build 23C71)
+            let osVersion = processInfo.operatingSystemVersion;
+            properties["$os_version"] = "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
+            properties["$device_type"] = "Desktop"
         #endif
 
         return properties
@@ -94,6 +106,12 @@ class PostHogContext {
         #if os(iOS) || os(tvOS)
             properties["$screen_width"] = Float(UIScreen.main.bounds.width)
             properties["$screen_height"] = Float(UIScreen.main.bounds.height)
+        #elseif os(macOS)
+            if let mainScreen = NSScreen.main {
+                let screenFrame = mainScreen.visibleFrame
+                properties["$screen_width"] = Float(screenFrame.size.width)
+                properties["$screen_height"] = Float(screenFrame.size.height)
+            }
         #endif
 
         properties["$lib"] = postHogSdkName

--- a/PostHog/PostHogContext.swift
+++ b/PostHog/PostHogContext.swift
@@ -67,12 +67,12 @@ class PostHogContext {
             }
         #elseif os(macOS)
             let deviceName = Host.current().localizedName
-            if ((deviceName?.isEmpty) != nil) {
+            if (deviceName?.isEmpty) != nil {
                 properties["$device_name"] = deviceName
             }
             let processInfo = ProcessInfo.processInfo
             properties["$os_name"] = "macOS \(processInfo.operatingSystemVersionString)" // eg Version 14.2.1 (Build 23C71)
-            let osVersion = processInfo.operatingSystemVersion;
+            let osVersion = processInfo.operatingSystemVersion
             properties["$os_version"] = "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
             properties["$device_type"] = "Desktop"
         #endif

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -9,6 +9,8 @@ import Foundation
 
 #if os(iOS) || os(tvOS)
     import UIKit
+#elseif os(macOS)
+    import AppKit
 #endif
 
 let retryDelay = 5.0
@@ -651,6 +653,20 @@ let maxRetryDelay = 30.0
             defaultCenter.addObserver(self,
                                       selector: #selector(captureAppOpened),
                                       name: UIApplication.didBecomeActiveNotification,
+                                      object: nil)
+        #elseif os(macOS)
+            defaultCenter.addObserver(self,
+                                      selector: #selector(captureAppInstallLifecycle),
+                                      name: NSApplication.didFinishLaunchingNotification,
+                                      object: nil)
+            // macOS does not have didEnterBackgroundNotification, so we use didResignActiveNotification
+            defaultCenter.addObserver(self,
+                                      selector: #selector(captureAppBackgrounded),
+                                      name: NSApplication.didResignActiveNotification,
+                                      object: nil)
+            defaultCenter.addObserver(self,
+                                      selector: #selector(captureAppOpened),
+                                      name: NSApplication.didBecomeActiveNotification,
                                       object: nil)
         #endif
     }


### PR DESCRIPTION
## :bulb: Motivation and Context
Noticed a few properties were missing when doing https://github.com/PostHog/posthog-flutter/pull/76
Helps with better dashboard templates since you can filter out per device type

For another time:
Add better support for Mac Catalyst


## :green_heart: How did you test it?
Running the macOS example

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
