### PR TITLE
fix: read session replay endpoint from cache

### DIFF
--- a/PostHog/PostHogFeatureFlags.swift
+++ b/PostHog/PostHogFeatureFlags.swift
@@ -40,8 +40,12 @@ class PostHogFeatureFlags {
             sessionReplay = self.storage.getDictionary(forKey: .sessionReplay) as? [String: Any]
         }
 
-        if sessionReplay != nil {
+        if let sessionReplay = sessionReplay {
             sessionReplayFlagActive = true
+
+            if let endpoint = sessionReplay["endpoint"] as? String {
+                config.snapshotEndpoint = endpoint
+            }
         }
     }
 


### PR DESCRIPTION
## :bulb: Motivation and Context
_#skip-changelog_
the endpoint is always /s/ so not a user facing change for now

## :green_heart: How did you test it?
running the example

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
