### PR TITLE
fix: Xcode15.4 builds

### DIFF
--- a/PostHog/Surveys/Utils/EmojiRating.swift
+++ b/PostHog/Surveys/Utils/EmojiRating.swift
@@ -97,25 +97,33 @@
         }
     }
 
-    @available(iOS 18.0, *)
-    #Preview {
-        @Previewable @State var selectedValue: Int?
+    #if DEBUG
+        @available(iOS 18.0, *)
+        private struct TestView: View {
+            @State var selectedValue: Int?
 
-        NavigationView {
-            VStack(spacing: 40) {
-                EmojiRating(
-                    selectedValue: $selectedValue,
-                    emojiRange: .oneToFive,
-                    lowerBoundLabel: "Unlikely",
-                    upperBoundLabel: "Very likely"
-                )
-                .padding(.horizontal, 20)
+            var body: some View {
+                NavigationView {
+                    VStack(spacing: 40) {
+                        EmojiRating(
+                            selectedValue: $selectedValue,
+                            emojiRange: .oneToFive,
+                            lowerBoundLabel: "Unlikely",
+                            upperBoundLabel: "Very likely"
+                        )
+                        .padding(.horizontal, 20)
+                    }
+                }
+                .navigationBarTitle(Text("Emoji Rating"))
+                .environment(\.surveyAppearance.ratingButtonColor, .green.opacity(0.3))
+                .environment(\.surveyAppearance.ratingButtonActiveColor, .green)
+                .environment(\.surveyAppearance.descriptionTextColor, .orange)
             }
         }
-        .navigationBarTitle(Text("Emoji Rating"))
-        .environment(\.surveyAppearance.ratingButtonColor, .green.opacity(0.3))
-        .environment(\.surveyAppearance.ratingButtonActiveColor, .green)
-        .environment(\.surveyAppearance.descriptionTextColor, .orange)
-    }
 
+        @available(iOS 18.0, *)
+        #Preview {
+            TestView()
+        }
+    #endif
 #endif

--- a/PostHog/Surveys/Utils/MultipleChoiceOptions.swift
+++ b/PostHog/Surveys/Utils/MultipleChoiceOptions.swift
@@ -128,25 +128,33 @@
         }
     }
 
-    @available(iOS 18.0, *)
-    #Preview {
-        @Previewable @State var selectedOptions: Set<String> = []
-        @Previewable @State var openChoiceInput = ""
+    #if DEBUG
+        @available(iOS 18.0, *)
+        private struct TestView: View {
+            @State var selectedOptions: Set<String> = []
+            @State var openChoiceInput = ""
 
-        MultipleChoiceOptions(
-            allowsMultipleSelection: true,
-            hasOpenChoiceQuestion: true,
-            options: [
-                "Tutorials",
-                "Customer case studies",
-                "Product announcements",
-                "Other",
-            ],
-            selectedOptions: $selectedOptions,
-            openChoiceInput: $openChoiceInput
-        )
-        .colorScheme(.dark)
-        .padding()
-    }
+            var body: some View {
+                MultipleChoiceOptions(
+                    allowsMultipleSelection: true,
+                    hasOpenChoiceQuestion: true,
+                    options: [
+                        "Tutorials",
+                        "Customer case studies",
+                        "Product announcements",
+                        "Other",
+                    ],
+                    selectedOptions: $selectedOptions,
+                    openChoiceInput: $openChoiceInput
+                )
+                .colorScheme(.dark)
+                .padding()
+            }
+        }
 
+        @available(iOS 18.0, *)
+        #Preview {
+            TestView()
+        }
+    #endif
 #endif

--- a/PostHog/Surveys/Utils/NumberRating.swift
+++ b/PostHog/Surveys/Utils/NumberRating.swift
@@ -99,26 +99,31 @@
         }
     }
 
-    @available(iOS 18.0, *)
-    #Preview {
-        @Previewable @State var selectedValue: Int?
+    #if DEBUG
+        @available(iOS 18.0, *)
+        private struct TestView: View {
+            @State var selectedValue: Int?
 
-        NavigationView {
-            VStack(spacing: 15) {
-                NumberRating(
-                    selectedValue: $selectedValue,
-                    numberRange: .oneToFive,
-                    lowerBoundLabel: "Unlikely",
-                    upperBoundLabel: "Very Likely"
-                )
+            var body: some View {
+                NavigationView {
+                    VStack(spacing: 15) {
+                        NumberRating(
+                            selectedValue: $selectedValue,
+                            numberRange: .oneToFive,
+                            lowerBoundLabel: "Unlikely",
+                            upperBoundLabel: "Very Likely"
+                        )
+                    }
+                    .padding()
+                }
+                .navigationBarTitle(Text("Number Rating"))
+                .environment(\.colorScheme, .light)
             }
-            .padding()
         }
-        .navigationBarTitle(Text("Number Rating"))
-        .environment(\.colorScheme, .light)
-        // .environment(\.surveyAppearance.borderColor, .blue)
-        // .environment(\.surveyAppearance.ratingButtonActiveColor, .white)
-        // .environment(\.surveyAppearance.ratingButtonColor, .red)
-    }
 
+        @available(iOS 18.0, *)
+        #Preview {
+            TestView()
+        }
+    #endif
 #endif


### PR DESCRIPTION
## :bulb: Motivation and Context

Removes `@Previewable` which breaks builds on Xcode 15.4 (spotted on Flutter CI)
#skip-changelog

## :green_heart: How did you test it?

locally

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
