### PR TITLE
fix: make snapshot endpoint api public but internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- no user facing changes
+
 ## 3.12.3 - 2024-09-18
 
 - no user facing changes

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -34,7 +34,8 @@ import Foundation
     @objc public var personProfiles: PostHogPersonProfiles = .identifiedOnly
 
     /// Internal
-    var snapshotEndpoint: String = "/s/"
+    /// Do not modify it, this flag is read and updated by the SDK via feature flags
+    @objc public var snapshotEndpoint: String = "/s/"
 
     /// or EU Host: 'https://eu.i.posthog.com'
     public static let defaultHost: String = "https://us.i.posthog.com"


### PR DESCRIPTION
## :bulb: Motivation and Context
https://github.com/PostHog/posthog-react-native-session-replay/pull/2#discussion_r1765800338
_#skip-changelog_


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
