### PR TITLE
Add session tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+## 3.1.0 - 2024-02-07
+
+- Add session tracking [#100](https://github.com/PostHog/posthog-ios/pull/100)
+
 ## 3.0.0 - 2024-01-29
 
 Check out the updated [docs](https://posthog.com/docs/libraries/ios).

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -15,7 +15,8 @@ import Foundation
 
 let retryDelay = 5.0
 let maxRetryDelay = 30.0
-private let sessionChangeThreshold: TimeInterval = 1800
+// 30 minutes in seconds
+private let sessionChangeThreshold: TimeInterval = 60 * 30
 
 // renamed to PostHogSDK due to https://github.com/apple/swift/issues/56573
 @objc public class PostHogSDK: NSObject {

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -696,16 +696,16 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
                                       object: nil)
         #elseif os(macOS)
             defaultCenter.addObserver(self,
-                                      selector: #selector(handleAppOpened),
+                                      selector: #selector(handleAppDidFinishLaunching),
                                       name: NSApplication.didFinishLaunchingNotification,
                                       object: nil)
             // macOS does not have didEnterBackgroundNotification, so we use didResignActiveNotification
             defaultCenter.addObserver(self,
-                                      selector: #selector(captureAppBackgrounded),
+                                      selector: #selector(handleAppDidEnterBackground),
                                       name: NSApplication.didResignActiveNotification,
                                       object: nil)
             defaultCenter.addObserver(self,
-                                      selector: #selector(handleAppOpened),
+                                      selector: #selector(handleAppDidBecomeActive),
                                       name: NSApplication.didBecomeActiveNotification,
                                       object: nil)
         #endif

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -378,7 +378,8 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
         }
 
         // If events fire in the background after the threshold, they should no longer have a sessionId
-        if isInBackground && sessionId != nil,
+        if isInBackground,
+           sessionId != nil,
            let sessionLastTimestamp = sessionLastTimestamp,
            now().timeIntervalSince1970 - sessionLastTimestamp > sessionChangeThreshold
         {

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -261,12 +261,12 @@ private let sessionChangeThreshold: TimeInterval = 1800
         storage?.setString(forKey: .sessionId, contents: newValue)
     }
     
-    private func getSessionlastTimestamp() -> TimeInterval? {
-        storage?.getDouble(forKey: .sessionlastTimestamp)
+    private func getSessionLastTimestamp() -> TimeInterval? {
+        storage?.getDouble(forKey: .sessionLastTimestamp)
     }
     
-    private func setSessionlastTimestamp(_ newValue: TimeInterval) {
-        storage?.setDouble(forKey: .sessionlastTimestamp, contents: newValue)
+    private func setSessionLastTimestamp(_ newValue: TimeInterval) {
+        storage?.setDouble(forKey: .sessionLastTimestamp, contents: newValue)
     }
 
     // register is a reserved word in ObjC
@@ -382,8 +382,6 @@ private let sessionChangeThreshold: TimeInterval = 1800
         guard let queue = queue else {
             return
         }
-        
-        rotateSessionIdIfRequired()
       
         queue.add(PostHogEvent(
             event: event,
@@ -606,8 +604,8 @@ private let sessionChangeThreshold: TimeInterval = 1800
     }
   
     private func rotateSessionIdIfRequired() {
-        let sessionId = storage?.getString(forKey: .sessionId)
-        let sessionLastTimestamp = storage?.getDouble(forKey: .sessionlastTimestamp)
+        let sessionId = getSessionId()
+        let sessionLastTimestamp = getSessionLastTimestamp()
         
         guard let _ = sessionId, let sessionLastTimestamp = sessionLastTimestamp else {
             rotateSession()
@@ -621,10 +619,10 @@ private let sessionChangeThreshold: TimeInterval = 1800
     
     private func rotateSession() {
         let sessionId = UUID()
-        let sessionlastTimestamp = Date()
+        let sessionLastTimestamp = Date()
         
         setSessionId(sessionId.uuidString)
-        setSessionlastTimestamp(sessionlastTimestamp.timeIntervalSince1970)
+        setSessionLastTimestamp(sessionLastTimestamp.timeIntervalSince1970)
     }
 
     @objc public func optIn() {

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -145,9 +145,7 @@ private let sessionChangeThreshold: TimeInterval = 1800
 
     private func dynamicContext() -> [String: Any] {
         var properties = getRegisteredProperties()
-        let sessionId = getSessionId()
-        let sessionlastTimestamp = getSessionlastTimestamp()
-
+        
         var groups: [String: String]?
         groupsLock.withLock {
             groups = getGroups()
@@ -156,9 +154,8 @@ private let sessionChangeThreshold: TimeInterval = 1800
             properties["$groups"] = groups!
         }
         
-        if let sessionId = sessionId, let sessionlastTimestamp = sessionlastTimestamp {
-            properties["posthog.sessionId"] = sessionId
-            properties["posthog.sessionlastTimestamp"] = sessionlastTimestamp
+        if let sessionId = getSessionId() {
+            properties["$session_id"] = sessionId
         }
 
         guard let flags = featureFlags?.getFeatureFlags() as? [String: Any] else {

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -105,7 +105,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
                 let optOut = theStorage.getBool(forKey: .optOut)
                 config.optOut = optOut ?? config.optOut
             }
-            
+
             #if !os(watchOS)
                 queue = PostHogQueue(config, theStorage, theApi, reachability)
             #else
@@ -117,7 +117,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
 
             registerNotifications()
             captureScreenViews()
-            
+
             rotateSession()
 
             DispatchQueue.main.async {
@@ -150,7 +150,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
 
     private func dynamicContext() -> [String: Any] {
         var properties = getRegisteredProperties()
-        
+
         var groups: [String: String]?
         groupsLock.withLock {
             groups = getGroups()
@@ -158,7 +158,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
         if groups != nil, !groups!.isEmpty {
             properties["$groups"] = groups!
         }
-        
+
         if let sessionId = sessionId {
             properties["$session_id"] = sessionId
         }
@@ -371,7 +371,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
         guard let queue = queue else {
             return
         }
-      
+
         queue.add(PostHogEvent(
             event: event,
             distinctId: getDistinctId(),
@@ -383,7 +383,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
 
         if !isInBackground {
             sessionLock.withLock {
-                sessionLastTimestamp =  Date().timeIntervalSince1970
+                sessionLastTimestamp = Date().timeIntervalSince1970
             }
         }
     }
@@ -597,18 +597,18 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
         }
         return enabled
     }
-  
+
     private func rotateSessionIdIfRequired() {
-        guard let _ = sessionId, let sessionLastTimestamp = sessionLastTimestamp else {
+        guard sessionId != nil, let sessionLastTimestamp = sessionLastTimestamp else {
             rotateSession()
             return
         }
-        
-        if (Date().timeIntervalSince1970 - sessionLastTimestamp > sessionChangeThreshold) {
+
+        if Date().timeIntervalSince1970 - sessionLastTimestamp > sessionChangeThreshold {
             rotateSession()
         }
     }
-    
+
     private func rotateSession() {
         let newSessionId = UUID().uuidString
         let newSessionLastTimestamp = Date().timeIntervalSince1970
@@ -718,7 +718,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
             #endif
         }
     }
-    
+
     @objc func handleAppDidFinishLaunching() {
         captureAppInstallLifecycle()
     }
@@ -781,7 +781,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
             capturedAppInstalled = true
         }
     }
-    
+
     @objc func handleAppDidBecomeActive() {
         rotateSessionIdIfRequired()
 

--- a/PostHog/PostHogStorage.swift
+++ b/PostHog/PostHogStorage.swift
@@ -31,7 +31,7 @@ class PostHogStorage {
         case registerProperties = "posthog.registerProperties"
         case optOut = "posthog.optOut"
         case sessionId = "posthog.sessionId"
-        case sessionlastTimestamp = "posthog.sessionlastTimestamp"
+        case sessionLastTimestamp = "posthog.sessionLastTimestamp"
     }
 
     private let config: PostHogConfig

--- a/PostHog/PostHogStorage.swift
+++ b/PostHog/PostHogStorage.swift
@@ -30,8 +30,6 @@ class PostHogStorage {
         case groups = "posthog.groups"
         case registerProperties = "posthog.registerProperties"
         case optOut = "posthog.optOut"
-        case sessionId = "posthog.sessionId"
-        case sessionLastTimestamp = "posthog.sessionLastTimestamp"
     }
 
     private let config: PostHogConfig
@@ -146,7 +144,7 @@ class PostHogStorage {
         }
         return nil
     }
-    
+
     public func setString(forKey key: StorageKey, contents: String) {
         setJson(forKey: key, json: contents)
     }
@@ -170,18 +168,6 @@ class PostHogStorage {
     }
 
     public func setBool(forKey key: StorageKey, contents: Bool) {
-        setJson(forKey: key, json: contents)
-    }
-    
-    public func getDouble(forKey key: StorageKey) -> Double? {
-        let value = getJson(forKey: key)
-        if let timeIntervalValue = value as? Double {
-            return timeIntervalValue
-        }
-        return nil
-    }
-    
-    public func setDouble(forKey key: StorageKey, contents: Double) {
         setJson(forKey: key, json: contents)
     }
 }

--- a/PostHog/PostHogStorage.swift
+++ b/PostHog/PostHogStorage.swift
@@ -30,6 +30,8 @@ class PostHogStorage {
         case groups = "posthog.groups"
         case registerProperties = "posthog.registerProperties"
         case optOut = "posthog.optOut"
+        case sessionId = "posthog.sessionId"
+        case sessionlastTimestamp = "posthog.sessionlastTimestamp"
     }
 
     private let config: PostHogConfig
@@ -144,7 +146,7 @@ class PostHogStorage {
         }
         return nil
     }
-
+    
     public func setString(forKey key: StorageKey, contents: String) {
         setJson(forKey: key, json: contents)
     }
@@ -168,6 +170,18 @@ class PostHogStorage {
     }
 
     public func setBool(forKey key: StorageKey, contents: Bool) {
+        setJson(forKey: key, json: contents)
+    }
+    
+    public func getDouble(forKey key: StorageKey) -> Double? {
+        let value = getJson(forKey: key)
+        if let timeIntervalValue = value as? Double {
+            return timeIntervalValue
+        }
+        return nil
+    }
+    
+    public func setDouble(forKey key: StorageKey, contents: Double) {
         setJson(forKey: key, json: contents)
     }
 }

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -631,5 +631,5 @@ class PostHogSDKTest: QuickSpec {
 }
 
 private class MockDate {
-    var date = Calendar(identifier: .gregorian).date(from: .init(year: 2024, month: 1, day: 1))!
+    var date = Date()
 }

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -614,7 +614,7 @@ class PostHogSDKTest: QuickSpec {
 
             sut.handleAppDidEnterBackground() // Background "timer": 0 mins
 
-            mockNow.date.addTimeInterval(60 * 30 + 1) // Background "timer": 15 mins
+            mockNow.date.addTimeInterval(60 * 30 + 1) // Background "timer": 30 mins 1 second
 
             sut.capture("event captured while in background")
 

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -301,7 +301,7 @@ class PostHogSDKTest: QuickSpec {
         it("capture AppInstalled") {
             let sut = self.getSut()
 
-            sut.handleAppStarted()
+            sut.handleAppDidBecomeActive()
 
             let events = getBatchedEvents(server)
 
@@ -324,7 +324,7 @@ class PostHogSDKTest: QuickSpec {
             userDefaults.setValue("1", forKey: "PHGBuildKeyV2")
             userDefaults.synchronize()
 
-            sut.handleAppStarted()
+            sut.handleAppDidBecomeActive()
 
             let events = getBatchedEvents(server)
 
@@ -344,7 +344,7 @@ class PostHogSDKTest: QuickSpec {
         it("capture AppOpenedFromBackground from_background should be false") {
             let sut = self.getSut()
 
-            sut.handleAppOpened()
+            sut.handleAppDidBecomeActive()
 
             let events = getBatchedEvents(server)
 
@@ -361,8 +361,8 @@ class PostHogSDKTest: QuickSpec {
         it("capture AppOpenedFromBackground from_background should be true") {
             let sut = self.getSut(flushAt: 2)
 
-            sut.handleAppOpened()
-            sut.handleAppOpened()
+            sut.handleAppDidBecomeActive()
+            sut.handleAppDidBecomeActive()
 
             let events = getBatchedEvents(server)
 
@@ -379,7 +379,7 @@ class PostHogSDKTest: QuickSpec {
         it("capture captureAppOpened") {
             let sut = self.getSut()
 
-            sut.handleAppOpened()
+            sut.handleAppDidBecomeActive()
 
             let events = getBatchedEvents(server)
 

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -301,7 +301,7 @@ class PostHogSDKTest: QuickSpec {
         it("capture AppInstalled") {
             let sut = self.getSut()
 
-            sut.captureAppInstallLifecycle()
+            sut.handleAppStarted()
 
             let events = getBatchedEvents(server)
 
@@ -324,7 +324,7 @@ class PostHogSDKTest: QuickSpec {
             userDefaults.setValue("1", forKey: "PHGBuildKeyV2")
             userDefaults.synchronize()
 
-            sut.captureAppInstallLifecycle()
+            sut.handleAppStarted()
 
             let events = getBatchedEvents(server)
 
@@ -344,7 +344,7 @@ class PostHogSDKTest: QuickSpec {
         it("capture AppOpenedFromBackground from_background should be false") {
             let sut = self.getSut()
 
-            sut.captureAppOpened()
+            sut.handleAppOpened()
 
             let events = getBatchedEvents(server)
 
@@ -361,8 +361,8 @@ class PostHogSDKTest: QuickSpec {
         it("capture AppOpenedFromBackground from_background should be true") {
             let sut = self.getSut(flushAt: 2)
 
-            sut.captureAppOpened()
-            sut.captureAppOpened()
+            sut.handleAppOpened()
+            sut.handleAppOpened()
 
             let events = getBatchedEvents(server)
 
@@ -379,7 +379,7 @@ class PostHogSDKTest: QuickSpec {
         it("capture captureAppOpened") {
             let sut = self.getSut()
 
-            sut.captureAppOpened()
+            sut.handleAppOpened()
 
             let events = getBatchedEvents(server)
 


### PR DESCRIPTION
## :bulb: Motivation and Context
We would like to switch to PostHog, but the lack of session tracking on iOS was a dealbreaker. Although @marandaneto indicated it would be implemented this week in  #97 , I got curious after looking at the old PR.

This is still a draft PR. I would like feedback from @marandaneto if they would like me to continue to finish it (refine logic, add tests). Otherwise I'm happy for this to be closed and wait for the official thing.

Closes https://github.com/PostHog/posthog-ios/issues/97

## :green_heart: How did you test it?
Simply ran our app integrated with my local posthog-ios and saw that session ID appeared in the events, and I was able to track session related metrics https://us.posthog.com/shared/HeXYA1N8aHnvLpGfGrwpBzllJiswgw

I would like to add to the test suite if this PR is deemed workable.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
