### PR TITLE
chore: cache flags, distinct id and anon id in memory to avoid file IO every time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- chore: cache flags, distinct id and anon id in memory to avoid file IO every time ([#175](https://github.com/PostHog/posthog-ios/pull/175))
+- chore: cache flags, distinct id and anon id in memory to avoid file IO every time ([#177](https://github.com/PostHog/posthog-ios/pull/177))
 
 ## 3.8.1 - 2024-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- chore: cache flags, distinct id and anon id in memory to avoid file IO every time ([#175](https://github.com/PostHog/posthog-ios/pull/175))
+
 ## 3.8.1 - 2024-08-30
 
 - fix: do not clear events when reset is called ([#175](https://github.com/PostHog/posthog-ios/pull/175))

--- a/PostHog/PostHogFeatureFlags.swift
+++ b/PostHog/PostHogFeatureFlags.swift
@@ -168,7 +168,10 @@ class PostHogFeatureFlags {
     }
 
     private func getCachedFeatureFlagPayload() -> [String: Any]? {
-        featureFlagPayloads ?? storage.getDictionary(forKey: .enabledFeatureFlagPayloads) as? [String: Any]
+        if featureFlagPayloads == nil {
+            featureFlagPayloads = storage.getDictionary(forKey: .enabledFeatureFlagPayloads) as? [String: Any]
+        }
+        return featureFlagPayloads
     }
 
     private func setCachedFeatureFlagPayload(_ featureFlagPayloads: [String: Any]) {
@@ -177,7 +180,10 @@ class PostHogFeatureFlags {
     }
 
     private func getCachedFeatureFlags() -> [String: Any]? {
-        featureFlags ?? storage.getDictionary(forKey: .enabledFeatureFlags) as? [String: Any]
+        if featureFlags == nil {
+            featureFlags = storage.getDictionary(forKey: .enabledFeatureFlags) as? [String: Any]
+        }
+        return featureFlags
     }
 
     private func setCachedFeatureFlags(_ featureFlags: [String: Any]) {

--- a/PostHog/PostHogFeatureFlags.swift
+++ b/PostHog/PostHogFeatureFlags.swift
@@ -20,8 +20,6 @@ class PostHogFeatureFlags {
     private var featureFlags: [String: Any]?
     private var featureFlagPayloads: [String: Any]?
 
-    // TODO: cache flags
-
     private let dispatchQueue = DispatchQueue(label: "com.posthog.FeatureFlags",
                                               target: .global(qos: .utility))
 

--- a/PostHog/PostHogFeatureFlags.swift
+++ b/PostHog/PostHogFeatureFlags.swift
@@ -17,6 +17,11 @@ class PostHogFeatureFlags {
     private var loadingFeatureFlags = false
     private var sessionReplayFlagActive = false
 
+    private var featureFlags: [String: Any]?
+    private var featureFlagPayloads: [String: Any]?
+
+    // TODO: cache flags
+
     private let dispatchQueue = DispatchQueue(label: "com.posthog.FeatureFlags",
                                               target: .global(qos: .utility))
 
@@ -94,18 +99,18 @@ class PostHogFeatureFlags {
 
                 self.featureFlagsLock.withLock {
                     if errorsWhileComputingFlags {
-                        let cachedFeatureFlags = self.storage.getDictionary(forKey: .enabledFeatureFlags) as? [String: Any] ?? [:]
-                        let cachedFeatureFlagsPayloads = self.storage.getDictionary(forKey: .enabledFeatureFlagPayloads) as? [String: Any] ?? [:]
+                        let cachedFeatureFlags = self.getCachedFeatureFlags() ?? [:]
+                        let cachedFeatureFlagsPayloads = self.getCachedFeatureFlagPayload() ?? [:]
 
                         let newFeatureFlags = cachedFeatureFlags.merging(featureFlags) { _, new in new }
                         let newFeatureFlagsPayloads = cachedFeatureFlagsPayloads.merging(featureFlagPayloads) { _, new in new }
 
                         // if not all flags were computed, we upsert flags instead of replacing them
-                        self.storage.setDictionary(forKey: .enabledFeatureFlags, contents: newFeatureFlags)
-                        self.storage.setDictionary(forKey: .enabledFeatureFlagPayloads, contents: newFeatureFlagsPayloads)
+                        self.setCachedFeatureFlags(newFeatureFlags)
+                        self.setCachedFeatureFlagPayload(newFeatureFlagsPayloads)
                     } else {
-                        self.storage.setDictionary(forKey: .enabledFeatureFlags, contents: featureFlags)
-                        self.storage.setDictionary(forKey: .enabledFeatureFlagPayloads, contents: featureFlagPayloads)
+                        self.setCachedFeatureFlags(featureFlags)
+                        self.setCachedFeatureFlagPayload(featureFlagPayloads)
                     }
                 }
 
@@ -129,7 +134,7 @@ class PostHogFeatureFlags {
     func getFeatureFlags() -> [String: Any]? {
         var flags: [String: Any]?
         featureFlagsLock.withLock {
-            flags = self.storage.getDictionary(forKey: .enabledFeatureFlags) as? [String: Any]
+            flags = self.getCachedFeatureFlags()
         }
 
         return flags
@@ -138,7 +143,7 @@ class PostHogFeatureFlags {
     func isFeatureEnabled(_ key: String) -> Bool {
         var flags: [String: Any]?
         featureFlagsLock.withLock {
-            flags = self.storage.getDictionary(forKey: .enabledFeatureFlags) as? [String: Any]
+            flags = self.getCachedFeatureFlags()
         }
 
         let value = flags?[key]
@@ -158,16 +163,34 @@ class PostHogFeatureFlags {
     func getFeatureFlag(_ key: String) -> Any? {
         var flags: [String: Any]?
         featureFlagsLock.withLock {
-            flags = self.storage.getDictionary(forKey: .enabledFeatureFlags) as? [String: Any]
+            flags = self.getCachedFeatureFlags()
         }
 
         return flags?[key]
     }
 
+    private func getCachedFeatureFlagPayload() -> [String: Any]? {
+        featureFlagPayloads ?? storage.getDictionary(forKey: .enabledFeatureFlagPayloads) as? [String: Any]
+    }
+
+    private func setCachedFeatureFlagPayload(_ featureFlagPayloads: [String: Any]) {
+        self.featureFlagPayloads = featureFlagPayloads
+        storage.setDictionary(forKey: .enabledFeatureFlagPayloads, contents: featureFlagPayloads)
+    }
+
+    private func getCachedFeatureFlags() -> [String: Any]? {
+        featureFlags ?? storage.getDictionary(forKey: .enabledFeatureFlags) as? [String: Any]
+    }
+
+    private func setCachedFeatureFlags(_ featureFlags: [String: Any]) {
+        self.featureFlags = featureFlags
+        storage.setDictionary(forKey: .enabledFeatureFlags, contents: featureFlags)
+    }
+
     func getFeatureFlagPayload(_ key: String) -> Any? {
         var flags: [String: Any]?
         featureFlagsLock.withLock {
-            flags = self.storage.getDictionary(forKey: .enabledFeatureFlagPayloads) as? [String: Any]
+            flags = getCachedFeatureFlagPayload()
         }
 
         let value = flags?[key]

--- a/PostHog/PostHogStorageManager.swift
+++ b/PostHog/PostHogStorageManager.swift
@@ -25,13 +25,16 @@ class PostHogStorageManager {
 
     public func getAnonymousId() -> String {
         anonLock.withLock {
-            if self.anonymousId == nil {
+            if anonymousId == nil {
                 var anonymousId = storage.getString(forKey: .anonymousId)
 
                 if anonymousId == nil {
                     let uuid = UUID.v7()
                     anonymousId = idGen(uuid).uuidString
                     setAnonId(anonymousId ?? "")
+                } else {
+                    // update the memory value
+                    self.anonymousId = anonymousId
                 }
             }
         }
@@ -69,6 +72,9 @@ class PostHogStorageManager {
                     // update the memory value
                     self.distinctId = distinctId
                 }
+            } else {
+                // read from memory
+                distinctId = self.distinctId
             }
         }
         return distinctId ?? ""

--- a/PostHog/PostHogStorageManager.swift
+++ b/PostHog/PostHogStorageManager.swift
@@ -23,22 +23,19 @@ class PostHogStorageManager {
     }
 
     public func getAnonymousId() -> String {
-        var anonymousId: String?
         anonLock.withLock {
             if self.anonymousId == nil {
-                anonymousId = storage.getString(forKey: .anonymousId)
-                // update the memory value
-                self.anonymousId = anonymousId
-            }
+                var anonymousId = storage.getString(forKey: .anonymousId)
 
-            if anonymousId == nil {
-                let uuid = UUID.v7()
-                anonymousId = idGen(uuid).uuidString
-                setAnonId(anonymousId ?? "")
+                if anonymousId == nil {
+                    let uuid = UUID.v7()
+                    anonymousId = idGen(uuid).uuidString
+                    setAnonId(anonymousId ?? "")
+                }
             }
         }
 
-        return self.anonymousId ?? ""
+        return anonymousId ?? ""
     }
 
     public func setAnonymousId(_ id: String) {
@@ -56,12 +53,18 @@ class PostHogStorageManager {
         var distinctId: String?
         distinctLock.withLock {
             if self.distinctId == nil {
-                distinctId = storage.getString(forKey: .distinctId) ?? getAnonymousId()
-                // update the memory value
-                self.distinctId = distinctId
+                distinctId = storage.getString(forKey: .distinctId)
+
+                // do this to not assign the AnonymousId to the DistinctId, its just a fallback
+                if distinctId == nil {
+                    distinctId = getAnonymousId()
+                } else {
+                    // update the memory value
+                    self.distinctId = distinctId
+                }
             }
         }
-        return self.distinctId ?? ""
+        return distinctId ?? ""
     }
 
     public func setDistinctId(_ id: String) {

--- a/PostHog/PostHogStorageManager.swift
+++ b/PostHog/PostHogStorageManager.swift
@@ -25,21 +25,20 @@ class PostHogStorageManager {
     public func getAnonymousId() -> String {
         var anonymousId: String?
         anonLock.withLock {
-            anonymousId = self.anonymousId ?? storage.getString(forKey: .anonymousId)
+            if self.anonymousId == nil {
+                anonymousId = storage.getString(forKey: .anonymousId)
+                // update the memory value
+                self.anonymousId = anonymousId
+            }
 
             if anonymousId == nil {
                 let uuid = UUID.v7()
                 anonymousId = idGen(uuid).uuidString
                 setAnonId(anonymousId ?? "")
-            } else {
-                // update the memory value
-                if self.anonymousId == nil {
-                    self.anonymousId = anonymousId
-                }
             }
         }
 
-        return anonymousId ?? ""
+        return self.anonymousId ?? ""
     }
 
     public func setAnonymousId(_ id: String) {
@@ -56,14 +55,13 @@ class PostHogStorageManager {
     public func getDistinctId() -> String {
         var distinctId: String?
         distinctLock.withLock {
-            distinctId = self.distinctId ?? storage.getString(forKey: .distinctId) ?? getAnonymousId()
-
-            // update the memory value
-            if self.distinctId == nil, distinctId != nil {
+            if self.distinctId == nil {
+                distinctId = storage.getString(forKey: .distinctId) ?? getAnonymousId()
+                // update the memory value
                 self.distinctId = distinctId
             }
         }
-        return distinctId ?? ""
+        return self.distinctId ?? ""
     }
 
     public func setDistinctId(_ id: String) {

--- a/PostHog/PostHogStorageManager.swift
+++ b/PostHog/PostHogStorageManager.swift
@@ -31,6 +31,11 @@ class PostHogStorageManager {
                 let uuid = UUID.v7()
                 anonymousId = idGen(uuid).uuidString
                 setAnonId(anonymousId ?? "")
+            } else {
+                // update the memory value
+                if self.anonymousId == nil {
+                    self.anonymousId = anonymousId
+                }
             }
         }
 
@@ -52,6 +57,11 @@ class PostHogStorageManager {
         var distinctId: String?
         distinctLock.withLock {
             distinctId = self.distinctId ?? storage.getString(forKey: .distinctId) ?? getAnonymousId()
+
+            // update the memory value
+            if self.distinctId == nil, distinctId != nil {
+                self.distinctId = distinctId
+            }
         }
         return distinctId ?? ""
     }

--- a/PostHogExample/AppDelegate.swift
+++ b/PostHogExample/AppDelegate.swift
@@ -28,7 +28,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
         PostHogSDK.shared.setup(config)
 //        PostHogSDK.shared.debug()
-//        PostHogSDK.shared.capture("App started!")
+        PostHogSDK.shared.capture("App started!")
 //        PostHogSDK.shared.reset()
 
 //        PostHogSDK.shared.identify("Manoel")

--- a/PostHogExample/AppDelegate.swift
+++ b/PostHogExample/AppDelegate.swift
@@ -31,7 +31,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 //        PostHogSDK.shared.capture("App started!")
 //        PostHogSDK.shared.reset()
 
-        PostHogSDK.shared.identify("Manoel")
+//        PostHogSDK.shared.identify("Manoel")
 
         let defaultCenter = NotificationCenter.default
 

--- a/PostHogExample/AppDelegate.swift
+++ b/PostHogExample/AppDelegate.swift
@@ -28,7 +28,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
         PostHogSDK.shared.setup(config)
 //        PostHogSDK.shared.debug()
-        PostHogSDK.shared.capture("App started!")
+//        PostHogSDK.shared.capture("App started!")
 //        PostHogSDK.shared.reset()
 
 //        PostHogSDK.shared.identify("Manoel")

--- a/PostHogExample/ContentView.swift
+++ b/PostHogExample/ContentView.swift
@@ -63,7 +63,7 @@ class FeatureFlagsModel: ObservableObject {
 
 struct ContentView: View {
     @State var counter: Int = 0
-    @State private var name: String = "Manoel3"
+    @State private var name: String = "Max"
     @State private var showingSheet = false
     @State private var showingRedactedSheet = false
     @StateObject var api = Api()

--- a/PostHogExample/ContentView.swift
+++ b/PostHogExample/ContentView.swift
@@ -63,7 +63,7 @@ class FeatureFlagsModel: ObservableObject {
 
 struct ContentView: View {
     @State var counter: Int = 0
-    @State private var name: String = "Tim"
+    @State private var name: String = "Manoel"
     @State private var showingSheet = false
     @State private var showingRedactedSheet = false
     @StateObject var api = Api()

--- a/PostHogExample/ContentView.swift
+++ b/PostHogExample/ContentView.swift
@@ -63,7 +63,7 @@ class FeatureFlagsModel: ObservableObject {
 
 struct ContentView: View {
     @State var counter: Int = 0
-    @State private var name: String = "Manoel"
+    @State private var name: String = "Manoel3"
     @State private var showingSheet = false
     @State private var showingRedactedSheet = false
     @StateObject var api = Api()


### PR DESCRIPTION
## :bulb: Motivation and Context
Closes https://github.com/PostHog/posthog-ios/issues/176
Only read the value from the storage if it's not in memory yet.
Setters always overwrite the value in the storage and memory.
Storage only will be accessed the very first time unless the value changes async (eg flags), then the memory value is also updated.
This should reduce the main thread warnings.
All values are read and updated using lockers already.

## :green_heart: How did you test it?
unit tests already exist and they are all green

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
