### PR TITLE
recording: use non deprecated methods for getCurrentWindow if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- recording: use non deprecated methods for getCurrentWindow if available ([#177](https://github.com/PostHog/posthog-ios/pull/177))
+- recording: use non deprecated methods for getCurrentWindow if available ([#178](https://github.com/PostHog/posthog-ios/pull/178))
 
 ## 3.8.2 - 2024-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- recording: use non deprecated methods for getCurrentWindow if available ([#177](https://github.com/PostHog/posthog-ios/pull/177))
+
 ## 3.8.2 - 2024-09-03
 
 - chore: cache flags, distinct id and anon id in memory to avoid file IO every time ([#177](https://github.com/PostHog/posthog-ios/pull/177))

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -449,14 +449,32 @@
         }
 
         static func getCurrentWindow() -> UIWindow? {
-            guard let activeScene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) else {
-                return nil
+            let app = UIApplication.shared
+
+            // TODO: support multi windows
+
+            // app.windows is deprecated
+            var currentWindow: UIWindow?
+            for scene in app.connectedScenes {
+                if scene is UIWindowScene,
+                   scene.activationState == .foregroundActive,
+                   let windowScene = scene as? UIWindowScene
+                {
+                    if #available(iOS 15.0, *) {
+                        if let keyWindow = windowScene.keyWindow {
+                            currentWindow = keyWindow
+                            break
+                        }
+                    }
+
+                    for window in windowScene.windows where window.isKeyWindow {
+                        currentWindow = window
+                        break
+                    }
+                }
             }
 
-            guard let window = (activeScene as? UIWindowScene)?.windows.first(where: { $0.isKeyWindow }) else {
-                return nil
-            }
-            return window
+            return currentWindow
         }
 
         @objc private func snapshot() {

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -449,12 +449,10 @@
         }
 
         static func getCurrentWindow() -> UIWindow? {
-            let app = UIApplication.shared
-
             // TODO: support multi windows
 
-            // app.windows is deprecated
-            for scene in app.connectedScenes {
+            // UIApplication.shared.windows is deprecated
+            for scene in UIApplication.shared.connectedScenes {
                 if scene is UIWindowScene,
                    scene.activationState == .foregroundActive,
                    let windowScene = scene as? UIWindowScene

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -454,7 +454,6 @@
             // TODO: support multi windows
 
             // app.windows is deprecated
-            var currentWindow: UIWindow?
             for scene in app.connectedScenes {
                 if scene is UIWindowScene,
                    scene.activationState == .foregroundActive,
@@ -462,19 +461,17 @@
                 {
                     if #available(iOS 15.0, *) {
                         if let keyWindow = windowScene.keyWindow {
-                            currentWindow = keyWindow
-                            break
+                            return keyWindow
                         }
                     }
 
                     for window in windowScene.windows where window.isKeyWindow {
-                        currentWindow = window
-                        break
+                        return window
                     }
                 }
             }
 
-            return currentWindow
+            return nil
         }
 
         @objc private func snapshot() {


### PR DESCRIPTION
## :bulb: Motivation and Context
sometimes the recordings are black
one assumption is that the heuristics algo to detect the current window is wrong
this one uses the latest methods available from iOS 15 otherwise fallback to another one


## :green_heart: How did you test it?
running the app with storyboard and swiftui

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
