### PR TITLE
fix: use global frame on wireframe views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: mangled wireframe layouts ([#250](https://github.com/PostHog/posthog-ios/pull/250))
+
 ## 3.15.2 - 2024-11-13
 
 - fix: allow changing person properties after identify ([#249](https://github.com/PostHog/posthog-ios/pull/249))

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -506,7 +506,7 @@
             if !view.subviews.isEmpty {
                 var childWireframes: [RRWireframe] = []
                 for subview in view.subviews {
-                    if let child = toWireframe(subview, isParentSensitive: isSensitive) {
+                    if let child = toWireframe(subview, isParentSensitive: isSensitive || isParentSensitive) {
                         childWireframes.append(child)
                     }
                 }

--- a/PostHog/Replay/UIView+Util.swift
+++ b/PostHog/Replay/UIView+Util.swift
@@ -59,7 +59,7 @@
         }
 
         // you need this because of SwiftUI otherwise the coordinates always zeroed for some reason
-        func toAbsoluteRect(_ window: UIWindow) -> CGRect {
+        func toAbsoluteRect(_ window: UIWindow?) -> CGRect {
             convert(bounds, to: window)
         }
     }

--- a/PostHog/Utils/UIApplication+.swift
+++ b/PostHog/Utils/UIApplication+.swift
@@ -25,11 +25,8 @@
                     }
                 } else {
                     // check scene.windows.isKeyWindow
-                    for window in scene.windows {
-                        // swiftlint:disable:next for_where
-                        if window.isKeyWindow {
-                            return window
-                        }
+                    for window in scene.windows where window.isKeyWindow {
+                        return window
                     }
                 }
 

--- a/PostHog/Utils/UIApplication+.swift
+++ b/PostHog/Utils/UIApplication+.swift
@@ -26,6 +26,7 @@
                 } else {
                     // check scene.windows.isKeyWindow
                     for window in scene.windows {
+                        // swiftlint:disable:next for_where
                         if window.isKeyWindow {
                             return window
                         }


### PR DESCRIPTION
## :bulb: Motivation and Context

Closes #231 

This issue was a bit challenging to uncover, but the solution turned out to be quite straightforward. After digging into the frontend code, I realized we always use `position: fixed` when styling nodes. To ensure the wireframe renders correctly, we need to convert all view frames to global screen coordinates.

### Before
![before](https://github.com/user-attachments/assets/d24e7cf4-21f9-4c00-a89b-e47e48233ea2)

### After
![after](https://github.com/user-attachments/assets/cf09aa66-9a5f-4f11-9139-966e9613d5ef)

## :green_heart: How did you test it?

Locally with some sample projects

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
