### PR TITLE
chore: add SwiftUI View extensions to capture screen view and views in general (postHogViewSeen, postHogScreenView)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- chore: add SwiftUI View extensions to capture screen view and views in general (postHogViewEvent, postHogScreenView) ([#178](https://github.com/PostHog/posthog-ios/pull/178))
+- chore: add SwiftUI View extensions to capture screen view and views in general (postHogViewEvent, postHogScreenView) ([#180](https://github.com/PostHog/posthog-ios/pull/180))
 
 ## 3.8.3 - 2024-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- chore: add SwiftUI View extensions to capture screen view and views in general (postHogViewEvent, postHogScreenView) ([#178](https://github.com/PostHog/posthog-ios/pull/178))
+
 ## 3.8.3 - 2024-09-03
 
 - recording: use non deprecated methods for getCurrentWindow if available ([#178](https://github.com/PostHog/posthog-ios/pull/178))

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		699C5FEF2C20242A007DB818 /* UUIDTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 699C5FEE2C20242A007DB818 /* UUIDTest.swift */; };
 		69BA38D72B888E8500AA69D6 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 69BA38D62B888E8500AA69D6 /* PrivacyInfo.xcprivacy */; };
 		69ED1A5C2C7F15F300FE7A91 /* PostHogSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69ED1A5B2C7F15F300FE7A91 /* PostHogSessionManager.swift */; };
+		69ED1A882C89B73100FE7A91 /* PostHogSwiftUIViewModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69ED1A872C89B73100FE7A91 /* PostHogSwiftUIViewModifiers.swift */; };
 		69EE82BA2BA9C50400EB9542 /* PostHogReplayIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69EE82B92BA9C50400EB9542 /* PostHogReplayIntegration.swift */; };
 		69EE82BC2BA9C53000EB9542 /* PostHogSessionReplayConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69EE82BB2BA9C53000EB9542 /* PostHogSessionReplayConfig.swift */; };
 		69EE82BE2BA9C8AA00EB9542 /* ViewLayoutTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69EE82BD2BA9C8AA00EB9542 /* ViewLayoutTracker.swift */; };
@@ -341,6 +342,7 @@
 		699C5FEE2C20242A007DB818 /* UUIDTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UUIDTest.swift; sourceTree = "<group>"; };
 		69BA38D62B888E8500AA69D6 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		69ED1A5B2C7F15F300FE7A91 /* PostHogSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSessionManager.swift; sourceTree = "<group>"; };
+		69ED1A872C89B73100FE7A91 /* PostHogSwiftUIViewModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSwiftUIViewModifiers.swift; sourceTree = "<group>"; };
 		69EE82B92BA9C50400EB9542 /* PostHogReplayIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogReplayIntegration.swift; sourceTree = "<group>"; };
 		69EE82BB2BA9C53000EB9542 /* PostHogSessionReplayConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSessionReplayConfig.swift; sourceTree = "<group>"; };
 		69EE82BD2BA9C8AA00EB9542 /* ViewLayoutTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewLayoutTracker.swift; sourceTree = "<group>"; };
@@ -549,6 +551,7 @@
 				69F518372BB2BA0100F52C14 /* PostHogSwizzler.swift */,
 				693E977A2C625208004B1030 /* PostHogPropertiesSanitizer.swift */,
 				69ED1A5B2C7F15F300FE7A91 /* PostHogSessionManager.swift */,
+				69ED1A872C89B73100FE7A91 /* PostHogSwiftUIViewModifiers.swift */,
 			);
 			path = PostHog;
 			sourceTree = "<group>";
@@ -1087,6 +1090,7 @@
 				69F518142BAC7F4300F52C14 /* Date+Util.swift in Sources */,
 				69F5183A2BB2BA8300F52C14 /* UIApplicationTracker.swift in Sources */,
 				69F518182BAC80A300F52C14 /* String+Util.swift in Sources */,
+				69ED1A882C89B73100FE7A91 /* PostHogSwiftUIViewModifiers.swift in Sources */,
 				69F5181A2BAC81FC00F52C14 /* UITextInputTraits+Util.swift in Sources */,
 				69F517E82BAC675800F52C14 /* RRWireframe.swift in Sources */,
 				3A0F108529C9ABB6002C0084 /* ReadWriteLock.swift in Sources */,

--- a/PostHog/PostHogSwiftUIViewModifiers.swift
+++ b/PostHog/PostHogSwiftUIViewModifiers.swift
@@ -37,8 +37,8 @@
                                                        properties: properties))
         }
 
-        func postHogViewEvent(_ event: String,
-                              _ properties: [String: Any]? = nil) -> some View
+        func postHogViewSeen(_ event: String,
+                             _ properties: [String: Any]? = nil) -> some View
         {
             modifier(PostHogSwiftUIViewModifier(viewEventName: event,
                                                 screenEvent: false,

--- a/PostHog/PostHogSwiftUIViewModifiers.swift
+++ b/PostHog/PostHogSwiftUIViewModifiers.swift
@@ -1,0 +1,48 @@
+//
+//  PostHogSwiftUIViewModifiers.swift
+//  PostHog
+//
+//  Created by Manoel Aranda Neto on 05.09.24.
+//
+
+#if canImport(SwiftUI)
+    import Foundation
+    import SwiftUI
+
+    struct PostHogSwiftUIViewModifier: ViewModifier {
+        let viewEventName: String
+
+        let screenEvent: Bool
+
+        let properties: [String: Any]?
+
+        func body(content: Content) -> some View {
+            content.onAppear {
+                if screenEvent {
+                    PostHogSDK.shared.screen(viewEventName, properties: properties)
+                } else {
+                    PostHogSDK.shared.capture(viewEventName, properties: properties)
+                }
+            }
+        }
+    }
+
+    public extension View {
+        func postHogScreenView(_ screenName: String,
+                               _ properties: [String: Any]? = nil) -> some View
+        {
+            modifier(PostHogSwiftUIViewModifier(viewEventName: screenName,
+                                                screenEvent: true,
+                                                properties: properties))
+        }
+
+        func postHogViewEvent(_ event: String,
+                              _ properties: [String: Any]? = nil) -> some View
+        {
+            modifier(PostHogSwiftUIViewModifier(viewEventName: event,
+                                                screenEvent: false,
+                                                properties: properties))
+        }
+    }
+
+#endif

--- a/PostHog/PostHogSwiftUIViewModifiers.swift
+++ b/PostHog/PostHogSwiftUIViewModifiers.swift
@@ -28,12 +28,13 @@
     }
 
     public extension View {
-        func postHogScreenView(_ screenName: String,
+        func postHogScreenView(_ screenName: String? = nil,
                                _ properties: [String: Any]? = nil) -> some View
         {
-            modifier(PostHogSwiftUIViewModifier(viewEventName: screenName,
-                                                screenEvent: true,
-                                                properties: properties))
+            let viewEventName = screenName ?? "\(type(of: self))"
+            return modifier(PostHogSwiftUIViewModifier(viewEventName: viewEventName,
+                                                       screenEvent: true,
+                                                       properties: properties))
         }
 
         func postHogViewEvent(_ event: String,

--- a/PostHogExample/ContentView.swift
+++ b/PostHogExample/ContentView.swift
@@ -125,7 +125,7 @@ struct ContentView: View {
                     }
                     Button(action: triggerIdentify) {
                         Text("Trigger identify!")
-                    }.postHogViewEvent("Trigger identify")
+                    }.postHogViewSeen("Trigger identify")
                 }
 
                 Section("Feature flags") {

--- a/PostHogExample/ContentView.swift
+++ b/PostHogExample/ContentView.swift
@@ -104,6 +104,7 @@ struct ContentView: View {
                     }
                     .sheet(isPresented: $showingSheet) {
                         ContentView()
+                            .postHogScreenView("ContentViewSheet")
                     }
                     Button("Show redacted view") {
                         showingRedactedSheet.toggle()
@@ -124,7 +125,7 @@ struct ContentView: View {
                     }
                     Button(action: triggerIdentify) {
                         Text("Trigger identify!")
-                    }
+                    }.postHogViewEvent("Trigger identify")
                 }
 
                 Section("Feature flags") {

--- a/PostHogExample/PostHogExampleApp.swift
+++ b/PostHogExample/PostHogExampleApp.swift
@@ -14,7 +14,7 @@ struct PostHogExampleApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .postHogScreenView("ContentView")
+                .postHogScreenView() // will infer the class name (ContentView)
         }
     }
 }

--- a/PostHogExample/PostHogExampleApp.swift
+++ b/PostHogExample/PostHogExampleApp.swift
@@ -14,6 +14,7 @@ struct PostHogExampleApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .postHogScreenView("ContentView")
         }
     }
 }


### PR DESCRIPTION
## :bulb: Motivation and Context
Spike for "semi automatic" or more UX friendly https://github.com/PostHog/posthog-ios/issues/167

Screen view (applied to the root view)

```swift
var body: some Scene {
        WindowGroup {
            ContentView()
                .postHogScreenView() // will infer the class name (ContentView)
        }
    }
```

Widget view (applied to any view)

```swift
Button(action: triggerAction) {
    Text("My Text!")
}.postHogViewSeen("My Button")
```

Events will be captured when the View triggers the [onAppear](https://developer.apple.com/documentation/swiftui/view/onappear(perform:)) method

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
