### PR TITLE
fix: add UITextEffectsWindow type in screen ignore list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: ignore additional keyboard windows for $screen event ([#279](https://github.com/PostHog/posthog-ios/pull/279))
+
 ## 3.17.1 - 2024-12-18
 
 - fix: avoid masking SwiftUI Gradient views ([#275](https://github.com/PostHog/posthog-ios/pull/275))

--- a/PostHog/UIViewController.swift
+++ b/PostHog/UIViewController.swift
@@ -60,7 +60,6 @@
 
         @objc func viewDidAppearOverride(animated: Bool) {
             // ignore views from keyboard window
-            // these may include: UIInputWindowController, _UICursorAccessoryViewController, UICompatibilityInputViewController,UIKeyboardHiddenViewController_Autofill and others
             if let window = viewIfLoaded?.window, !window.isKeyboardWindow {
                 captureScreenView(window)
             }

--- a/PostHog/Utils/UIWindow+.swift
+++ b/PostHog/Utils/UIWindow+.swift
@@ -9,9 +9,42 @@
     import Foundation
     import UIKit
 
+    /**
+     Known keyboard window (private) types
+
+     ## UIRemoteKeyboardWindow
+     This is the window that manages the actual keyboard
+     
+     The following system view controllers were observed to be presented in a UIRemoteKeyboardWindow window
+        - UIInputWindowController
+        - UICompatibilityInputViewController
+        - UISystemInputAssistantViewController
+        - UIPredictionViewController
+        - UISystemKeyboardDockController
+        - TUIEmojiSearchInputViewController
+        - STKPrewarmingViewController
+        - STKStickerRemoteSearchViewController
+        - _UIRemoteInputViewController
+        - _UISceneHostingViewController
+        - STKEmojiAndStickerCollectionViewController
+     
+     ## UITextEffectsWindow
+     Hosts system components like the magnifying glass for text selection, predictive text suggestions, copy/paste menus, input accessory views etc.
+     
+     The following system view controllers were observed to be presented in a UITextEffectsWindow window
+        - UIInputWindowController
+        - UICompatibilityInputViewController
+     
+     These view controllers should not appear in a $screen event. If they do, then it means that they are presented in a UIWindow not listed below
+     */
+    private let knownKeyboardWindowTypes: [String] = [
+        "UIRemoteKeyboardWindow",
+        "UITextEffectsWindow",
+    ]
+
     extension UIWindow {
         var isKeyboardWindow: Bool {
-            String(describing: type(of: window)) == "UIRemoteKeyboardWindow"
+            knownKeyboardWindowTypes.contains(String(describing: type(of: self)))
         }
     }
 #endif

--- a/PostHog/Utils/UIWindow+.swift
+++ b/PostHog/Utils/UIWindow+.swift
@@ -14,7 +14,7 @@
 
      ## UIRemoteKeyboardWindow
      This is the window that manages the actual keyboard
-     
+
      The following system view controllers were observed to be presented in a UIRemoteKeyboardWindow window
         - UIInputWindowController
         - UICompatibilityInputViewController
@@ -27,14 +27,14 @@
         - _UIRemoteInputViewController
         - _UISceneHostingViewController
         - STKEmojiAndStickerCollectionViewController
-     
+
      ## UITextEffectsWindow
      Hosts system components like the magnifying glass for text selection, predictive text suggestions, copy/paste menus, input accessory views etc.
-     
+
      The following system view controllers were observed to be presented in a UITextEffectsWindow window
         - UIInputWindowController
         - UICompatibilityInputViewController
-     
+
      These view controllers should not appear in a $screen event. If they do, then it means that they are presented in a UIWindow not listed below
      */
     private let knownKeyboardWindowTypes: [String] = [


### PR DESCRIPTION
## :bulb: Motivation and Context

follow up for: https://github.com/PostHog/posthog-ios/pull/269
ticket: https://posthoghelp.zendesk.com/agent/tickets/21072 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/24648)

We missed `UITextEffectsWindow` which is another window presented when keyboard appears (for SwiftUI at least). 

I also listed all the UIViewController types in code so we know what we believe we are ignoring. If any $screen event ever pops up with on of those UIViewController types, then it means it was presented on another UIWindow type. 

Note: We don't ignore any other system UIViewController / UIWindow (e.g UIActivityViewController) but: 
1. I doubt these will ever prove problematic in terms of billing (a messaging app was flooded with keyboard screen events)
2. They may be even useful for some customers

## :green_heart: How did you test it?

Local sample project

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
