### PR TITLE
Catch race condition in PostHogFileBackedQueue.deleteFiles

### DIFF
--- a/PostHog/PostHogFileBackedQueue.swift
+++ b/PostHog/PostHogFileBackedQueue.swift
@@ -100,9 +100,14 @@ class PostHogFileBackedQueue {
 
     private func deleteFiles(_ count: Int) {
         for _ in 0 ..< count {
-            if items.isEmpty { return }
-            let removed = items.remove(at: 0) // We always remove from the top of the queue
-
+            guard let removed: String = _items.mutate({ items in
+                if items.isEmpty {
+                    return nil
+                }
+                return items.remove(at: 0) // We always remove from the top of the queue
+            }) else {
+                continue
+            }
             deleteSafely(queue.appendingPathComponent(removed))
         }
     }


### PR DESCRIPTION
In rare cases, `deleteFiles(_:)` can be invoked such that, between the check for items.isEmpty and the call to items.remove, the task gets pre-empted and items is mutated. Once the thread resumes, the `.remove(at: 0)` operation causes a crash.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?

Tested by using my app with this patch enabled and verifying that the files are deleted as expected.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
