### PR TITLE
fix: update changelog and readme on cocoapods for next release

### DIFF
--- a/PostHog.podspec
+++ b/PostHog.podspec
@@ -13,6 +13,8 @@ Pod::Spec.new do |s|
   s.author           = { "PostHog" => "engineering@posthog.com" }
   s.source           = { :git => "https://github.com/PostHog/posthog-ios.git", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/PostHog'
+  s.readme           = "https://raw.githubusercontent.com/PostHog/posthog-ios/#{s.version.to_s}/README.md"
+  s.changelog        = "https://raw.githubusercontent.com/PostHog/posthog-ios/#{s.version.to_s}/CHANGELOG.md"
 
   s.ios.deployment_target = '13.0'
   s.tvos.deployment_target = '13.0'


### PR DESCRIPTION
## :bulb: Motivation and Context
_#skip-changelog)

https://cocoapods.org/pods/PostHog
overview (readme) and changelog are outdated.

trusting https://stackoverflow.com/questions/76199890/how-to-update-pod-homepage-readme-on-cocoapods-org-website


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
