### PR TITLE
fix: rename groupProperties to groups for capture methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Next
 
 - chore: change host to new address ([#139](https://github.com/PostHog/posthog-ios/pull/139))
-- fix: rename groupProperties to groups for capture methods ([#139](https://github.com/PostHog/posthog-android/pull/139))
+- fix: rename groupProperties to groups for capture methods ([#140](https://github.com/PostHog/posthog-android/pull/140))
 
 ## 3.4.0 - 2024-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 - chore: change host to new address ([#139](https://github.com/PostHog/posthog-ios/pull/139))
+- fix: rename groupProperties to groups for capture methods ([#139](https://github.com/PostHog/posthog-android/pull/139))
 
 ## 3.4.0 - 2024-05-23
 

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -1,3 +1,5 @@
+// swiftlint:disable file_length
+
 //
 //  PostHogSDK.swift
 //  PostHogSDK
@@ -1002,3 +1004,5 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
         }
     #endif
 }
+
+// swiftlint:enable file_length

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -234,7 +234,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
                                  properties: [String: Any]?,
                                  userProperties: [String: Any]? = nil,
                                  userPropertiesSetOnce: [String: Any]? = nil,
-                                 groupProperties: [String: Any]? = nil,
+                                 groups: [String: String]? = nil,
                                  appendSharedProps: Bool = true) -> [String: Any]
     {
         var props: [String: Any] = [:]
@@ -257,10 +257,10 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
             if userPropertiesSetOnce != nil {
                 props["$set_once"] = (userPropertiesSetOnce ?? [:])
             }
-            if groupProperties != nil {
+            if groups != nil {
                 // $groups are also set via the dynamicContext
-                let currentGroups = props["$groups"] as? [String: Any] ?? [:]
-                let mergedGroups = currentGroups.merging(groupProperties ?? [:]) { current, _ in current }
+                let currentGroups = props["$groups"] as? [String: String] ?? [:]
+                let mergedGroups = currentGroups.merging(groups ?? [:]) { current, _ in current }
                 props["$groups"] = mergedGroups
             }
         }
@@ -396,14 +396,14 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
     }
 
     @objc public func capture(_ event: String) {
-        capture(event, properties: nil, userProperties: nil, userPropertiesSetOnce: nil, groupProperties: nil)
+        capture(event, properties: nil, userProperties: nil, userPropertiesSetOnce: nil, groups: nil)
     }
 
     @objc(captureWithEvent:properties:)
     public func capture(_ event: String,
                         properties: [String: Any]? = nil)
     {
-        capture(event, properties: properties, userProperties: nil, userPropertiesSetOnce: nil, groupProperties: nil)
+        capture(event, properties: properties, userProperties: nil, userPropertiesSetOnce: nil, groups: nil)
     }
 
     @objc(captureWithEvent:properties:userProperties:)
@@ -411,7 +411,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
                         properties: [String: Any]? = nil,
                         userProperties: [String: Any]? = nil)
     {
-        capture(event, properties: properties, userProperties: userProperties, userPropertiesSetOnce: nil, groupProperties: nil)
+        capture(event, properties: properties, userProperties: userProperties, userPropertiesSetOnce: nil, groups: nil)
     }
 
     @objc(captureWithEvent:properties:userProperties:userPropertiesSetOnce:)
@@ -420,7 +420,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
                         userProperties: [String: Any]? = nil,
                         userPropertiesSetOnce: [String: Any]? = nil)
     {
-        capture(event, properties: properties, userProperties: userProperties, userPropertiesSetOnce: userPropertiesSetOnce, groupProperties: nil)
+        capture(event, properties: properties, userProperties: userProperties, userPropertiesSetOnce: userPropertiesSetOnce, groups: nil)
     }
 
     private func isOptOutState() -> Bool {
@@ -431,12 +431,12 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
         return false
     }
 
-    @objc(captureWithEvent:properties:userProperties:userPropertiesSetOnce:groupProperties:)
+    @objc(captureWithEvent:properties:userProperties:userPropertiesSetOnce:groups:)
     public func capture(_ event: String,
                         properties: [String: Any]? = nil,
                         userProperties: [String: Any]? = nil,
                         userPropertiesSetOnce: [String: Any]? = nil,
-                        groupProperties: [String: Any]? = nil)
+                        groups: [String: String]? = nil)
     {
         if !isEnabled() {
             return
@@ -474,7 +474,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
                                         properties: sanitizeDicionary(properties),
                                         userProperties: sanitizeDicionary(userProperties),
                                         userPropertiesSetOnce: sanitizeDicionary(userPropertiesSetOnce),
-                                        groupProperties: sanitizeDicionary(groupProperties),
+                                        groups: sanitizeDicionary(groups),
                                         appendSharedProps: !snapshotEvent)
         )
 

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -474,7 +474,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
                                         properties: sanitizeDicionary(properties),
                                         userProperties: sanitizeDicionary(userProperties),
                                         userPropertiesSetOnce: sanitizeDicionary(userPropertiesSetOnce),
-                                        groups: sanitizeDicionary(groups),
+                                        groups: groups,
                                         appendSharedProps: !snapshotEvent)
         )
 

--- a/PostHogExampleStoryboard/SceneDelegate.swift
+++ b/PostHogExampleStoryboard/SceneDelegate.swift
@@ -14,6 +14,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        // swiftlint:disable:next unused_optional_binding
         guard let _ = (scene as? UIWindowScene) else { return }
     }
 

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -541,9 +541,7 @@ class PostHogSDKTest: QuickSpec {
                         userProperties: ["userProp": "value",
                                          "test2": UserDefaults.standard],
                         userPropertiesSetOnce: ["userPropOnce": "value",
-                                                "test3": UserDefaults.standard],
-                        groups: ["groupProp": "value",
-                                 "test4": UserDefaults.standard])
+                                                "test3": UserDefaults.standard])
 
             let events = getBatchedEvents(server)
 

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -543,7 +543,7 @@ class PostHogSDKTest: QuickSpec {
                         userPropertiesSetOnce: ["userPropOnce": "value",
                                                 "test3": UserDefaults.standard],
                         groups: ["groupProp": "value",
-                                          "test4": UserDefaults.standard])
+                                 "test4": UserDefaults.standard])
 
             let events = getBatchedEvents(server)
 

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -59,7 +59,7 @@ class PostHogSDKTest: QuickSpec {
                         properties: ["foo": "bar"],
                         userProperties: ["userProp": "value"],
                         userPropertiesSetOnce: ["userPropOnce": "value"],
-                        groupProperties: ["groupProp": "value"])
+                        groups: ["groupProp": "value"])
 
             let events = getBatchedEvents(server)
 
@@ -76,8 +76,8 @@ class PostHogSDKTest: QuickSpec {
             let setOnce = event.properties["$set_once"] as? [String: Any] ?? [:]
             expect(setOnce["userPropOnce"] as? String) == "value"
 
-            let groupProps = event.properties["$groups"] as? [String: Any] ?? [:]
-            expect(groupProps["groupProp"] as? String) == "value"
+            let groupProps = event.properties["$groups"] as? [String: String] ?? [:]
+            expect(groupProps["groupProp"]) == "value"
 
             sut.reset()
             sut.close()
@@ -451,8 +451,8 @@ class PostHogSDKTest: QuickSpec {
             expect(requests.count) == 1
             let request = requests.first
 
-            let groups = request!["$groups"] as? [String: Any]
-            expect(groups!["some-type"] as? String) == "some-key"
+            let groups = request!["$groups"] as? [String: String]
+            expect(groups!["some-type"]) == "some-key"
 
             sut.reset()
             sut.close()
@@ -472,9 +472,9 @@ class PostHogSDKTest: QuickSpec {
             expect(events.count) == 3
             let event = events.last!
 
-            let groups = event.properties["$groups"] as? [String: Any]
-            expect(groups!["some-type"] as? String) == "some-key"
-            expect(groups!["some-type-2"] as? String) == "some-key-2"
+            let groups = event.properties["$groups"] as? [String: String]
+            expect(groups!["some-type"]) == "some-key"
+            expect(groups!["some-type-2"]) == "some-key-2"
 
             sut.reset()
             sut.close()
@@ -542,7 +542,7 @@ class PostHogSDKTest: QuickSpec {
                                          "test2": UserDefaults.standard],
                         userPropertiesSetOnce: ["userPropOnce": "value",
                                                 "test3": UserDefaults.standard],
-                        groupProperties: ["groupProp": "value",
+                        groups: ["groupProp": "value",
                                           "test4": UserDefaults.standard])
 
             let events = getBatchedEvents(server)

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -163,7 +163,7 @@ class PostHogSDKTest: QuickSpec {
             expect(groupEvent.event) == "$groupidentify"
             expect(groupEvent.properties["$group_type"] as? String?) == "some-type"
             expect(groupEvent.properties["$group_key"] as? String?) == "some-key"
-            expect((groupEvent.properties["$group_set"] as? [String: String])?["name"] as? String) == "some-company-name"
+            expect((groupEvent.properties["$group_set"] as? [String: Any])?["name"] as? String) == "some-company-name"
 
             sut.reset()
             sut.close()
@@ -451,8 +451,8 @@ class PostHogSDKTest: QuickSpec {
             expect(requests.count) == 1
             let request = requests.first
 
-            let groups = request!["$groups"] as? [String: String]
-            expect(groups!["some-type"]) == "some-key"
+            let groups = request!["$groups"] as? [String: String] ?? [:]
+            expect(groups["some-type"]) == "some-key"
 
             sut.reset()
             sut.close()


### PR DESCRIPTION
## :bulb: Motivation and Context
Similar https://github.com/PostHog/posthog-android/pull/139/


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [X] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
