### PR TITLE
fix ISO8601 formatter to always use the 24h format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.1.3 - 2024-02-09
 
-- fix ISO8601 formatter to always use the 24h format [#104](https://github.com/PostHog/posthog-ios/pull/104)
+- fix ISO8601 formatter to always use the 24h format [#106](https://github.com/PostHog/posthog-ios/pull/106)
 
 ## 3.1.2 - 2024-02-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+## 3.1.3 - 2024-02-09
+
+- fix ISO8601 formatter to always use the 24h format [#104](https://github.com/PostHog/posthog-ios/pull/104)
+
 ## 3.1.2 - 2024-02-09
 
 - fix and improve logging if the `debug` flag is enabled [#104](https://github.com/PostHog/posthog-ios/pull/104)

--- a/PostHog/Utils/DateUtils.swift
+++ b/PostHog/Utils/DateUtils.swift
@@ -7,21 +7,22 @@
 
 import Foundation
 
-// returns 2024-02-09T10:53:53.781Z
-public func toISO8601String(_ date: Date) -> String {
+private func newDateFormatter() -> DateFormatter {
     let dateFormatter = DateFormatter()
     dateFormatter.locale = Locale(identifier: "en_US_POSIX")
     dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
 
     dateFormatter.dateFormat = "yyyy-MM-dd'T'hh:mm:ss.SSS'Z'" // Use 'hh' for 12-hour clock
+    return dateFormatter
+}
+
+// returns 2024-02-09T10:53:53.781Z
+public func toISO8601String(_ date: Date) -> String {
+    let dateFormatter = newDateFormatter()
     return dateFormatter.string(from: date)
 }
 
 public func toISO8601Date(_ date: String) -> Date? {
-    let dateFormatter = DateFormatter()
-    dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-    dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
-
-    dateFormatter.dateFormat = "yyyy-MM-dd'T'hh:mm:ss.SSS'Z'" // Use 'hh' for 12-hour clock
+    let dateFormatter = newDateFormatter()
     return dateFormatter.date(from: date)
 }

--- a/PostHog/Utils/DateUtils.swift
+++ b/PostHog/Utils/DateUtils.swift
@@ -12,11 +12,10 @@ private func newDateFormatter() -> DateFormatter {
     dateFormatter.locale = Locale(identifier: "en_US_POSIX")
     dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
 
-    dateFormatter.dateFormat = "yyyy-MM-dd'T'hh:mm:ss.SSS'Z'" // Use 'hh' for 12-hour clock
+    dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
     return dateFormatter
 }
 
-// returns 2024-02-09T10:53:53.781Z
 public func toISO8601String(_ date: Date) -> String {
     let dateFormatter = newDateFormatter()
     return dateFormatter.string(from: date)

--- a/PostHog/Utils/DateUtils.swift
+++ b/PostHog/Utils/DateUtils.swift
@@ -7,14 +7,21 @@
 
 import Foundation
 
+// returns 2024-02-09T10:53:53.781Z
 public func toISO8601String(_ date: Date) -> String {
     let dateFormatter = DateFormatter()
-    dateFormatter.dateFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSS'Z'"
+    dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+    dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
+
+    dateFormatter.dateFormat = "yyyy-MM-dd'T'hh:mm:ss.SSS'Z'" // Use 'hh' for 12-hour clock
     return dateFormatter.string(from: date)
 }
 
 public func toISO8601Date(_ date: String) -> Date? {
     let dateFormatter = DateFormatter()
-    dateFormatter.dateFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSS'Z'"
+    dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+    dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
+
+    dateFormatter.dateFormat = "yyyy-MM-dd'T'hh:mm:ss.SSS'Z'" // Use 'hh' for 12-hour clock
     return dateFormatter.date(from: date)
 }


### PR DESCRIPTION
## :bulb: Motivation and Context
Closes https://github.com/PostHog/posthog-ios/issues/103


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
