### PR TITLE
recording: send meta event again if session rotates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Next
 
 - chore: add SwiftUI View extensions to capture screen view and views in general (postHogViewEvent, postHogScreenView) ([#180](https://github.com/PostHog/posthog-ios/pull/180))
-- recording: send meta event again if session rotates ([#178](https://github.com/PostHog/posthog-ios/pull/178))
+- recording: send meta event again if session rotates ([#183](https://github.com/PostHog/posthog-ios/pull/183))
 
 ## 3.8.3 - 2024-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 - chore: add SwiftUI View extensions to capture screen view and views in general (postHogViewEvent, postHogScreenView) ([#180](https://github.com/PostHog/posthog-ios/pull/180))
+- recording: send meta event again if session rotates ([#178](https://github.com/PostHog/posthog-ios/pull/178))
 
 ## 3.8.3 - 2024-09-03
 

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -325,7 +325,9 @@ let maxRetryDelay = 30.0
 
     private func resetViews() {
         #if os(iOS)
-            replayIntegration?.resetViews()
+            if config.sessionReplay, featureFlags?.isSessionReplayFlagActive() ?? false {
+                replayIntegration?.resetViews()
+            }
         #endif
     }
 

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -184,7 +184,7 @@ let maxRetryDelay = 30.0
         }
 
         PostHogSessionManager.shared.startSession {
-            self.resetViewsCallback()
+            self.resetViews()
         }
     }
 
@@ -194,7 +194,7 @@ let maxRetryDelay = 30.0
         }
 
         PostHogSessionManager.shared.endSession {
-            self.resetViewsCallback()
+            self.resetViews()
         }
     }
 
@@ -315,7 +315,7 @@ let maxRetryDelay = 30.0
         storage?.reset()
         flagCallReported.removeAll()
         PostHogSessionManager.shared.endSession {
-            self.resetViewsCallback()
+            self.resetViews()
         }
         PostHogSessionManager.shared.startSession()
 
@@ -323,7 +323,7 @@ let maxRetryDelay = 30.0
         reloadFeatureFlags()
     }
 
-    private func resetViewsCallback() {
+    private func resetViews() {
         #if os(iOS)
             replayIntegration?.resetViews()
         #endif
@@ -484,7 +484,7 @@ let maxRetryDelay = 30.0
         // If events fire in the background after the threshold, they should no longer have a sessionId
         if isInBackground {
             PostHogSessionManager.shared.resetSessionIfExpired {
-                self.resetViewsCallback()
+                self.resetViews()
             }
         }
 
@@ -829,7 +829,7 @@ let maxRetryDelay = 30.0
             flagCallReported.removeAll()
             context = nil
             PostHogSessionManager.shared.endSession {
-                self.resetViewsCallback()
+                self.resetViews()
             }
             unregisterNotifications()
             capturedAppInstalled = false
@@ -965,7 +965,7 @@ let maxRetryDelay = 30.0
 
     @objc func handleAppDidBecomeActive() {
         PostHogSessionManager.shared.rotateSessionIdIfRequired {
-            self.resetViewsCallback()
+            self.resetViews()
         }
 
         isInBackground = false

--- a/PostHog/PostHogSessionManager.swift
+++ b/PostHog/PostHogSessionManager.swift
@@ -33,11 +33,11 @@ class PostHogSessionManager {
         }
     }
 
-    func endSession(_ completion: (() -> Void)? = nil) {
+    func endSession(_ completion: () -> Void) {
         sessionLock.withLock {
             sessionId = nil
             sessionLastTimestamp = nil
-            completion?()
+            completion()
         }
     }
 
@@ -45,7 +45,7 @@ class PostHogSessionManager {
         timeNow - sessionLastTimestamp > sessionChangeThreshold
     }
 
-    func resetSessionIfExpired(_ completion: (() -> Void)? = nil) {
+    func resetSessionIfExpired(_ completion: () -> Void) {
         sessionLock.withLock {
             let timeNow = now().timeIntervalSince1970
             if sessionId != nil,
@@ -53,7 +53,7 @@ class PostHogSessionManager {
                isExpired(timeNow, sessionLastTimestamp)
             {
                 sessionId = nil
-                completion?()
+                completion()
             }
         }
     }
@@ -77,7 +77,7 @@ class PostHogSessionManager {
         }
     }
 
-    func rotateSessionIdIfRequired(_ completion: (() -> Void)?) {
+    func rotateSessionIdIfRequired(_ completion: @escaping (() -> Void)) {
         sessionLock.withLock {
             let timeNow = now().timeIntervalSince1970
 

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -73,6 +73,10 @@
             timer = nil
         }
 
+        func resetViews() {
+            windowViews.removeAllObjects()
+        }
+
         private func generateSnapshot(_ view: UIView, _ screenName: String? = nil) {
             var hasChanges = false
 

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -52,7 +52,7 @@ class PostHogSDKTest: QuickSpec {
             now = { Date() }
             server.stop()
             server = nil
-            PostHogSessionManager.shared.endSession()
+            PostHogSessionManager.shared.endSession {}
         }
 
         it("captures the capture event") {


### PR DESCRIPTION
## :bulb: Motivation and Context
The problem: If meta event is missing, the replay will be just a black screen because rrweb hides everything if no meta event is provided

We cache the window and the status object in a weak reference.
If the session rotates, and the window and status object are still in memory, we won't be sending the meta event again
Every time the session rotates, we clear the weak reference object so meta events will be sent again

## :green_heart: How did you test it?
Running

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
