### PR TITLE
fix: do not clear events and reload flags after reset is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next
 
+- fix: do not clear events when reset is called ([#170](https://github.com/PostHog/posthog-ios/pull/170))
+- fix: reload feature flags as anon user after reset is called ([#170](https://github.com/PostHog/posthog-ios/pull/170))
+
 ## 3.8.0 - 2024-08-29
 
 - fix: rotate session id when reset is called ([#174](https://github.com/PostHog/posthog-ios/pull/174))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Next
 
-- fix: do not clear events when reset is called ([#170](https://github.com/PostHog/posthog-ios/pull/170))
-- fix: reload feature flags as anon user after reset is called ([#170](https://github.com/PostHog/posthog-ios/pull/170))
+- fix: do not clear events when reset is called ([#175](https://github.com/PostHog/posthog-ios/pull/175))
+- fix: reload feature flags as anon user after reset is called ([#175](https://github.com/PostHog/posthog-ios/pull/175))
 
 ## 3.8.0 - 2024-08-29
 

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -309,11 +309,12 @@ let maxRetryDelay = 30.0
 
         // storage also removes all feature flags
         storage?.reset()
-        queue?.clear()
-        replayQueue?.clear()
         flagCallReported.removeAll()
         PostHogSessionManager.shared.endSession()
         PostHogSessionManager.shared.startSession()
+
+        // reload flags as anon user
+        reloadFeatureFlags()
     }
 
     private func getGroups() -> [String: String] {

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -727,6 +727,17 @@ class PostHogSDKTest: QuickSpec {
             sut.reset()
             sut.close()
         }
+
+        it("reset reloads flags as anon user") {
+            let sut = self.getSut()
+
+            sut.reset()
+
+            waitDecideRequest(server)
+            expect(sut.isFeatureEnabled("bool-value")) == true
+
+            sut.close()
+        }
     }
 }
 


### PR DESCRIPTION
## :bulb: Motivation and Context
similar to https://github.com/PostHog/posthog-android/pull/170


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [X] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
