### PR TITLE
chore: API requests do a 10s timeoutInterval instead of 60s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- API requests do a 10s timeoutInterval instead of 60s  [#112](https://github.com/PostHog/posthog-ios/pull/112)
+- API requests do a 10s timeoutInterval instead of 60s  [#113](https://github.com/PostHog/posthog-ios/pull/113)
 
 ## 3.2.1 - 2024-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- API requests do a 10s timeoutInterval instead of 60s  [#112](https://github.com/PostHog/posthog-ios/pull/112)
+
 ## 3.2.1 - 2024-02-26
 
 - PrivacyInfo manifest set in the SPM and CocoaPods config  [#112](https://github.com/PostHog/posthog-ios/pull/112)

--- a/PostHog/PostHogApi.swift
+++ b/PostHog/PostHogApi.swift
@@ -9,7 +9,7 @@ import Foundation
 
 class PostHogApi {
     private let config: PostHogConfig
-    
+
     // default is 60s but we do 10s
     private let defaultTimeout: TimeInterval = 10
 
@@ -27,7 +27,7 @@ class PostHogApi {
 
         return config
     }
-    
+
     private func getURL(_ url: URL) -> URLRequest {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"

--- a/PostHog/PostHogApi.swift
+++ b/PostHog/PostHogApi.swift
@@ -9,6 +9,9 @@ import Foundation
 
 class PostHogApi {
     private let config: PostHogConfig
+    
+    // default is 60s but we do 10s
+    private let defaultTimeout: TimeInterval = 10
 
     init(_ config: PostHogConfig) {
         self.config = config
@@ -24,6 +27,13 @@ class PostHogApi {
 
         return config
     }
+    
+    private func getURL(_ url: URL) -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = defaultTimeout
+        return request
+    }
 
     func batch(events: [PostHogEvent], completion: @escaping (PostHogBatchUploadInfo) -> Void) {
         guard let url = URL(string: "batch", relativeTo: config.host) else {
@@ -37,8 +47,7 @@ class PostHogApi {
         headers["Content-Encoding"] = "gzip"
         config.httpAdditionalHeaders = headers
 
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
+        let request = getURL(url)
 
         let toSend: [String: Any] = [
             "api_key": self.config.apiKey,
@@ -99,8 +108,7 @@ class PostHogApi {
 
         let config = sessionConfig()
 
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
+        let request = getURL(url)
 
         let toSend: [String: Any] = [
             "api_key": self.config.apiKey,


### PR DESCRIPTION
## :bulb: Motivation and Context
follow up after the [incident](https://status.posthog.com/incidents/p9fhh5gnd5ky), not because of the iOS SDK but we don't want to hold the requests for too long anyway.
Android and [JS-lite](https://github.com/PostHog/posthog-js-lite/blob/c59c9d6b13bc972e0b1b3b66fe7a6c6a0e22f0ab/posthog-core/src/types.ts#L27-L28) are already 10s


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
