### PR TITLE
fix: missing swiftlint in GH Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,5 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Bootstrap
+        run: make bootstrap
+
       - name: Run lints
         run: make lint


### PR DESCRIPTION
## :bulb: Motivation and Context
/bin/sh: swiftlint: command not found
make: *** [lint] Error 127
_#skip-changelog_

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
