### PR TITLE
chore: add Is Emulator support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- chore: add Is Emulator support ([#187](https://github.com/PostHog/posthog-ios/pull/187))
+- chore: add Is Emulator support ([#190](https://github.com/PostHog/posthog-ios/pull/190))
 
 ## 3.11.0 - 2024-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- chore: add Is Emulator support ([#187](https://github.com/PostHog/posthog-ios/pull/187))
+
 ## 3.11.0 - 2024-09-11
 
 - chore: add personProfiles support ([#187](https://github.com/PostHog/posthog-ios/pull/187))

--- a/PostHog/PostHogContext.swift
+++ b/PostHog/PostHogContext.swift
@@ -42,6 +42,12 @@ class PostHogContext {
         properties["$device_manufacturer"] = "Apple"
         properties["$device_model"] = platform()
 
+        #if targetEnvironment(simulator)
+            properties["$is_emulator"] = true
+        #else
+            properties["$is_emulator"] = false
+        #endif
+
         #if os(iOS) || os(tvOS)
             let device = UIDevice.current
             // use https://github.com/devicekit/DeviceKit

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -250,6 +250,7 @@ let maxRetryDelay = 30.0
         )
     }
 
+    @discardableResult
     private func requirePersonProcessing() -> Bool {
         if config.personProfiles == .never {
             hedgeLog("personProfiles is set to `never`. This call will be ignored.")

--- a/PostHogTests/PostHogContextTest.swift
+++ b/PostHogTests/PostHogContextTest.swift
@@ -34,6 +34,7 @@ class PostHogContextTest: QuickSpec {
             expect(context["$app_version"] as? String) != nil
             expect(context["$app_build"] as? String) != nil
             expect(context["$app_namespace"] as? String) == "com.apple.dt.xctest.tool"
+            expect(context["$is_emulator"] as? Bool) != nil
             #if os(iOS) || os(tvOS)
                 expect(context["$device_name"] as? String) != nil
                 expect(context["$os_name"] as? String) != nil


### PR DESCRIPTION
## :bulb: Motivation and Context
Closes https://github.com/PostHog/posthog-ios/issues/157
Relates to https://posthog.com/changelog/2024#android-sdk-now-sets-is-emulator-automatically


## :green_heart: How did you test it?
Running on both devices

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [X] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
