### PR TITLE
fix: reset deletes only sdk files instead of the whole folder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 3.2.5_patch
   pull_request:
     paths-ignore:
       - "**/*.md"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,4 +14,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run lints
-        run: make lint
+        run: |
+          brew install swiftlint
+          make lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 3.2.5_patch
   pull_request:
     paths-ignore:
       - "**/*.md"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 3.2.5_patch
   pull_request:
     paths-ignore:
       - "**/*.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+## 3.2.5 - 2024-05-14
+
 ## 3.2.4 - 2024-03-12
 
 - `maxQueueSize` wasn't respected when capturing events [#116](https://github.com/PostHog/posthog-ios/pull/116)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 3.2.5 - 2024-05-14
 
+- fix: `reset` deletes only sdk files instead of the whole folder [#132](https://github.com/PostHog/posthog-ios/pull/132)
+
 ## 3.2.4 - 2024-03-12
 
 - `maxQueueSize` wasn't respected when capturing events [#116](https://github.com/PostHog/posthog-ios/pull/116)

--- a/PostHog.podspec
+++ b/PostHog.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PostHog"
-  s.version          = "3.2.4"
+  s.version          = "3.2.5"
   s.summary          = "The hassle-free way to add posthog to your iOS app."
 
   s.description      = <<-DESC

--- a/PostHog/PostHogStorage.swift
+++ b/PostHog/PostHogStorage.swift
@@ -127,20 +127,15 @@ class PostHogStorage {
 
     public func reset() {
         // sadly the StorageKey.allCases does not work here
-        deleteAndCreateDir(url(forKey: .distinctId))
-        deleteAndCreateDir(url(forKey: .anonymousId))
+        deleteSafely(url(forKey: .distinctId))
+        deleteSafely(url(forKey: .anonymousId))
         // .queue not needed since it'll be deleted by the queue.clear()
-        deleteAndCreateDir(url(forKey: .oldQeueue))
-        deleteAndCreateDir(url(forKey: .enabledFeatureFlags))
-        deleteAndCreateDir(url(forKey: .enabledFeatureFlagPayloads))
-        deleteAndCreateDir(url(forKey: .groups))
-        deleteAndCreateDir(url(forKey: .registerProperties))
-        deleteAndCreateDir(url(forKey: .optOut))
-    }
-
-    private func deleteAndCreateDir(_ url: URL) {
-        deleteSafely(url)
-        createDirectoryAtURLIfNeeded(url: url)
+        deleteSafely(url(forKey: .oldQeueue))
+        deleteSafely(url(forKey: .enabledFeatureFlags))
+        deleteSafely(url(forKey: .enabledFeatureFlagPayloads))
+        deleteSafely(url(forKey: .groups))
+        deleteSafely(url(forKey: .registerProperties))
+        deleteSafely(url(forKey: .optOut))
     }
 
     public func remove(key: StorageKey) {

--- a/PostHog/PostHogStorage.swift
+++ b/PostHog/PostHogStorage.swift
@@ -20,6 +20,7 @@ func applicationSupportDirectoryURL() -> URL {
 }
 
 class PostHogStorage {
+    // when adding or removing items here, make sure to update the reset method
     enum StorageKey: String {
         case distinctId = "posthog.distinctId"
         case anonymousId = "posthog.anonymousId"
@@ -125,8 +126,21 @@ class PostHogStorage {
     }
 
     public func reset() {
-        deleteSafely(appFolderUrl)
-        createDirectoryAtURLIfNeeded(url: appFolderUrl)
+        // sadly the StorageKey.allCases does not work here
+        deleteAndCreateDir(url(forKey: .distinctId))
+        deleteAndCreateDir(url(forKey: .anonymousId))
+        // .queue not needed since it'll be deleted by the queue.clear()
+        deleteAndCreateDir(url(forKey: .oldQeueue))
+        deleteAndCreateDir(url(forKey: .enabledFeatureFlags))
+        deleteAndCreateDir(url(forKey: .enabledFeatureFlagPayloads))
+        deleteAndCreateDir(url(forKey: .groups))
+        deleteAndCreateDir(url(forKey: .registerProperties))
+        deleteAndCreateDir(url(forKey: .optOut))
+    }
+
+    private func deleteAndCreateDir(_ url: URL) {
+        deleteSafely(url)
+        createDirectoryAtURLIfNeeded(url: url)
     }
 
     public func remove(key: StorageKey) {

--- a/PostHog/PostHogVersion.swift
+++ b/PostHog/PostHogVersion.swift
@@ -9,7 +9,7 @@ import Foundation
 
 // if you change this, make sure to also change it in the podspec and check if the script scripts/bump-version.sh still works
 // This property is internal only
-public var postHogVersion = "3.2.4"
+public var postHogVersion = "3.2.5"
 
 // This property is internal only
 public var postHogSdkName = "posthog-ios"

--- a/PostHogExample/AppDelegate.swift
+++ b/PostHogExample/AppDelegate.swift
@@ -24,6 +24,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         PostHogSDK.shared.setup(config)
 //        PostHogSDK.shared.debug()
 //        PostHogSDK.shared.capture("App started!")
+//        PostHogSDK.shared.reset()
 
         let defaultCenter = NotificationCenter.default
 

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -695,7 +695,7 @@ class PostHogSDKTest: QuickSpec {
             sut.close()
         }
 
-        it("reset deletes posthog folder but not other folders") {
+        it("reset deletes posthog files but not other folders") {
             let appFolder = applicationSupportDirectoryURL()
             expect(FileManager.default.fileExists(atPath: appFolder.path)) == false
 

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -694,6 +694,18 @@ class PostHogSDKTest: QuickSpec {
             sut.reset()
             sut.close()
         }
+
+        it("reset deletes posthog folder but not other folders") {
+            let appFolder = applicationSupportDirectoryURL()
+            expect(FileManager.default.fileExists(atPath: appFolder.path)) == false
+
+            let sut = self.getSut()
+
+            sut.reset()
+            sut.close()
+
+            expect(FileManager.default.fileExists(atPath: appFolder.path)) == true
+        }
     }
 }
 


### PR DESCRIPTION
## :bulb: Motivation and Context
Closes https://github.com/PostHog/posthog-ios/issues/130
PR won't be merged to the main branch since it's a patch and there's the 3.3 alpha.
Will cherry-pick the branch after cutting the patch and make sure the changes make to the main branch

- [x] Add tests to avoid regression


## :green_heart: How did you test it?
Running locally and checking cache folders

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
