### PR TITLE
chore: expose session id setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- chore: expose session id ([#165](https://github.com/PostHog/posthog-ios/pull/165)) and ([#170](https://github.com/PostHog/posthog-ios/pull/170))
+- chore: expose session id ([#165](https://github.com/PostHog/posthog-ios/pull/165)), ([#170](https://github.com/PostHog/posthog-ios/pull/170)) and ([#171](https://github.com/PostHog/posthog-ios/pull/171))
 
 ## 3.7.2 - 2024-08-16
 

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -32,7 +32,7 @@
 		3AE3FB472992AB0000AFFC18 /* Hedgelog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE3FB462992AB0000AFFC18 /* Hedgelog.swift */; };
 		3AE3FB49299391DF00AFFC18 /* PostHogStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE3FB48299391DF00AFFC18 /* PostHogStorage.swift */; };
 		3AE3FB4B2993A68500AFFC18 /* PostHogStorageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE3FB4A2993A68500AFFC18 /* PostHogStorageTest.swift */; };
-		3AE3FB4E2993D1D600AFFC18 /* PostHogSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE3FB4D2993D1D600AFFC18 /* PostHogSessionManager.swift */; };
+		3AE3FB4E2993D1D600AFFC18 /* PostHogStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE3FB4D2993D1D600AFFC18 /* PostHogStorageManager.swift */; };
 		690B2DF32C205B5600AE3B45 /* TimeBasedEpochGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690B2DF22C205B5600AE3B45 /* TimeBasedEpochGenerator.swift */; };
 		690FF05F2AE7E2D400A0B06B /* Data+Gzip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690FF05E2AE7E2D400A0B06B /* Data+Gzip.swift */; };
 		690FF0AF2AEB9C1400A0B06B /* DateUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690FF0AE2AEB9C1400A0B06B /* DateUtils.swift */; };
@@ -88,6 +88,7 @@
 		699C5FE62C20178E007DB818 /* UUIDUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 699C5FE52C20178E007DB818 /* UUIDUtils.swift */; };
 		699C5FEF2C20242A007DB818 /* UUIDTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 699C5FEE2C20242A007DB818 /* UUIDTest.swift */; };
 		69BA38D72B888E8500AA69D6 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 69BA38D62B888E8500AA69D6 /* PrivacyInfo.xcprivacy */; };
+		69ED1A5C2C7F15F300FE7A91 /* PostHogSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69ED1A5B2C7F15F300FE7A91 /* PostHogSessionManager.swift */; };
 		69EE82BA2BA9C50400EB9542 /* PostHogReplayIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69EE82B92BA9C50400EB9542 /* PostHogReplayIntegration.swift */; };
 		69EE82BC2BA9C53000EB9542 /* PostHogSessionReplayConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69EE82BB2BA9C53000EB9542 /* PostHogSessionReplayConfig.swift */; };
 		69EE82BE2BA9C8AA00EB9542 /* ViewLayoutTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69EE82BD2BA9C8AA00EB9542 /* ViewLayoutTracker.swift */; };
@@ -281,7 +282,7 @@
 		3AE3FB462992AB0000AFFC18 /* Hedgelog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hedgelog.swift; sourceTree = "<group>"; };
 		3AE3FB48299391DF00AFFC18 /* PostHogStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogStorage.swift; sourceTree = "<group>"; };
 		3AE3FB4A2993A68500AFFC18 /* PostHogStorageTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogStorageTest.swift; sourceTree = "<group>"; };
-		3AE3FB4D2993D1D600AFFC18 /* PostHogSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSessionManager.swift; sourceTree = "<group>"; };
+		3AE3FB4D2993D1D600AFFC18 /* PostHogStorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogStorageManager.swift; sourceTree = "<group>"; };
 		690B2DF22C205B5600AE3B45 /* TimeBasedEpochGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeBasedEpochGenerator.swift; sourceTree = "<group>"; };
 		690FF02F2AE7C5BA00A0B06B /* PostHogExampleWithPods.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = PostHogExampleWithPods.xcodeproj; path = PostHogExampleWithPods/PostHogExampleWithPods.xcodeproj; sourceTree = "<group>"; };
 		690FF0532AE7DB3700A0B06B /* PostHogExampleWithSPM.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = PostHogExampleWithSPM.xcodeproj; path = PostHogExampleWithSPM/PostHogExampleWithSPM.xcodeproj; sourceTree = "<group>"; };
@@ -339,6 +340,7 @@
 		699C5FE52C20178E007DB818 /* UUIDUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UUIDUtils.swift; sourceTree = "<group>"; };
 		699C5FEE2C20242A007DB818 /* UUIDTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UUIDTest.swift; sourceTree = "<group>"; };
 		69BA38D62B888E8500AA69D6 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		69ED1A5B2C7F15F300FE7A91 /* PostHogSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSessionManager.swift; sourceTree = "<group>"; };
 		69EE82B92BA9C50400EB9542 /* PostHogReplayIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogReplayIntegration.swift; sourceTree = "<group>"; };
 		69EE82BB2BA9C53000EB9542 /* PostHogSessionReplayConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSessionReplayConfig.swift; sourceTree = "<group>"; };
 		69EE82BD2BA9C8AA00EB9542 /* ViewLayoutTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewLayoutTracker.swift; sourceTree = "<group>"; };
@@ -533,7 +535,7 @@
 				3AE3FB322991388500AFFC18 /* PostHogQueue.swift */,
 				3AE3FB3C29924E8200AFFC18 /* PostHogSDK.swift */,
 				3AE3FB3E29924F4F00AFFC18 /* PostHogConfig.swift */,
-				3AE3FB4D2993D1D600AFFC18 /* PostHogSessionManager.swift */,
+				3AE3FB4D2993D1D600AFFC18 /* PostHogStorageManager.swift */,
 				3AE3FB48299391DF00AFFC18 /* PostHogStorage.swift */,
 				69261D122AD5685B00232EC7 /* PostHogFeatureFlags.swift */,
 				69261D182AD9673500232EC7 /* PostHogBatchUploadInfo.swift */,
@@ -546,6 +548,7 @@
 				690FF0C42AEFAE8200A0B06B /* PostHogLegacyQueue.swift */,
 				69F518372BB2BA0100F52C14 /* PostHogSwizzler.swift */,
 				693E977A2C625208004B1030 /* PostHogPropertiesSanitizer.swift */,
+				69ED1A5B2C7F15F300FE7A91 /* PostHogSessionManager.swift */,
 			);
 			path = PostHog;
 			sourceTree = "<group>";
@@ -1069,7 +1072,7 @@
 				69F23A762BB308AE001194F6 /* URLSessionInterceptor.swift in Sources */,
 				690FF0BF2AEFA97F00A0B06B /* FileUtils.swift in Sources */,
 				69261D252AD9787A00232EC7 /* PostHogExtensions.swift in Sources */,
-				3AE3FB4E2993D1D600AFFC18 /* PostHogSessionManager.swift in Sources */,
+				3AE3FB4E2993D1D600AFFC18 /* PostHogStorageManager.swift in Sources */,
 				3AE3FB49299391DF00AFFC18 /* PostHogStorage.swift in Sources */,
 				69261D232AD9784200232EC7 /* PostHogVersion.swift in Sources */,
 				69779BEC2AE68E6900D7A48E /* UIViewController.swift in Sources */,
@@ -1079,6 +1082,7 @@
 				690FF0AF2AEB9C1400A0B06B /* DateUtils.swift in Sources */,
 				69F518162BAC7F9200F52C14 /* UIView+Util.swift in Sources */,
 				69261D192AD9673500232EC7 /* PostHogBatchUploadInfo.swift in Sources */,
+				69ED1A5C2C7F15F300FE7A91 /* PostHogSessionManager.swift in Sources */,
 				69F23A742BB3088E001194F6 /* URLSessionSwizzler.swift in Sources */,
 				69F518142BAC7F4300F52C14 /* Date+Util.swift in Sources */,
 				69F5183A2BB2BA8300F52C14 /* UIApplicationTracker.swift in Sources */,

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		3A0F108929C9BD76002C0084 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0F108829C9BD76002C0084 /* Errors.swift */; };
 		3A580B4329E489D000C5C6F3 /* URLSession+body.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A580B4229E489D000C5C6F3 /* URLSession+body.swift */; };
 		3A62646A29C9E385007E8C07 /* MockPostHogServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A62646929C9E385007E8C07 /* MockPostHogServer.swift */; };
-		3A62647129CAF67B007E8C07 /* PostHogSessionManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A62647029CAF67B007E8C07 /* PostHogSessionManagerTest.swift */; };
+		3A62647129CAF67B007E8C07 /* PostHogStorageManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A62647029CAF67B007E8C07 /* PostHogStorageManagerTest.swift */; };
 		3A62647529CB0168007E8C07 /* TestPostHog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A62647429CB0168007E8C07 /* TestPostHog.swift */; };
 		3A81BEAE297704F400A6908D /* PostHog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AC745B5296D6FE60025C109 /* PostHog.framework */; };
 		3A81BEAF297704F400A6908D /* PostHog.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3AC745B5296D6FE60025C109 /* PostHog.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -261,7 +261,7 @@
 		3A0F108829C9BD76002C0084 /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		3A580B4229E489D000C5C6F3 /* URLSession+body.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+body.swift"; sourceTree = "<group>"; };
 		3A62646929C9E385007E8C07 /* MockPostHogServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPostHogServer.swift; sourceTree = "<group>"; };
-		3A62647029CAF67B007E8C07 /* PostHogSessionManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSessionManagerTest.swift; sourceTree = "<group>"; };
+		3A62647029CAF67B007E8C07 /* PostHogStorageManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogStorageManagerTest.swift; sourceTree = "<group>"; };
 		3A62647429CB0168007E8C07 /* TestPostHog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestPostHog.swift; sourceTree = "<group>"; };
 		3AA34CF7296D951A003398F4 /* PostHogExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PostHogExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AA34CF9296D951A003398F4 /* PostHogExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogExampleApp.swift; sourceTree = "<group>"; };
@@ -558,7 +558,7 @@
 			children = (
 				3A62646829C9E37A007E8C07 /* TestUtils */,
 				3AE3FB4A2993A68500AFFC18 /* PostHogStorageTest.swift */,
-				3A62647029CAF67B007E8C07 /* PostHogSessionManagerTest.swift */,
+				3A62647029CAF67B007E8C07 /* PostHogStorageManagerTest.swift */,
 				690FF0BA2AEF8B8200A0B06B /* PostHogContextTest.swift */,
 				690FF0BC2AEF93F400A0B06B /* PostHogFeatureFlagsTest.swift */,
 				690FF0DE2AEFBC5700A0B06B /* PostHogLegacyQueueTest.swift */,
@@ -1124,7 +1124,7 @@
 				3A62646A29C9E385007E8C07 /* MockPostHogServer.swift in Sources */,
 				690FF0BB2AEF8B8200A0B06B /* PostHogContextTest.swift in Sources */,
 				690FF0E32AEFD12900A0B06B /* PostHogConfigTest.swift in Sources */,
-				3A62647129CAF67B007E8C07 /* PostHogSessionManagerTest.swift in Sources */,
+				3A62647129CAF67B007E8C07 /* PostHogStorageManagerTest.swift in Sources */,
 				693E977D2C6257F9004B1030 /* ExampleSanitizer.swift in Sources */,
 				690FF0DF2AEFBC5700A0B06B /* PostHogLegacyQueueTest.swift in Sources */,
 				690FF0BD2AEF93F400A0B06B /* PostHogFeatureFlagsTest.swift in Sources */,

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -17,8 +17,6 @@ import Foundation
 
 let retryDelay = 5.0
 let maxRetryDelay = 30.0
-// 30 minutes in seconds
-private let sessionChangeThreshold: TimeInterval = 60 * 30
 
 // renamed to PostHogSDK due to https://github.com/apple/swift/issues/56573
 @objc public class PostHogSDK: NSObject {
@@ -33,25 +31,21 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
     private let optOutLock = NSLock()
     private let groupsLock = NSLock()
     private let personPropsLock = NSLock()
-    private let sessionLock = NSLock()
 
     private var queue: PostHogQueue?
     private var replayQueue: PostHogQueue?
     private var api: PostHogApi?
     private var storage: PostHogStorage?
-    private var sessionManager: PostHogSessionManager?
+    private var storageManager: PostHogStorageManager?
     #if !os(watchOS)
         private var reachability: Reachability?
     #endif
-    var now: () -> Date = { Date() }
     private var flagCallReported = Set<String>()
     private var featureFlags: PostHogFeatureFlags?
     private var context: PostHogContext?
     private static var apiKeys = Set<String>()
     private var capturedAppInstalled = false
     private var appFromBackground = false
-    private var sessionId: String?
-    private var sessionLastTimestamp: TimeInterval?
     private var isInBackground = false
     #if os(iOS)
         private var replayIntegration: PostHogReplayIntegration?
@@ -105,7 +99,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
             let theApi = PostHogApi(config)
             api = theApi
             featureFlags = PostHogFeatureFlags(config, theStorage, theApi)
-            sessionManager = PostHogSessionManager(config)
+            storageManager = PostHogStorageManager(config)
             #if os(iOS)
                 replayIntegration = PostHogReplayIntegration(config)
             #endif
@@ -142,7 +136,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
             registerNotifications()
             captureScreenViews()
 
-            rotateSession()
+            PostHogSessionManager.shared.startSession()
 
             #if os(iOS)
                 if config.sessionReplay {
@@ -165,7 +159,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
             return ""
         }
 
-        return sessionManager?.getDistinctId() ?? ""
+        return storageManager?.getDistinctId() ?? ""
     }
 
     @objc public func getAnonymousId() -> String {
@@ -173,7 +167,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
             return ""
         }
 
-        return sessionManager?.getAnonymousId() ?? ""
+        return storageManager?.getAnonymousId() ?? ""
     }
 
     @objc public func getSessionId() -> String? {
@@ -181,11 +175,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
             return nil
         }
 
-        var tempSessionId: String?
-        sessionLock.withLock {
-            tempSessionId = sessionId
-        }
-        return tempSessionId
+        return PostHogSessionManager.shared.getSessionId()
     }
 
     // EVENT CAPTURE
@@ -264,17 +254,13 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
             }
         }
 
-        var theSessionId: String?
-        sessionLock.withLock {
-            theSessionId = sessionId
-        }
-        if let theSessionId = theSessionId {
-            props["$session_id"] = theSessionId
+        if let sessionId = PostHogSessionManager.shared.getSessionId() {
+            props["$session_id"] = sessionId
             // Session replay requires $window_id, so we set as the same as $session_id.
             // the backend might fallback to $session_id if $window_id is not present next.
             #if os(iOS)
                 if config.sessionReplay {
-                    props["$window_id"] = theSessionId
+                    props["$window_id"] = sessionId
                 }
             #endif
         }
@@ -310,14 +296,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
         queue?.clear()
         replayQueue?.clear()
         flagCallReported.removeAll()
-        resetSession()
-    }
-
-    private func resetSession() {
-        sessionLock.withLock {
-            sessionId = nil
-            sessionLastTimestamp = nil
-        }
+        PostHogSessionManager.shared.endSession()
     }
 
     private func getGroups() -> [String: String] {
@@ -386,7 +365,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
             return
         }
 
-        guard let queue = queue, let sessionManager = sessionManager else {
+        guard let queue = queue, let sessionManager = storageManager else {
             return
         }
         let oldDistinctId = getDistinctId()
@@ -473,14 +452,8 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
         }
 
         // If events fire in the background after the threshold, they should no longer have a sessionId
-        if isInBackground,
-           sessionId != nil,
-           let sessionLastTimestamp = sessionLastTimestamp,
-           now().timeIntervalSince1970 - sessionLastTimestamp > sessionChangeThreshold
-        {
-            sessionLock.withLock {
-                sessionId = nil
-            }
+        if isInBackground {
+            PostHogSessionManager.shared.resetSessionIfExpired()
         }
 
         let distinctId = getDistinctId()
@@ -675,7 +648,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
             return
         }
 
-        guard let featureFlags = featureFlags, let sessionManager = sessionManager else {
+        guard let featureFlags = featureFlags, let sessionManager = storageManager else {
             return
         }
 
@@ -759,27 +732,6 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
         return enabled
     }
 
-    private func rotateSessionIdIfRequired() {
-        guard sessionId != nil, let sessionLastTimestamp = sessionLastTimestamp else {
-            rotateSession()
-            return
-        }
-
-        if now().timeIntervalSince1970 - sessionLastTimestamp > sessionChangeThreshold {
-            rotateSession()
-        }
-    }
-
-    private func rotateSession() {
-        let newSessionId = UUID.v7().uuidString
-        let newSessionLastTimestamp = now().timeIntervalSince1970
-
-        sessionLock.withLock {
-            sessionId = newSessionId
-            sessionLastTimestamp = newSessionLastTimestamp
-        }
-    }
-
     @objc public func optIn() {
         if !isEnabled() {
             return
@@ -833,7 +785,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
             #endif
             queue = nil
             replayQueue = nil
-            sessionManager = nil
+            storageManager = nil
             config = PostHogConfig(apiKey: "")
             api = nil
             featureFlags = nil
@@ -844,7 +796,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
             #endif
             flagCallReported.removeAll()
             context = nil
-            resetSession()
+            PostHogSessionManager.shared.endSession()
             unregisterNotifications()
             capturedAppInstalled = false
             appFromBackground = false
@@ -978,7 +930,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
     }
 
     @objc func handleAppDidBecomeActive() {
-        rotateSessionIdIfRequired()
+        PostHogSessionManager.shared.rotateSessionIdIfRequired()
 
         isInBackground = false
         captureAppOpened()
@@ -1014,9 +966,7 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
     @objc func handleAppDidEnterBackground() {
         captureAppBackgrounded()
 
-        sessionLock.withLock {
-            sessionLastTimestamp = now().timeIntervalSince1970
-        }
+        PostHogSessionManager.shared.updateSessionLastTime()
 
         isInBackground = true
     }
@@ -1029,11 +979,10 @@ private let sessionChangeThreshold: TimeInterval = 60 * 30
     }
 
     func isSessionActive() -> Bool {
-        var active = false
-        sessionLock.withLock {
-            active = sessionId != nil
+        guard let _ = PostHogSessionManager.shared.getSessionId() else {
+            return false
         }
-        return active
+        return true
     }
 
     #if os(iOS)

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -178,6 +178,22 @@ let maxRetryDelay = 30.0
         return PostHogSessionManager.shared.getSessionId()
     }
 
+    @objc public func startSession() {
+        if !isEnabled() {
+            return
+        }
+
+        return PostHogSessionManager.shared.startSession()
+    }
+
+    @objc public func endSession() {
+        if !isEnabled() {
+            return
+        }
+
+        return PostHogSessionManager.shared.endSession()
+    }
+
     // EVENT CAPTURE
 
     private func dynamicContext() -> [String: Any] {
@@ -979,10 +995,7 @@ let maxRetryDelay = 30.0
     }
 
     func isSessionActive() -> Bool {
-        guard let _ = PostHogSessionManager.shared.getSessionId() else {
-            return false
-        }
-        return true
+        PostHogSessionManager.shared.isSessionActive()
     }
 
     #if os(iOS)

--- a/PostHog/PostHogSessionManager.swift
+++ b/PostHog/PostHogSessionManager.swift
@@ -67,7 +67,7 @@ class PostHogSessionManager {
     func startSession() {
         sessionLock.withLock {
             // only start if there is no session
-            guard sessionId != nil else {
+            if sessionId != nil {
                 return
             }
             rotateSession()
@@ -96,9 +96,6 @@ class PostHogSessionManager {
     }
 
     func isSessionActive() -> Bool {
-        guard let _ = getSessionId() else {
-            return false
-        }
-        return true
+        getSessionId() != nil
     }
 }

--- a/PostHog/PostHogSessionManager.swift
+++ b/PostHog/PostHogSessionManager.swift
@@ -26,7 +26,7 @@ class PostHogSessionManager {
         }
         return tempSessionId
     }
-    
+
     func setSessionId(sessionId: String) {
         sessionLock.withLock {
             self.sessionId = sessionId

--- a/PostHog/PostHogStorageManager.swift
+++ b/PostHog/PostHogStorageManager.swift
@@ -1,0 +1,69 @@
+//
+//  PostHogStorageManager.swift
+//  PostHog
+//
+//  Created by Ben White on 08.02.23.
+//
+
+import Foundation
+
+class PostHogStorageManager {
+    private let storage: PostHogStorage!
+
+    private let anonLock = NSLock()
+    private let distinctLock = NSLock()
+    private let idGen: (UUID) -> UUID
+
+    init(_ config: PostHogConfig) {
+        storage = PostHogStorage(config)
+        idGen = config.getAnonymousId
+    }
+
+    public func getAnonymousId() -> String {
+        var anonymousId: String?
+        anonLock.withLock {
+            anonymousId = storage.getString(forKey: .anonymousId)
+
+            if anonymousId == nil {
+                let uuid = UUID.v7()
+                anonymousId = idGen(uuid).uuidString
+                setAnonId(anonymousId ?? "")
+            }
+        }
+
+        return anonymousId ?? ""
+    }
+
+    public func setAnonymousId(_ id: String) {
+        anonLock.withLock {
+            setAnonId(id)
+        }
+    }
+
+    private func setAnonId(_ id: String) {
+        storage.setString(forKey: .anonymousId, contents: id)
+    }
+
+    public func getDistinctId() -> String {
+        var distinctId: String?
+        distinctLock.withLock {
+            distinctId = storage.getString(forKey: .distinctId) ?? getAnonymousId()
+        }
+        return distinctId ?? ""
+    }
+
+    public func setDistinctId(_ id: String) {
+        distinctLock.withLock {
+            storage.setString(forKey: .distinctId, contents: id)
+        }
+    }
+
+    public func reset() {
+        distinctLock.withLock {
+            storage.remove(key: .distinctId)
+        }
+        anonLock.withLock {
+            storage.remove(key: .anonymousId)
+        }
+    }
+}

--- a/PostHog/Utils/DateUtils.swift
+++ b/PostHog/Utils/DateUtils.swift
@@ -25,3 +25,5 @@ public func toISO8601Date(_ date: String) -> Date? {
     let dateFormatter = newDateFormatter()
     return dateFormatter.date(from: date)
 }
+
+var now: () -> Date = { Date() }

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -49,7 +49,7 @@ class PostHogSDKTest: QuickSpec {
             server.start()
         }
         afterEach {
-            PostHogSDK.shared.now = { Date() }
+            now = { Date() }
             server.stop()
             server = nil
         }
@@ -582,7 +582,7 @@ class PostHogSDKTest: QuickSpec {
         it("uses the same sessionId for all events in a session") {
             let sut = self.getSut(flushAt: 3)
             let mockNow = MockDate()
-            sut.now = { mockNow.date }
+            now = { mockNow.date }
 
             sut.capture("event1")
 
@@ -610,7 +610,7 @@ class PostHogSDKTest: QuickSpec {
         it("rotates to a new sessionId only after > 30 mins in the background") {
             let sut = self.getSut(captureApplicationLifecycleEvents: true, flushAt: 5)
             let mockNow = MockDate()
-            sut.now = { mockNow.date }
+            now = { mockNow.date }
 
             sut.handleAppDidEnterBackground() // Background "timer": 0 mins
 
@@ -647,7 +647,7 @@ class PostHogSDKTest: QuickSpec {
         it("clears sessionId for background events after 30 mins in background") {
             let sut = self.getSut(captureApplicationLifecycleEvents: true, flushAt: 2)
             let mockNow = MockDate()
-            sut.now = { mockNow.date }
+            now = { mockNow.date }
 
             sut.handleAppDidEnterBackground() // Background "timer": 0 mins
 
@@ -668,7 +668,7 @@ class PostHogSDKTest: QuickSpec {
         it("clears sessionId after reset") {
             let sut = self.getSut(captureApplicationLifecycleEvents: true, flushAt: 1)
             let mockNow = MockDate()
-            sut.now = { mockNow.date }
+            now = { mockNow.date }
 
             sut.capture("event captured with session")
 

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -52,6 +52,7 @@ class PostHogSDKTest: QuickSpec {
             now = { Date() }
             server.stop()
             server = nil
+            PostHogSessionManager.shared.endSession()
         }
 
         it("captures the capture event") {

--- a/PostHogTests/PostHogStorageManagerTest.swift
+++ b/PostHogTests/PostHogStorageManagerTest.swift
@@ -1,5 +1,5 @@
 //
-//  PostHogSessionManagerTest.swift
+//  PostHogStorageManagerTest.swift
 //  PostHogTests
 //
 //  Created by Ben White on 22.03.23.
@@ -10,10 +10,10 @@ import Nimble
 @testable import PostHog
 import Quick
 
-class PostHogSessionManagerTest: QuickSpec {
-    func getSut() -> PostHogSessionManager {
+class PostHogStorageManagerTest: QuickSpec {
+    func getSut() -> PostHogStorageManager {
         let config = PostHogConfig(apiKey: "123")
-        return PostHogSessionManager(config)
+        return PostHogStorageManager(config)
     }
 
     override func spec() {
@@ -50,7 +50,7 @@ class PostHogSessionManagerTest: QuickSpec {
             let config = PostHogConfig(apiKey: "123")
             let fixedUuid = UUID.v7()
             config.getAnonymousId = { _ in fixedUuid }
-            let sut = PostHogSessionManager(config)
+            let sut = PostHogStorageManager(config)
             let anonymousId = sut.getAnonymousId()
             expect(anonymousId) == fixedUuid.uuidString
 


### PR DESCRIPTION
## :bulb: Motivation and Context
follow up https://github.com/PostHog/posthog-ios/pull/170/

Renamed PostHogSessionManager to PostHogStorageManager because it was more about reading/caching things from the storage.
Created a new PostHogSessionManager which is responsible for all session Id related


## :green_heart: How did you test it?
unit tests already exist and they are green, just refactoring and exposing the session id (setter) via an internal class instead of the public API

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
