### PR TITLE
chore: read `$app_name` from `CFBundleDisplayName` as a fallback if `CFBundleName` isn't available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- read `$app_name` from `CFBundleDisplayName` as a fallback is `CFBundleName` isn't available [#107](https://github.com/PostHog/posthog-ios/pull/107)
+
 ## 3.1.4 - 2024-02-19
 
 - fix reset session when reset or close are called [#107](https://github.com/PostHog/posthog-ios/pull/107)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- read `$app_name` from `CFBundleDisplayName` as a fallback is `CFBundleName` isn't available [#107](https://github.com/PostHog/posthog-ios/pull/107)
+- read `$app_name` from `CFBundleDisplayName` as a fallback is `CFBundleName` isn't available [#108](https://github.com/PostHog/posthog-ios/pull/108)
 
 ## 3.1.4 - 2024-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- read `$app_name` from `CFBundleDisplayName` as a fallback is `CFBundleName` isn't available [#108](https://github.com/PostHog/posthog-ios/pull/108)
+- read `$app_name` from `CFBundleDisplayName` as a fallback if `CFBundleName` isn't available [#108](https://github.com/PostHog/posthog-ios/pull/108)
 
 ## 3.1.4 - 2024-02-19
 

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -1022,6 +1022,7 @@
 				DEVELOPMENT_TEAM = PNC2XCH2XP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(PRODUCT_NAME)";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -1056,6 +1057,7 @@
 				DEVELOPMENT_TEAM = PNC2XCH2XP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "$(PRODUCT_NAME)";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/PostHog/PostHogContext.swift
+++ b/PostHog/PostHogContext.swift
@@ -26,6 +26,8 @@ class PostHogContext {
 
         if let appName = infoDictionary?[kCFBundleNameKey as String] {
             properties["$app_name"] = appName
+        } else if let appName = infoDictionary?["CFBundleDisplayName"] {
+            properties["$app_name"] = appName
         }
         if let appVersion = infoDictionary?["CFBundleShortVersionString"] {
             properties["$app_version"] = appVersion


### PR DESCRIPTION
## :bulb: Motivation and Context
Closes https://github.com/PostHog/posthog-ios/issues/92


## :green_heart: How did you test it?
both are always `xctest` because it comes from the test runner, test already exists.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
