### PR TITLE
fix: flicker when sensitive text field is on screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: screen flicker when capturing a screenshot when a sensitive text field is on screen ([#270](https://github.com/PostHog/posthog-ios/pull/270))
+
 ## 3.16.0 - 2024-12-03
 
 - fix: deprecate `maskPhotoLibraryImages` due to unintended masking issues ([#268](https://github.com/PostHog/posthog-ios/pull/268))

--- a/PostHog/Replay/UIView+Util.swift
+++ b/PostHog/Replay/UIView+Util.swift
@@ -54,11 +54,9 @@
             let renderer = UIGraphicsImageRenderer(size: size, format: rendererFormat)
 
             let image = renderer.image { _ in
-                // true for afterScreenUpdates so that we capture view *after* any pending animations are committed
-                // As a side effect, we need to pause view tracker temporarily to avoid recursive calls since this option will cause subviews to layout, which will then trigger another capture
-                ViewLayoutTracker.paused = true
-                drawHierarchy(in: bounds, afterScreenUpdates: true)
-                ViewLayoutTracker.paused = false
+                /// Note: Always `false` for `afterScreenUpdates` since this will cause the screen to flicker when a sensitive text field is visible on screen
+                /// This can potentially affect capturing a snapshot during a screen transition but we want the lesser of the two evils here
+                drawHierarchy(in: bounds, afterScreenUpdates: false)
             }
 
             return image

--- a/PostHog/Replay/ViewLayoutTracker.swift
+++ b/PostHog/Replay/ViewLayoutTracker.swift
@@ -3,17 +3,14 @@
     import UIKit
 
     enum ViewLayoutTracker {
-        static var paused = false
         private(set) static var hasChanges = false
         private static var hasSwizzled = false
 
         static func viewDidLayout(view _: UIView) {
-            guard !paused else { return }
             hasChanges = true
         }
 
         static func clear() {
-            guard !paused else { return }
             hasChanges = false
         }
 


### PR DESCRIPTION
## :bulb: Motivation and Context

See: https://github.com/PostHog/posthog-react-native-session-replay/issues/17

In an attempt to avoid capturing a screenshot during screen transitions we enabled capturing a snapshot after screen updates https://github.com/PostHog/posthog-ios/pull/265. However, this causes the screen to flicker since iOS will hide secure text fields and keyboard when drawing the view hierarchy. 

Let's revert this change for now

## :green_heart: How did you test it?

Sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
