### PR TITLE
fix: don't mask SwiftUI gradient views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: avoid masking SwiftUI Gradient views ([#275](https://github.com/PostHog/posthog-ios/pull/275))
+
 ## 3.17.0 - 2024-12-10
 
 - feat: ability to add a custom label to autocapture elements ([#271](https://github.com/PostHog/posthog-ios/pull/271))

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -443,9 +443,9 @@
         private func isTextFieldSensitive(_ view: UITextField) -> Bool {
             (isTextInputSensitive(view) || view.isSensitiveText()) && (hasText(view.text) || hasText(view.placeholder))
         }
-        
+
         private func isSwiftUILayerSafe(_ layer: CALayer) -> Bool {
-            swiftUISafeLayerTypes.contains(where: {layer.isKind(of: $0)})
+            swiftUISafeLayerTypes.contains(where: { layer.isKind(of: $0) })
         }
 
         private func hasText(_ text: String?) -> Bool {

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -86,6 +86,11 @@
         // These are usually views that don't belong to the current process and are most likely sensitive
         private let systemSandboxedView: AnyClass? = NSClassFromString("_UIRemoteView")
 
+        // These layer types should be safe to ignore while masking
+        private let swiftUISafeLayerTypes: [AnyClass] = [
+            "SwiftUI.GradientLayer", // Views like LinearGradient, RadialGradient, or AngularGradient
+        ].compactMap(NSClassFromString)
+
         static let dispatchQueue = DispatchQueue(label: "com.posthog.PostHogReplayIntegration",
                                                  target: .global(qos: .utility))
 
@@ -331,7 +336,7 @@
             }
 
             // this can be anything, so better to be conservative
-            if swiftUIGenericTypes.contains(where: { view.isKind(of: $0) }) {
+            if swiftUIGenericTypes.contains(where: { view.isKind(of: $0) }), !isSwiftUILayerSafe(view.layer) {
                 if isTextInputSensitive(view), !hasSubViews {
                     maskableWidgets.append(view.toAbsoluteRect(window))
                     return
@@ -437,6 +442,10 @@
 
         private func isTextFieldSensitive(_ view: UITextField) -> Bool {
             (isTextInputSensitive(view) || view.isSensitiveText()) && (hasText(view.text) || hasText(view.placeholder))
+        }
+        
+        private func isSwiftUILayerSafe(_ layer: CALayer) -> Bool {
+            swiftUISafeLayerTypes.contains(where: {layer.isKind(of: $0)})
         }
 
         private func hasText(_ text: String?) -> Bool {


### PR DESCRIPTION
## :bulb: Motivation and Context
ticket: https://posthoghelp.zendesk.com/agent/tickets/22163 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/24885)

Avoid masking SwiftUI gradient views (e.g LinearGradient, RadialGradient, or AngularGradient)

## :green_heart: How did you test it?

locally

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
