### PR TITLE
fix: optional link in link survey question type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- fix: optional link in survey question type ([#341](https://github.com/PostHog/posthog-ios/pull/341))
+
 ## 3.24.1 - 2025-04-23
 
 - fix: Send correct `$feature_flag_response` for the `$feature_flag_called` event when calling `isFeatureEnabled` ([#337](https://github.com/PostHog/posthog-ios/pull/337))

--- a/PostHog/Models/Surveys/PostHogSurveyQuestion.swift
+++ b/PostHog/Models/Surveys/PostHogSurveyQuestion.swift
@@ -117,7 +117,7 @@ struct PostHogLinkSurveyQuestion: PostHogSurveyQuestionProperties, Decodable {
     let originalQuestionIndex: Int?
     let branching: PostHogSurveyQuestionBranching?
     /// URL link associated with the question
-    let link: String
+    let link: String?
 }
 
 /// Represents a rating-based survey question

--- a/PostHog/Surveys/QuestionTypes.swift
+++ b/PostHog/Surveys/QuestionTypes.swift
@@ -84,7 +84,10 @@
         }
 
         private var link: URL? {
-            URL(string: question.link)
+            if let link = question.link {
+                return URL(string: link)
+            }
+            return nil
         }
     }
 


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Realized that we can save and launch a link survey type with an empty link (I guess this is the notification type). We were not handling this case on iOS correctly 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
