### PR TITLE
fix: missing import for url session extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- recording: missing import for url session extensions ([#189](https://github.com/PostHog/posthog-ios/pull/189))
+- recording: missing import for url session extensions ([#194](https://github.com/PostHog/posthog-ios/pull/194))
 
 ## 3.12.0 - 2024-09-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- recording: missing import for url session extensions ([#189](https://github.com/PostHog/posthog-ios/pull/189))
+
 ## 3.12.0 - 2024-09-12
 
 - chore: add Is Emulator support ([#190](https://github.com/PostHog/posthog-ios/pull/190))

--- a/PostHog/Replay/CGSize+Util.swift
+++ b/PostHog/Replay/CGSize+Util.swift
@@ -5,9 +5,9 @@
 //  Created by Manoel Aranda Neto on 24.07.24.
 //
 
-import Foundation
-
 #if os(iOS)
+    import Foundation
+
     extension CGSize {
         func hasSize() -> Bool {
             if width == 0 || height == 0 {

--- a/PostHog/Replay/URLSessionExtension.swift
+++ b/PostHog/Replay/URLSessionExtension.swift
@@ -1,4 +1,6 @@
 #if os(iOS)
+    import Foundation
+
     public extension URLSession {
         private func getMonotonicTimeInMilliseconds() -> UInt64 {
             // Get the raw mach time

--- a/PostHog/UIViewController.swift
+++ b/PostHog/UIViewController.swift
@@ -8,8 +8,8 @@
 //  Created by Manoel Aranda Neto on 23.10.23.
 //
 
-import Foundation
 #if os(iOS) || os(tvOS)
+    import Foundation
     import UIKit
 
     extension UIViewController {


### PR DESCRIPTION
## :bulb: Motivation and Context
follow up https://github.com/PostHog/posthog-ios/pull/189


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
