### PR TITLE
fix: support ISO8601 dates without milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: support ISO8601 dates with missing milliseconds ([#338](https://github.com/PostHog/posthog-ios/pull/338))
+
 ## 3.24.0 - 2025-04-17
 
 - chore: Autocapture GA ([#334](https://github.com/PostHog/posthog-ios/pull/334))

--- a/PostHog/Utils/DateUtils.swift
+++ b/PostHog/Utils/DateUtils.swift
@@ -7,14 +7,36 @@
 
 import Foundation
 
-let apiDateFormatter: DateFormatter = {
-    let dateFormatter = DateFormatter()
-    dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-    dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
+final class PostHogAPIDateFormatter {
+    private let dateFormatterWithMilliseconds: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
 
-    dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
-    return dateFormatter
-}()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        return dateFormatter
+    }()
+
+    private let dateFormatterWithSeconds: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
+
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
+        return dateFormatter
+    }()
+
+    func string(from date: Date) -> String {
+        dateFormatterWithMilliseconds.string(from: date)
+    }
+
+    func date(from string: String) -> Date? {
+        dateFormatterWithMilliseconds.date(from: string)
+            ?? dateFormatterWithSeconds.date(from: string)
+    }
+}
+
+let apiDateFormatter = PostHogAPIDateFormatter()
 
 public func toISO8601String(_ date: Date) -> String {
     apiDateFormatter.string(from: date)

--- a/PostHog/Utils/DateUtils.swift
+++ b/PostHog/Utils/DateUtils.swift
@@ -8,23 +8,17 @@
 import Foundation
 
 final class PostHogAPIDateFormatter {
-    private let dateFormatterWithMilliseconds: DateFormatter = {
+    private static func getFormatter(with format: String) -> DateFormatter {
         let dateFormatter = DateFormatter()
         dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
-
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        dateFormatter.dateFormat = format
         return dateFormatter
-    }()
+    }
 
-    private let dateFormatterWithSeconds: DateFormatter = {
-        let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-        dateFormatter.timeZone = TimeZone(abbreviation: "UTC")
+    private let dateFormatterWithMilliseconds = getFormatter(with: "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
 
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
-        return dateFormatter
-    }()
+    private let dateFormatterWithSeconds = getFormatter(with: "yyyy-MM-dd'T'HH:mm:ss'Z'")
 
     func string(from date: Date) -> String {
         dateFormatterWithMilliseconds.string(from: date)

--- a/PostHogTests/PostHogSurveysTest.swift
+++ b/PostHogTests/PostHogSurveysTest.swift
@@ -54,8 +54,8 @@ enum PostHogSurveysTest {
             #expect(sut.appearance?.surveyPopupDelaySeconds == 5)
             #expect(sut.startDate.map(ISO8601DateFormatter().string) == "2025-01-16T22:23:38Z")
             #expect(sut.endDate == nil)
-            #expect(sut.currentIteration == nil)
-            #expect(sut.currentIterationStartDate == nil)
+            #expect(sut.currentIteration == 1)
+            #expect(sut.currentIterationStartDate.map(ISO8601DateFormatter().string) == "2024-12-12T18:58:22Z")
         }
 
         @Suite("Survey question types decode correctly")

--- a/PostHogTests/Resources/fixture_survey_basic.json
+++ b/PostHogTests/Resources/fixture_survey_basic.json
@@ -38,6 +38,6 @@
     },
     "start_date": "2025-01-16T22:23:38.805000Z",
     "end_date": null,
-    "current_iteration": null,
-    "current_iteration_start_date": null
+    "current_iteration": 1,
+    "current_iteration_start_date": "2024-12-12T18:58:22Z"
 }

--- a/PostHogTests/UtilsTest.swift
+++ b/PostHogTests/UtilsTest.swift
@@ -53,4 +53,41 @@ struct UtilsTest {
             #expect(frNumber.toInt() == 1234567891)
         }
     }
+
+    @Suite("Date format tests")
+    struct DateTests {
+        @Test("can parse ISO8601 date with microsecond precision")
+        func canParseISO8601DateWithMicroseconds() {
+            let dateString = "2024-12-17T16:51:06.952123Z"
+            let date = toISO8601Date(dateString)
+            #expect(date != nil)
+            let backToString = toISO8601String(date!)
+            #expect(backToString == "2024-12-17T16:51:06.952Z")
+        }
+
+        @Test("can parse ISO8601 date with milliseconds precision")
+        func canParseISO8601DateWithMilliseconds() {
+            let dateString = "2024-12-17T16:51:06.952Z"
+            let date = toISO8601Date(dateString)
+            #expect(date != nil)
+            let backToString = toISO8601String(date!)
+            #expect(backToString == "2024-12-17T16:51:06.952Z")
+        }
+
+        @Test("can parse ISO8601 date with seconds precision")
+        func canParseISO8601DateWithSeconds() {
+            let dateString = "2024-12-12T18:58:22Z"
+            let date = toISO8601Date(dateString)
+            #expect(date != nil)
+            let backToString = toISO8601String(date!)
+            #expect(backToString == "2024-12-12T18:58:22.000Z")
+        }
+
+        @Test("converts date to ISO8601 string consistently")
+        func convertsDateToISO8601StringConsistently() {
+            let date = Date(timeIntervalSince1970: 1703174400) // 2023-12-21T16:00:00Z
+            let dateString = toISO8601String(date)
+            #expect(dateString == "2023-12-21T16:00:00.000Z")
+        }
+    }
 }


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Ticket: https://posthoghelp.zendesk.com/agent/tickets/29347 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/31579)

Parse ISO8601 date formats with no millisecond precision (e.g "2025-04-09T09:21:03Z")

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
