### PR TITLE
fix: respect session replay project settings from app start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- recording: fix: respect session replay project settings from app start ([#150](https://github.com/PostHog/posthog-ios/pull/150))
+
 ## 3.6.2 - 2024-07-25
 
 - recording: fix MTLTextureDescriptor has width of zero issue ([#149](https://github.com/PostHog/posthog-ios/pull/149))

--- a/PostHog/PostHogFeatureFlags.swift
+++ b/PostHog/PostHogFeatureFlags.swift
@@ -15,7 +15,6 @@ class PostHogFeatureFlags {
     private let loadingLock = NSLock()
     private let featureFlagsLock = NSLock()
     private var loadingFeatureFlags = false
-    private var featureFlagsLoaded = false
     private var sessionReplayFlagActive = false
 
     private let dispatchQueue = DispatchQueue(label: "com.posthog.FeatureFlags",
@@ -43,10 +42,6 @@ class PostHogFeatureFlags {
         }
     }
 
-    func isFeatureFlagsLoaded() -> Bool {
-        featureFlagsLoaded
-    }
-
     func loadFeatureFlags(
         distinctId: String,
         anonymousId: String,
@@ -69,8 +64,6 @@ class PostHogFeatureFlags {
                       let featureFlagPayloads = data?["featureFlagPayloads"] as? [String: Any]
                 else {
                     hedgeLog("Error: Decide response missing correct featureFlags format")
-
-                    // we dont reset featureFlagsLoaded here because it might have been succeed last time
 
                     self.notifyAndRelease()
 
@@ -115,8 +108,6 @@ class PostHogFeatureFlags {
                         self.storage.setDictionary(forKey: .enabledFeatureFlagPayloads, contents: featureFlagPayloads)
                     }
                 }
-
-                self.featureFlagsLoaded = true
 
                 self.notifyAndRelease()
 

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -1000,7 +1000,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
 
     #if os(iOS)
         func isSessionReplayActive() -> Bool {
-            config.sessionReplay && (featureFlags?.isSessionReplayFlagActive() ?? false)
+            config.sessionReplay && isSessionActive() && (featureFlags?.isSessionReplayFlagActive() ?? false)
         }
     #endif
 }

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -1000,7 +1000,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
 
     #if os(iOS)
         func isSessionReplayActive() -> Bool {
-            config.sessionReplay && isSessionActive()
+            config.sessionReplay && (featureFlags?.isSessionReplayFlagActive() ?? false)
         }
     #endif
 }

--- a/PostHog/PostHogStorage.swift
+++ b/PostHog/PostHogStorage.swift
@@ -32,7 +32,7 @@ class PostHogStorage {
         case groups = "posthog.groups"
         case registerProperties = "posthog.registerProperties"
         case optOut = "posthog.optOut"
-        case sessionReplay
+        case sessionReplay = "posthog.sessionReplay"
     }
 
     private let config: PostHogConfig

--- a/PostHog/PostHogStorage.swift
+++ b/PostHog/PostHogStorage.swift
@@ -32,6 +32,7 @@ class PostHogStorage {
         case groups = "posthog.groups"
         case registerProperties = "posthog.registerProperties"
         case optOut = "posthog.optOut"
+        case sessionReplay
     }
 
     private let config: PostHogConfig
@@ -137,6 +138,7 @@ class PostHogStorage {
         deleteSafely(url(forKey: .groups))
         deleteSafely(url(forKey: .registerProperties))
         deleteSafely(url(forKey: .optOut))
+        deleteSafely(url(forKey: .sessionReplay))
     }
 
     public func remove(key: StorageKey) {

--- a/PostHogTests/TestUtils/MockPostHogServer.swift
+++ b/PostHogTests/TestUtils/MockPostHogServer.swift
@@ -36,6 +36,7 @@ class MockPostHogServer {
 
     public var errorsWhileComputingFlags = false
     public var return500 = false
+    public var returnReplay = false
 
     init(port _: Int = 9001) {
         stub(condition: isPath("/decide")) { _ in
@@ -51,7 +52,7 @@ class MockPostHogServer {
                 flags.removeValue(forKey: "bool-value")
             }
 
-            let obj: [String: Any] = [
+            var obj: [String: Any] = [
                 "featureFlags": flags,
                 "featureFlagPayloads": [
                     "payload-bool": "true",
@@ -61,6 +62,15 @@ class MockPostHogServer {
                 ],
                 "errorsWhileComputingFlags": self.errorsWhileComputingFlags,
             ]
+
+            if self.returnReplay {
+                let sessionRecording: [String: Any] = [
+                    "endpoint": "/newS/",
+                ]
+                obj["sessionRecording"] = sessionRecording
+            } else {
+                obj["sessionRecording"] = false
+            }
 
             return HTTPStubsResponse(jsonObject: obj, statusCode: 200, headers: nil)
         }


### PR DESCRIPTION
## :bulb: Motivation and Context
The customer reported it https://posthoghelp.zendesk.com/agent/tickets/16125 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/18624)
The flag was already respected but only after flags were loaded.
Now it does respect with the cached value until the flags are loaded.
It might still send a recording if the cached value is enabled and the session project settings is disabled until it loads but on the next app start or session start it should not happen anymore since the new value will be updated.

The very same patch has to be done on Android


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
