### PR TITLE
fix: App opened event respects the life cycle config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+## 3.1.1 - 2024-02-08
+
+- `Application Opened` respects the `captureApplicationLifecycleEvents` config. [#100](https://github.com/PostHog/posthog-ios/pull/100)
+
 ## 3.1.0 - 2024-02-07
 
 - Add session tracking [#100](https://github.com/PostHog/posthog-ios/pull/100)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.1.1 - 2024-02-08
 
-- `Application Opened` respects the `captureApplicationLifecycleEvents` config. [#100](https://github.com/PostHog/posthog-ios/pull/100)
+- `Application Opened` respects the `captureApplicationLifecycleEvents` config. [#102](https://github.com/PostHog/posthog-ios/pull/102)
 
 ## 3.1.0 - 2024-02-07
 

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -803,7 +803,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
         if !config.captureApplicationLifecycleEvents {
             return
         }
-        
+
         var props: [String: Any] = [:]
         props["from_background"] = appFromBackground
 

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -800,6 +800,10 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
     }
 
     private func captureAppOpened() {
+        if !config.captureApplicationLifecycleEvents {
+            return
+        }
+        
         var props: [String: Any] = [:]
         props["from_background"] = appFromBackground
 

--- a/PostHogExample/AppDelegate.swift
+++ b/PostHogExample/AppDelegate.swift
@@ -16,6 +16,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         )
         // the ScreenViews for SwiftUI does not work, the names are not useful
         config.captureScreenViews = false
+        config.captureApplicationLifecycleEvents = false
         config.flushAt = 1
         config.flushIntervalSeconds = 10
 

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -397,20 +397,20 @@ class PostHogSDKTest: QuickSpec {
             sut.reset()
             sut.close()
         }
-        
+
         it("does not capture life cycle events") {
             let sut = self.getSut()
 
             sut.handleAppDidFinishLaunching()
             sut.handleAppDidBecomeActive()
             sut.handleAppDidEnterBackground()
-            
+
             sut.screen("test")
 
             let events = getBatchedEvents(server)
 
             expect(events.count) == 1
-            
+
             let event = events.first!
             expect(event.event) == "$screen"
 
@@ -549,7 +549,7 @@ class PostHogSDKTest: QuickSpec {
         }
 
         it("sets sessionId on app start") {
-            let sut = self.getSut()
+            let sut = self.getSut(captureApplicationLifecycleEvents: true)
 
             sut.handleAppDidBecomeActive()
 
@@ -593,7 +593,7 @@ class PostHogSDKTest: QuickSpec {
         }
 
         it("rotates to a new sessionId only after > 30 mins in the background") {
-            let sut = self.getSut(flushAt: 5)
+            let sut = self.getSut(captureApplicationLifecycleEvents: true, flushAt: 5)
             let mockNow = MockDate()
             sut.now = { mockNow.date }
 
@@ -630,7 +630,7 @@ class PostHogSDKTest: QuickSpec {
         }
 
         it("clears sessionId for background events after 30 mins in background") {
-            let sut = self.getSut(flushAt: 2)
+            let sut = self.getSut(captureApplicationLifecycleEvents: true, flushAt: 2)
             let mockNow = MockDate()
             sut.now = { mockNow.date }
 

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -14,6 +14,7 @@ import Quick
 class PostHogSDKTest: QuickSpec {
     func getSut(preloadFeatureFlags: Bool = false,
                 sendFeatureFlagEvent: Bool = false,
+                captureApplicationLifecycleEvents: Bool = false,
                 flushAt: Int = 1,
                 optOut: Bool = false) -> PostHogSDK
     {
@@ -23,6 +24,7 @@ class PostHogSDKTest: QuickSpec {
         config.sendFeatureFlagEvent = sendFeatureFlagEvent
         config.disableReachabilityForTesting = true
         config.disableQueueTimerForTesting = true
+        config.captureApplicationLifecycleEvents = captureApplicationLifecycleEvents
         config.optOut = optOut
         return PostHogSDK.with(config)
     }
@@ -284,7 +286,7 @@ class PostHogSDKTest: QuickSpec {
         }
 
         it("capture AppBackgrounded") {
-            let sut = self.getSut()
+            let sut = self.getSut(captureApplicationLifecycleEvents: true)
 
             sut.handleAppDidEnterBackground()
 
@@ -300,7 +302,7 @@ class PostHogSDKTest: QuickSpec {
         }
 
         it("capture AppInstalled") {
-            let sut = self.getSut()
+            let sut = self.getSut(captureApplicationLifecycleEvents: true)
 
             sut.handleAppDidFinishLaunching()
 
@@ -318,7 +320,7 @@ class PostHogSDKTest: QuickSpec {
         }
 
         it("capture AppUpdated") {
-            let sut = self.getSut()
+            let sut = self.getSut(captureApplicationLifecycleEvents: true)
 
             let userDefaults = UserDefaults.standard
             userDefaults.setValue("1.0.0", forKey: "PHGVersionKey")
@@ -343,7 +345,7 @@ class PostHogSDKTest: QuickSpec {
         }
 
         it("capture AppOpenedFromBackground from_background should be false") {
-            let sut = self.getSut()
+            let sut = self.getSut(captureApplicationLifecycleEvents: true)
 
             sut.handleAppDidBecomeActive()
 
@@ -360,7 +362,7 @@ class PostHogSDKTest: QuickSpec {
         }
 
         it("capture AppOpenedFromBackground from_background should be true") {
-            let sut = self.getSut(flushAt: 2)
+            let sut = self.getSut(captureApplicationLifecycleEvents: true, flushAt: 2)
 
             sut.handleAppDidBecomeActive()
             sut.handleAppDidBecomeActive()
@@ -378,7 +380,7 @@ class PostHogSDKTest: QuickSpec {
         }
 
         it("capture captureAppOpened") {
-            let sut = self.getSut()
+            let sut = self.getSut(captureApplicationLifecycleEvents: true)
 
             sut.handleAppDidBecomeActive()
 
@@ -391,6 +393,26 @@ class PostHogSDKTest: QuickSpec {
             expect(event.properties["from_background"] as? Bool) == false
             expect(event.properties["version"] as? String) != nil
             expect(event.properties["build"] as? String) != nil
+
+            sut.reset()
+            sut.close()
+        }
+        
+        it("does not capture life cycle events") {
+            let sut = self.getSut()
+
+            sut.handleAppDidFinishLaunching()
+            sut.handleAppDidBecomeActive()
+            sut.handleAppDidEnterBackground()
+            
+            sut.screen("test")
+
+            let events = getBatchedEvents(server)
+
+            expect(events.count) == 1
+            
+            let event = events.first!
+            expect(event.event) == "$screen"
 
             sut.reset()
             sut.close()


### PR DESCRIPTION
## :bulb: Motivation and Context
App opened event was being captured even though the lifecycle config was deactivated.
All the other events were already guarded by the lifecycle config.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
