### PR TITLE
fix: screen events and autocapture should ignore keyboard window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: ignore autocapture events from keyboard window ([#269](https://github.com/PostHog/posthog-ios/pull/269))
+
 ## 3.16.0 - 2024-12-03
 
 - fix: deprecate `maskPhotoLibraryImages` due to unintended masking issues ([#268](https://github.com/PostHog/posthog-ios/pull/268))

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		69F5181A2BAC81FC00F52C14 /* UITextInputTraits+Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69F518192BAC81FC00F52C14 /* UITextInputTraits+Util.swift */; };
 		69F518382BB2BA0100F52C14 /* PostHogSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69F518372BB2BA0100F52C14 /* PostHogSwizzler.swift */; };
 		69F5183A2BB2BA8300F52C14 /* UIApplicationTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69F518392BB2BA8300F52C14 /* UIApplicationTracker.swift */; };
+		DA0CA6F12CFF6B6300AF9500 /* UIWindow+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0CA6F02CFF6B6300AF9500 /* UIWindow+.swift */; };
 		DA26419C2CC0499300CB427B /* PostHogAutocaptureEventTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA26419A2CC0499300CB427B /* PostHogAutocaptureEventTracker.swift */; };
 		DA5AA7192CE245D2004EFB99 /* UIApplication+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5AA7132CE245CD004EFB99 /* UIApplication+.swift */; };
 		DA5B85882CD21CBB00686389 /* AutocaptureEventProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5B85872CD21CBB00686389 /* AutocaptureEventProcessing.swift */; };
@@ -392,6 +393,7 @@
 		69F518192BAC81FC00F52C14 /* UITextInputTraits+Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextInputTraits+Util.swift"; sourceTree = "<group>"; };
 		69F518372BB2BA0100F52C14 /* PostHogSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSwizzler.swift; sourceTree = "<group>"; };
 		69F518392BB2BA8300F52C14 /* UIApplicationTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIApplicationTracker.swift; sourceTree = "<group>"; };
+		DA0CA6F02CFF6B6300AF9500 /* UIWindow+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindow+.swift"; sourceTree = "<group>"; };
 		DA26419A2CC0499300CB427B /* PostHogAutocaptureEventTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogAutocaptureEventTracker.swift; sourceTree = "<group>"; };
 		DA5AA7132CE245CD004EFB99 /* UIApplication+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+.swift"; sourceTree = "<group>"; };
 		DA5B85872CD21CBB00686389 /* AutocaptureEventProcessing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutocaptureEventProcessing.swift; sourceTree = "<group>"; };
@@ -510,6 +512,7 @@
 		3AA4C09B2988315D006C4731 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				DA0CA6F02CFF6B6300AF9500 /* UIWindow+.swift */,
 				DA5AA7132CE245CD004EFB99 /* UIApplication+.swift */,
 				3AE3FB422992985A00AFFC18 /* Reachability.swift */,
 				3AE3FB462992AB0000AFFC18 /* Hedgelog.swift */,
@@ -1143,6 +1146,7 @@
 				69261D1F2AD9681300232EC7 /* PostHogConsumerPayload.swift in Sources */,
 				6955CB732C517651008EFD8D /* CGSize+Util.swift in Sources */,
 				69F517EA2BAC684F00F52C14 /* RRStyle.swift in Sources */,
+				DA0CA6F12CFF6B6300AF9500 /* UIWindow+.swift in Sources */,
 				69F23A782BB30991001194F6 /* NetworkSample.swift in Sources */,
 				69F23A762BB308AE001194F6 /* URLSessionInterceptor.swift in Sources */,
 				690FF0BF2AEFA97F00A0B06B /* FileUtils.swift in Sources */,

--- a/PostHog/Autocapture/PostHogAutocaptureEventTracker.swift
+++ b/PostHog/Autocapture/PostHogAutocaptureEventTracker.swift
@@ -205,6 +205,23 @@
             // first, call original method
             ph_swizzled_setContentOffset_Setter(contentOffset)
 
+            guard shouldTrack(self) else {
+                return
+            }
+
+            // ignore all keyboard events
+            if let window, window.isKeyboardWindow {
+                return
+            }
+
+            // nothing changed
+            guard
+                self.contentOffset.x.distance(to: contentOffset.x) > 0 ||
+                self.contentOffset.y.distance(to: contentOffset.y) > 0
+            else {
+                return
+            }
+
             // block scrolls on UIPickerTableView. (captured via a forwarding delegate implementation)
             if String(describing: type(of: self)) == "UIPickerTableView" {
                 return
@@ -476,6 +493,7 @@
         if view.isHidden { return false }
         if !view.isUserInteractionEnabled { return false }
         if view.isNoCapture() { return false }
+        if view.window?.isKeyboardWindow == true { return false }
 
         if let textField = view as? UITextField, textField.isSensitiveText() {
             return false

--- a/PostHog/Autocapture/PostHogAutocaptureEventTracker.swift
+++ b/PostHog/Autocapture/PostHogAutocaptureEventTracker.swift
@@ -201,9 +201,9 @@
     }
 
     extension UIScrollView {
-        @objc func ph_swizzled_setContentOffset_Setter(_ contentOffset: CGPoint) {
+        @objc func ph_swizzled_setContentOffset_Setter(_ newContentOffset: CGPoint) {
             // first, call original method
-            ph_swizzled_setContentOffset_Setter(contentOffset)
+            ph_swizzled_setContentOffset_Setter(newContentOffset)
 
             guard shouldTrack(self) else {
                 return
@@ -214,11 +214,8 @@
                 return
             }
 
-            // nothing changed
-            guard
-                self.contentOffset.x.distance(to: contentOffset.x) > 0 ||
-                self.contentOffset.y.distance(to: contentOffset.y) > 0
-            else {
+            // scrollview did not scroll (contentOffset didn't change)
+            guard contentOffset != newContentOffset else {
                 return
             }
 

--- a/PostHog/UIViewController.swift
+++ b/PostHog/UIViewController.swift
@@ -61,11 +61,10 @@
         @objc func viewDidAppearOverride(animated: Bool) {
             // ignore views from keyboard window
             // these may include: UIInputWindowController, _UICursorAccessoryViewController, UICompatibilityInputViewController,UIKeyboardHiddenViewController_Autofill and others
-            if let window = viewIfLoaded?.window, window.isKeyboardWindow {
-                return
+            if let window = viewIfLoaded?.window, !window.isKeyboardWindow {
+                captureScreenView(window)
             }
 
-            captureScreenView(viewIfLoaded?.window)
             // it looks like we're calling ourselves, but we're actually
             // calling the original implementation of viewDidAppear since it's been swizzled.
             viewDidAppearOverride(animated: animated)

--- a/PostHog/UIViewController.swift
+++ b/PostHog/UIViewController.swift
@@ -83,7 +83,6 @@
             if let presented = controller?.presentedViewController {
                 return findVisibleViewController(presented)
             }
-
             return controller
         }
     }

--- a/PostHog/UIViewController.swift
+++ b/PostHog/UIViewController.swift
@@ -16,12 +16,12 @@
         static func swizzleScreenView() {
             swizzle(forClass: UIViewController.self,
                     original: #selector(UIViewController.viewDidAppear(_:)),
-                    new: #selector(UIViewController.viewDidApperOverride))
+                    new: #selector(UIViewController.viewDidAppearOverride))
         }
 
         static func unswizzleScreenView() {
             swizzle(forClass: UIViewController.self,
-                    original: #selector(UIViewController.viewDidApperOverride),
+                    original: #selector(UIViewController.viewDidAppearOverride),
                     new: #selector(UIViewController.viewDidAppear(_:)))
         }
 
@@ -58,11 +58,17 @@
             }
         }
 
-        @objc func viewDidApperOverride(animated: Bool) {
+        @objc func viewDidAppearOverride(animated: Bool) {
+            // ignore views from keyboard window
+            // these may include: UIInputWindowController, _UICursorAccessoryViewController, UICompatibilityInputViewController,UIKeyboardHiddenViewController_Autofill and others
+            if let window = viewIfLoaded?.window, window.isKeyboardWindow {
+                return
+            }
+
             captureScreenView(viewIfLoaded?.window)
             // it looks like we're calling ourselves, but we're actually
             // calling the original implementation of viewDidAppear since it's been swizzled.
-            viewDidApperOverride(animated: animated)
+            viewDidAppearOverride(animated: animated)
         }
 
         private func findVisibleViewController(_ controller: UIViewController?) -> UIViewController? {
@@ -77,6 +83,7 @@
             if let presented = controller?.presentedViewController {
                 return findVisibleViewController(presented)
             }
+
             return controller
         }
     }

--- a/PostHog/Utils/UIWindow+.swift
+++ b/PostHog/Utils/UIWindow+.swift
@@ -1,0 +1,16 @@
+//
+//  UIWindow+.swift
+//  PostHog
+//
+//  Created by Yiannis Josephides on 03/12/2024.
+//
+
+#if os(iOS) || os(tvOS)
+    import UIKit
+
+    extension UIWindow {
+        var isKeyboardWindow: Bool {
+            String(describing: type(of: window)) == "UIRemoteKeyboardWindow"
+        }
+    }
+#endif

--- a/PostHog/Utils/UIWindow+.swift
+++ b/PostHog/Utils/UIWindow+.swift
@@ -6,6 +6,7 @@
 //
 
 #if os(iOS) || os(tvOS)
+    import Foundation
     import UIKit
 
     extension UIWindow {

--- a/PostHogExampleAutocapture/PostHogExampleAutocapture.xcodeproj/project.pbxproj
+++ b/PostHogExampleAutocapture/PostHogExampleAutocapture.xcodeproj/project.pbxproj
@@ -991,7 +991,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
-				DEVELOPMENT_TEAM = 2SL8CLD7D2;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/PostHogExampleAutocapture/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
@@ -1012,7 +1012,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
-				DEVELOPMENT_TEAM = 2SL8CLD7D2;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/PostHogExampleAutocapture/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";

--- a/PostHogExampleAutocapture/PostHogExampleAutocapture.xcodeproj/project.pbxproj
+++ b/PostHogExampleAutocapture/PostHogExampleAutocapture.xcodeproj/project.pbxproj
@@ -991,7 +991,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 2SL8CLD7D2;
 				INFOPLIST_FILE = "$(SRCROOT)/PostHogExampleAutocapture/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
@@ -1012,7 +1012,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 2SL8CLD7D2;
 				INFOPLIST_FILE = "$(SRCROOT)/PostHogExampleAutocapture/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";


### PR DESCRIPTION
## :bulb: Motivation and Context
Original thread: https://posthog.slack.com/archives/C0113360FFV/p1733238766585229
Ticket: https://posthoghelp.zendesk.com/agent/tickets/21072 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/24648)

### Problem

It seems that we were unintentionally capturing view controllers belonging to the keyboard window when sending `$screen` events. While this might not be a significant issue under normal circumstances, for applications that are message- or form-heavy, this behavior could result in inflated autocapture event volumes. 	

### Fix

- Updated logic to ignore any UIView or UIViewController that belongs to the keyboard window
- Added a similar logic got `$autocapture` events + some minor improvements

## :green_heart: How did you test it?

Sample project

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
