### PR TITLE
add missing capture method for objC with groups overload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- add missing capture method for objC with groups overload ([#216](https://github.com/PostHog/posthog-ios/pull/216))
+
 ## 3.13.1 - 2024-10-16
 
 - add optional distinctId parameter to capture methods ([#216](https://github.com/PostHog/posthog-ios/pull/216))

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -475,7 +475,7 @@ let maxRetryDelay = 30.0
     }
 
     @objc public func capture(_ event: String) {
-        capture(event, properties: nil, userProperties: nil, userPropertiesSetOnce: nil, groups: nil)
+        capture(event, distinctId: nil, properties: nil, userProperties: nil, userPropertiesSetOnce: nil, groups: nil)
     }
 
     @objc(captureWithEvent:properties:)
@@ -508,6 +508,16 @@ let maxRetryDelay = 30.0
             return true
         }
         return false
+    }
+
+    @objc(captureWithEvent:properties:userProperties:userPropertiesSetOnce:groups:)
+    public func capture(_ event: String,
+                        properties: [String: Any]? = nil,
+                        userProperties: [String: Any]? = nil,
+                        userPropertiesSetOnce: [String: Any]? = nil,
+                        groups: [String: String]? = nil)
+    {
+        capture(event, distinctId: nil, properties: properties, userProperties: userProperties, userPropertiesSetOnce: userPropertiesSetOnce, groups: groups)
     }
 
     @objc(captureWithEvent:distinctId:properties:userProperties:userPropertiesSetOnce:groups:)


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
