### PR TITLE
fix: mask swiftui picker if masking enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## Next
 
+- recording: mask swiftui picker if masking enabled ([#184](https://github.com/PostHog/posthog-ios/pull/184))
+
 ## 3.9.1 - 2024-09-06
 
-- recording: detect swiftui images not too agressively ([#184](https://github.com/PostHog/posthog-ios/pull/184))
+- recording: detect swiftui images not too agressively ([#181](https://github.com/PostHog/posthog-ios/pull/181))
 
 ## 3.9.0 - 2024-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.9.1 - 2024-09-06
 
-- recording: detect swiftui images not too agressively ([#181](https://github.com/PostHog/posthog-ios/pull/181))
+- recording: detect swiftui images not too agressively ([#184](https://github.com/PostHog/posthog-ios/pull/184))
 
 ## 3.9.0 - 2024-09-06
 


### PR DESCRIPTION
## :bulb: Motivation and Context
I took another stab at https://github.com/PostHog/posthog-ios/issues/163, and https://github.com/PostHog/posthog-ios/issues/167, and could not find a way to do this.
SwiftUI compiles a Text into an Image of the very same type (and many other types), so it's not possible to know if its one or the other.
SwiftUI discards all the accessibility tags during compilation
Meanwhile, I found a bug and made a few improvements.


## :green_heart: How did you test it?
Running a sample app with each type

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
