### PR TITLE
fix: Reimplement `isfeatureEnabled` using `getFeatureFlag`

### DIFF
--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -844,21 +844,8 @@ let maxRetryDelay = 30.0
     }
 
     @objc public func isFeatureEnabled(_ key: String) -> Bool {
-        if !isEnabled() {
-            return false
-        }
-
-        guard let remoteConfig else {
-            return false
-        }
-
-        let value = remoteConfig.isFeatureEnabled(key)
-
-        if config.sendFeatureFlagEvent {
-            reportFeatureFlagCalled(flagKey: key, flagValue: value)
-        }
-
-        return value
+        let result = getFeatureFlag(key)
+        return result is String ? true : (result as? Bool) ?? false
     }
 
     @objc public func getFeatureFlagPayload(_ key: String) -> Any? {

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -246,6 +246,29 @@ class PostHogSDKTest: QuickSpec {
             sut.close()
         }
 
+        it("send feature flag event with variant response for isFeatureEnabled when enabled") {
+            let sut = self.getSut(preloadFeatureFlags: true, sendFeatureFlagEvent: true)
+
+            waitDecideRequest(server)
+            expect(sut.isFeatureEnabled("string-value")) == true
+
+            let events = getBatchedEvents(server)
+
+            expect(events.count) == 1
+
+            let event = events.first!
+            expect(event.event) == "$feature_flag_called"
+            expect(event.properties["$feature_flag"] as? String) == "string-value"
+            expect(event.properties["$feature_flag_response"] as? String) == "test"
+            expect(event.properties["$feature_flag_request_id"] as? String) == "0f801b5b-0776-42ca-b0f7-8375c95730bf"
+            expect(event.properties["$feature_flag_id"] as? Int) == 3
+            expect(event.properties["$feature_flag_version"] as? Int) == 1
+            expect(event.properties["$feature_flag_reason"] as? String) == "Matched condition set 1"
+
+            sut.reset()
+            sut.close()
+        }
+
         it("send feature flag event for getFeatureFlag when enabled") {
             let sut = self.getSut(preloadFeatureFlags: true, sendFeatureFlagEvent: true)
 

--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#/ Usage: bin/build
+#/ Description: Runs linter and mypy
+source bin/helpers/_utils.sh
+set_source_and_root_dir
+
+make buildSdk

--- a/bin/fmt
+++ b/bin/fmt
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#/ Usage: bin/fmt
+#/ Description: Lints the code
+source bin/helpers/_utils.sh
+set_source_and_root_dir
+
+make lint

--- a/bin/helpers/_utils.sh
+++ b/bin/helpers/_utils.sh
@@ -1,0 +1,15 @@
+error() {
+    echo "$@" >&2
+}
+
+fatal() {
+    error "$@"
+    exit 1
+}
+
+set_source_and_root_dir() {
+    { set +x; } 2>/dev/null
+    source_dir="$( cd -P "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
+    root_dir=$(cd "$source_dir" && cd ../ && pwd)
+    cd "$root_dir"
+}

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#/ Usage: bin/setup
+#/ Description: Sets up the dependencies needed to develop this project
+source bin/helpers/_utils.sh
+set_source_and_root_dir
+
+make bootstrap

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#/ Usage: bin/test
+#/ Description: Runs all the unit tests for this project
+source bin/helpers/_utils.sh
+set_source_and_root_dir
+
+make test


### PR DESCRIPTION
Changes `isFeatureEnabled` to delegate to `getFeatureFlag` in order to get the result. This ensures that the `$feature_flag_called` event sends the correct `$feature_flag_response`.

Also added some bin scripts: See PostHog/meta#309 for context.

## :bulb: Motivation and Context

Fixes #336

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
