### PR TITLE
chore: replace screenshot deprecated method

### DIFF
--- a/PostHog/Replay/UIView+Util.swift
+++ b/PostHog/Replay/UIView+Util.swift
@@ -40,21 +40,12 @@
                 return nil
             }
 
-            // Begin image context
-            UIGraphicsBeginImageContextWithOptions(bounds.size, isOpaque, 0.0)
+            let renderer = UIGraphicsImageRenderer(size: size)
 
-            // Render the view's layer into the current context
-            guard let context = UIGraphicsGetCurrentContext() else {
-                UIGraphicsEndImageContext()
-                return UIImage()
+            let image = renderer.image { context in
+                // Render the view's layer into the current context
+                layer.render(in: context.cgContext)
             }
-            layer.render(in: context)
-
-            // Capture the image from the current context
-            let image = UIGraphicsGetImageFromCurrentImageContext()
-
-            // End the image context
-            UIGraphicsEndImageContext()
 
             return image
         }


### PR DESCRIPTION
## :bulb: Motivation and Context
`UIGraphicsBeginImageContextWithOptions` is deprecated, and we already use the `UIGraphicsImageRenderer` for downsizing.
_#skip-changelog_


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
