### PR TITLE
fix reset session when reset or close are called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- fix reset session when reset or close are called [#106](https://github.com/PostHog/posthog-ios/pull/106)
+- fix reset session when reset or close are called [#107](https://github.com/PostHog/posthog-ios/pull/107)
 
 ## 3.1.3 - 2024-02-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix reset session when reset or close are called [#106](https://github.com/PostHog/posthog-ios/pull/106)
+
 ## 3.1.3 - 2024-02-09
 
 - fix ISO8601 formatter to always use the 24h format [#106](https://github.com/PostHog/posthog-ios/pull/106)

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -649,6 +649,36 @@ class PostHogSDKTest: QuickSpec {
             sut.reset()
             sut.close()
         }
+
+        it("clears sessionId after reset") {
+            let sut = self.getSut(captureApplicationLifecycleEvents: true, flushAt: 1)
+            let mockNow = MockDate()
+            sut.now = { mockNow.date }
+
+            sut.handleAppDidEnterBackground() // Background "timer": 0 mins
+
+            var events = getBatchedEvents(server)
+            expect(events.count) == 1
+
+            expect(events[0].properties["$session_id"] as? String).toNot(beNil())
+
+            sut.reset()
+
+            server.stop()
+            server = nil
+            server = MockPostHogServer()
+            server.start()
+
+            sut.capture("event captured while in background")
+
+            events = getBatchedEvents(server)
+            expect(events.count) == 1
+
+            expect(events[0].properties["$session_id"] as? String).to(beNil())
+
+            sut.reset()
+            sut.close()
+        }
     }
 }
 

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -655,7 +655,7 @@ class PostHogSDKTest: QuickSpec {
             let mockNow = MockDate()
             sut.now = { mockNow.date }
 
-            sut.handleAppDidEnterBackground() // Background "timer": 0 mins
+            sut.capture("event captured with session")
 
             var events = getBatchedEvents(server)
             expect(events.count) == 1
@@ -669,7 +669,7 @@ class PostHogSDKTest: QuickSpec {
             server = MockPostHogServer()
             server.start()
 
-            sut.capture("event captured while in background")
+            sut.capture("event captured w/o session")
 
             events = getBatchedEvents(server)
             expect(events.count) == 1


### PR DESCRIPTION
## :bulb: Motivation and Context
Calling `reset` wasn't resetting the session.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
