### PR TITLE
fix: check viewcontroller hierarchy for transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: recordings not always properly masked during screen transitions ([#306](https://github.com/PostHog/posthog-ios/pull/306))
+
 ## 3.19.6 - 2025-02-18
 
 - fix: crash on autocapture when a segmented control has not selection ([#304](https://github.com/PostHog/posthog-ios/pull/304))

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -408,7 +408,7 @@
         }
 
         private func toScreenshotWireframe(_ window: UIWindow) -> RRWireframe? {
-            // this will bail on interactive animations (e.g edge slide)
+            // this will bail on view controller animations (interactive or not)
             if !window.isVisible() || isAnimatingTransition(window) {
                 return nil
             }
@@ -432,9 +432,29 @@
             return wireframe
         }
 
-        /// Check if window's root view controller is animating a transition
+        /// Check if any view controller in the hierarchy is animating a transition
         private func isAnimatingTransition(_ window: UIWindow) -> Bool {
-            window.rootViewController?.transitionCoordinator?.isAnimated ?? false
+            guard let rootViewController = window.rootViewController else { return false }
+            return isAnimatingTransition(rootViewController)
+        }
+
+        private func isAnimatingTransition(_ viewController: UIViewController) -> Bool {
+            // Check if this view controller is animating
+            if viewController.transitionCoordinator?.isAnimated ?? false {
+                return true
+            }
+
+            // Check if presented view controller is animating
+            if let presented = viewController.presentedViewController, isAnimatingTransition(presented) {
+                return true
+            }
+
+            // Check if any of the child view controllers is animating
+            if viewController.children.first(where: isAnimatingTransition) != nil {
+                return true
+            }
+
+            return false
         }
 
         private func isAssetsImage(_ image: UIImage) -> Bool {


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #298 

We used to skip snapshots if the current root view controller was animating a transition. However, there are cases where any view controller in the hierarchy can be animating a transition (For example in our SwiftUI example project, it's a `SwiftUI.UIKitNavigationController` that is actually animating , which is added as a child to the root VC) - we added that missing check. 

| Before    | After |
| -------- | ------- |
|  <img src="https://github.com/user-attachments/assets/74cdb648-7e19-46f1-9f1a-5f0045184e08"/>  | <img src="https://github.com/user-attachments/assets/86122150-0983-41c8-8fd8-620bda089a6c"/> |

More context in the original PR discussion [here](https://github.com/PostHog/posthog-ios/pull/265#discussion_r1860305805)

## :green_heart: How did you test it?

Manually local test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
