### PR TITLE
recording: fix MTLTextureDescriptor has width of zero issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- recording: fix MTLTextureDescriptor has width of zero issue ([#147](https://github.com/PostHog/posthog-ios/pull/147))
+- recording: fix MTLTextureDescriptor has width of zero issue ([#149](https://github.com/PostHog/posthog-ios/pull/149))
 
 ## 3.6.1 - 2024-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- recording: fix MTLTextureDescriptor has width of zero issue ([#147](https://github.com/PostHog/posthog-ios/pull/147))
+
 ## 3.6.1 - 2024-06-26
 
 - recording: improvements to screenshot masking ([#147](https://github.com/PostHog/posthog-ios/pull/147))

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		69278D472AE6BC7200BB541A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 69278D462AE6BC7200BB541A /* main.m */; };
 		69278D4B2AE6BC9000BB541A /* PostHog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AC745B5296D6FE60025C109 /* PostHog.framework */; };
 		69278D4C2AE6BC9000BB541A /* PostHog.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3AC745B5296D6FE60025C109 /* PostHog.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6955CB732C517651008EFD8D /* CGSize+Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6955CB722C517651008EFD8D /* CGSize+Util.swift */; };
 		69779BEC2AE68E6900D7A48E /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69779BEB2AE68E6900D7A48E /* UIViewController.swift */; };
 		6992AA832AFE51A000087600 /* PostHogExampleTvOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6992AA822AFE51A000087600 /* PostHogExampleTvOSApp.swift */; };
 		6992AA852AFE51A000087600 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6992AA842AFE51A000087600 /* ContentView.swift */; };
@@ -315,6 +316,7 @@
 		69278D432AE6BC7200BB541A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		69278D452AE6BC7200BB541A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		69278D462AE6BC7200BB541A /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		6955CB722C517651008EFD8D /* CGSize+Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGSize+Util.swift"; sourceTree = "<group>"; };
 		69779BEB2AE68E6900D7A48E /* UIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewController.swift; sourceTree = "<group>"; };
 		6992AA802AFE51A000087600 /* PostHogExampleTvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PostHogExampleTvOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6992AA822AFE51A000087600 /* PostHogExampleTvOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogExampleTvOSApp.swift; sourceTree = "<group>"; };
@@ -688,6 +690,7 @@
 				69F23A752BB308AE001194F6 /* URLSessionInterceptor.swift */,
 				69F23A772BB30991001194F6 /* NetworkSample.swift */,
 				69F23A792BB309F3001194F6 /* MethodSwizzler.swift */,
+				6955CB722C517651008EFD8D /* CGSize+Util.swift */,
 			);
 			path = Replay;
 			sourceTree = "<group>";
@@ -1054,6 +1057,7 @@
 				690FF05F2AE7E2D400A0B06B /* Data+Gzip.swift in Sources */,
 				69EE82BE2BA9C8AA00EB9542 /* ViewLayoutTracker.swift in Sources */,
 				69261D1F2AD9681300232EC7 /* PostHogConsumerPayload.swift in Sources */,
+				6955CB732C517651008EFD8D /* CGSize+Util.swift in Sources */,
 				69F517EA2BAC684F00F52C14 /* RRStyle.swift in Sources */,
 				69F23A782BB30991001194F6 /* NetworkSample.swift in Sources */,
 				69F23A762BB308AE001194F6 /* URLSessionInterceptor.swift in Sources */,

--- a/PostHog/Replay/CGSize+Util.swift
+++ b/PostHog/Replay/CGSize+Util.swift
@@ -1,0 +1,19 @@
+//
+//  CGSize+Util.swift
+//  PostHog
+//
+//  Created by Manoel Aranda Neto on 24.07.24.
+//
+
+import Foundation
+
+#if os(iOS)
+    extension CGSize {
+        func hasSize() -> Bool {
+            if width == 0 || height == 0 {
+                return false
+            }
+            return true
+        }
+    }
+#endif

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -237,6 +237,10 @@
             let wireframe = createBasicWireframe(view)
 
             if let image = view.toImage() {
+                if !image.size.hasSize() {
+                    return nil
+                }
+
                 let redactedImage = UIGraphicsImageRenderer(size: image.size, format: .init(for: .init(displayScale: 1))).image { context in
                     context.cgContext.interpolationQuality = .none
                     image.draw(at: .zero)
@@ -358,7 +362,7 @@
                 setAlignment(textField.textAlignment, style)
             }
 
-            if let picker = view as? UIPickerView {
+            if view is UIPickerView {
                 wireframe.type = "input"
                 wireframe.inputType = "select"
                 // set wireframe.value from selected row

--- a/PostHog/Replay/UIView+Util.swift
+++ b/PostHog/Replay/UIView+Util.swift
@@ -34,6 +34,12 @@
         }
 
         func toImage() -> UIImage? {
+            let size = bounds.size
+
+            if !size.hasSize() {
+                return nil
+            }
+
             // Begin image context
             UIGraphicsBeginImageContextWithOptions(bounds.size, isOpaque, 0.0)
 


### PR DESCRIPTION
## :bulb: Motivation and Context
customer report it:

> 51 iosApp                         0x2dd360 UIView.toImage() + 45 (UIView+Util.swift:45)
> 52 iosApp                         0x2d7480 PostHogReplayIntegration.toScreenshotWireframe(_:) + 239 (PostHogReplayIntegration.swift:239)
> 53 iosApp                         0x2d63c8 PostHogReplayIntegration.generateSnapshot(_:_:) + 80 (PostHogReplayIntegration.swift:80)
> 54 iosApp                         0x2d9324 PostHogReplayIntegration.snapshot() + 496 (PostHogReplayIntegration.swift:496)
> 55 iosApp                         0x2d9550 @objc PostHogReplayIntegration.snapshot() + 4342322512 (<compiler-generated>:4342322512)

similar to https://github.com/mapbox/mapbox-maps-ios/issues/1556


## :green_heart: How did you test it?
Running it but I can't reproduce the issue so I will release a version and check with the customer

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
