### PR TITLE
fix: changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 ## 3.15.7 - 2024-11-25
 
 - fix: detect and mask out system photo library and user photos ([#261](https://github.com/PostHog/posthog-ios/pull/261))
-
+    - This can be disabled through the following `sessionReplayConfig` options: 
+    
+    ```swift
+    config.sessionReplayConfig.maskAllSandboxedViews = false
+    config.sessionReplayConfig.maskPhotoLibraryImages = false
+    ```
 ## 3.15.6 - 2024-11-20
 
 - fix: read accessibilityLabel from parent's view to avoid performance hit on RN ([#259](https://github.com/PostHog/posthog-ios/pull/259))


### PR DESCRIPTION
## :bulb: Motivation and Context

- Added a small note in changelog on how to disable automatic masking of user photo and sandboxed views (Photo picker)

#skip-changelog

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
