### PR TITLE
added getSessionId

### DIFF
--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -176,6 +176,16 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
         return sessionManager?.getAnonymousId() ?? ""
     }
 
+    @objc public func getSessionId() -> String {
+        if !isEnabled() {
+            return ""
+        }
+        
+        return sessionLock.withLock {
+            return sessionId ?? ""
+        }
+    }
+
     // EVENT CAPTURE
 
     private func dynamicContext() -> [String: Any] {


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

I need your sessionId to help correlate your events with my own server events.

<!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/PostHog/posthog-ios/issues/164


## :green_heart: How did you test it?

In my app.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.



NOTE: The code I wrote is this:

```
    @objc public func getSessionId() -> String {
        if !isEnabled() {
            return ""
        }
        
        return sessionLock.withLock {
            return sessionId ?? ""
        }
    }
```
    
 which would have been better as this (return optional, use guard), but I did the above to match your other similar functions...
 
```
     @objc public func getSessionId() -> String? {
        guard isEnabled() { return nil }
        return sessionLock.withLock {
            return sessionId
        }
    }
```

Anyway,  this will help me, thanks!