### PR TITLE
`maxQueueSize` wasn't respected when capturing events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- `maxQueueSize` wasn't respected when capturing events [#114](https://github.com/PostHog/posthog-ios/pull/114)
+
 ## 3.2.3 - 2024-03-05
 
 - `optOut` wasn't respected in capture methods [#114](https://github.com/PostHog/posthog-ios/pull/114)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- `maxQueueSize` wasn't respected when capturing events [#114](https://github.com/PostHog/posthog-ios/pull/114)
+- `maxQueueSize` wasn't respected when capturing events [#116](https://github.com/PostHog/posthog-ios/pull/116)
 
 ## 3.2.3 - 2024-03-05
 

--- a/PostHog/PostHogQueue.swift
+++ b/PostHog/PostHogQueue.swift
@@ -168,6 +168,12 @@ class PostHogQueue {
     }
 
     func add(_ event: PostHogEvent) {
+        if fileQueue.depth >= config.maxQueueSize {
+            hedgeLog("Queue is full, dropping oldest event")
+            // first is always oldest
+            fileQueue.delete(index: 0)
+        }
+
         var data: Data?
         do {
             data = try JSONSerialization.data(withJSONObject: event.toJSON())


### PR DESCRIPTION
## :bulb: Motivation and Context
https://posthog.slack.com/archives/C0643MHR56X/p1710247917392199

similar to v3.2.3, I checked that no other config is missing from the last major version during merges and repo changes.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
