### PR TITLE
chore(flags): use new `/flags` endpoint instead of `/decide`

### DIFF
--- a/PostHog/PostHogApi.swift
+++ b/PostHog/PostHogApi.swift
@@ -192,18 +192,18 @@ class PostHogApi {
         }.resume()
     }
 
-    func decide(
+    func flags(
         distinctId: String,
         anonymousId: String?,
         groups: [String: String],
         completion: @escaping ([String: Any]?, _ error: Error?) -> Void
     ) {
         guard let url = getEndpointURL(
-            "/decide",
-            queryItems: URLQueryItem(name: "v", value: "4"),
+            "/flags",
+            queryItems: URLQueryItem(name: "v", value: "2"),
             relativeTo: config.host
         ) else {
-            hedgeLog("Malformed decide URL error.")
+            hedgeLog("Malformed flags URL error.")
             return completion(nil, nil)
         }
 
@@ -226,13 +226,13 @@ class PostHogApi {
         do {
             data = try JSONSerialization.data(withJSONObject: toSend)
         } catch {
-            hedgeLog("Error parsing the decide body: \(error)")
+            hedgeLog("Error parsing the flags body: \(error)")
             return completion(nil, error)
         }
 
         URLSession(configuration: config).uploadTask(with: request, from: data!) { data, response, error in
             if error != nil {
-                hedgeLog("Error calling the decide API: \(String(describing: error))")
+                hedgeLog("Error calling the flags API: \(String(describing: error))")
                 return completion(nil, error)
             }
 
@@ -240,20 +240,20 @@ class PostHogApi {
 
             if !(200 ... 299 ~= httpResponse.statusCode) {
                 let jsonBody = String(describing: try? JSONSerialization.jsonObject(with: data!, options: .allowFragments) as? [String: Any])
-                let errorMessage = "Error calling decide API: status: \(httpResponse.statusCode), body: \(jsonBody)."
+                let errorMessage = "Error calling flags API: status: \(httpResponse.statusCode), body: \(jsonBody)."
                 hedgeLog(errorMessage)
 
                 return completion(nil,
                                   InternalPostHogError(description: errorMessage))
             } else {
-                hedgeLog("Decide called successfully.")
+                hedgeLog("Flags called successfully.")
             }
 
             do {
                 let jsonData = try JSONSerialization.jsonObject(with: data!, options: .allowFragments) as? [String: Any]
                 completion(jsonData, nil)
             } catch {
-                hedgeLog("Error parsing the decide response: \(error)")
+                hedgeLog("Error parsing the flags response: \(error)")
                 completion(nil, error)
             }
         }.resume()

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -237,7 +237,7 @@ class PostHogRemoteConfig {
             self.loadingFeatureFlags = true
         }
 
-        api.decide(distinctId: distinctId,
+        api.flags(distinctId: distinctId,
                    anonymousId: anonymousId,
                    groups: groups)
         { data, _ in
@@ -260,7 +260,7 @@ class PostHogRemoteConfig {
 
                 // Safely handle optional data
                 guard var data = data else {
-                    hedgeLog("Error: Decide response data is nil")
+                    hedgeLog("Error: Flags response data is nil")
                     self.notifyFeatureFlagsAndRelease(data)
                     return callback(nil)
                 }
@@ -282,7 +282,7 @@ class PostHogRemoteConfig {
                 guard let featureFlags = data["featureFlags"] as? [String: Any],
                       let featureFlagPayloads = data["featureFlagPayloads"] as? [String: Any]
                 else {
-                    hedgeLog("Error: Decide response missing correct featureFlags format")
+                    hedgeLog("Error: Flags response missing correct featureFlags format")
 
                     self.notifyFeatureFlagsAndRelease(data)
 

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -447,7 +447,7 @@ let maxRetryDelay = 30.0
             var props: [String: Any] = ["distinct_id": distinctId]
 
             if !config.reuseAnonymousId {
-                // We keep the AnonymousId to be used by decide calls and identify to link the previousId
+                // We keep the AnonymousId to be used by flags calls and identify to link the previousId
                 storageManager.setAnonymousId(oldDistinctId)
                 props["$anon_distinct_id"] = oldDistinctId
             }

--- a/PostHogTests/PostHogApiTest.swift
+++ b/PostHogTests/PostHogApiTest.swift
@@ -45,10 +45,10 @@ enum PostHogApiTests {
             #expect(resp.statusCode == 200)
         }
 
-        func testDecideEndpoint(forHost host: String) async throws {
+        func testFlagsEndpoint(forHost host: String) async throws {
             let sut = getSut(host: host)
             let resp = await getApiResponse { completion in
-                sut.decide(distinctId: "", anonymousId: "", groups: [:]) { data, _ in
+                sut.flags(distinctId: "", anonymousId: "", groups: [:]) { data, _ in
                     completion(data)
                 }
             }
@@ -147,41 +147,41 @@ enum PostHogApiTests {
         }
     }
 
-    @Suite("Test decide endpoint with different host paths")
-    class TestDecideEndpoint: BaseTestSuite {
+    @Suite("Test flags endpoint with different host paths")
+    class TestFlagsEndpoint: BaseTestSuite {
         @Test("with host containing no path")
         func testHostWithNoPath() async throws {
-            try await testDecideEndpoint(forHost: "http://localhost")
+            try await testFlagsEndpoint(forHost: "http://localhost")
         }
 
         @Test("with host containing no path and trailing slash")
         func testHostWithNoPathAndTrailingSlash() async throws {
-            try await testDecideEndpoint(forHost: "http://localhost/")
+            try await testFlagsEndpoint(forHost: "http://localhost/")
         }
 
         @Test("with host containing path")
         func testHostWithPath() async throws {
-            try await testDecideEndpoint(forHost: "http://localhost/api/v1")
+            try await testFlagsEndpoint(forHost: "http://localhost/api/v1")
         }
 
         @Test("with host containing path and trailing slash")
         func testHostWithPathAndTrailingSlash() async throws {
-            try await testDecideEndpoint(forHost: "http://localhost/api/v1/")
+            try await testFlagsEndpoint(forHost: "http://localhost/api/v1/")
         }
 
         @Test("with host containing port number")
         func testHostWithPortNumber() async throws {
-            try await testDecideEndpoint(forHost: "http://localhost:9000")
+            try await testFlagsEndpoint(forHost: "http://localhost:9000")
         }
 
         @Test("with host containing port number and path")
         func testHostWithPortNumberAndPath() async throws {
-            try await testDecideEndpoint(forHost: "http://localhost:9000/api/v1")
+            try await testFlagsEndpoint(forHost: "http://localhost:9000/api/v1")
         }
 
         @Test("with host containing port number, path and trailing slash")
         func testHostWithPortNumberAndTrailingSlash() async throws {
-            try await testDecideEndpoint(forHost: "http://localhost:9000/api/v1/")
+            try await testFlagsEndpoint(forHost: "http://localhost:9000/api/v1/")
         }
     }
 }

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -216,7 +216,7 @@ class PostHogSDKTest: QuickSpec {
         it("loads feature flags automatically") {
             let sut = self.getSut(preloadFeatureFlags: true)
 
-            waitDecideRequest(server)
+            waitFlagsRequest(server)
             expect(sut.isFeatureEnabled("bool-value")) == true
 
             sut.reset()
@@ -226,7 +226,7 @@ class PostHogSDKTest: QuickSpec {
         it("send feature flag event for isFeatureEnabled when enabled") {
             let sut = self.getSut(preloadFeatureFlags: true, sendFeatureFlagEvent: true)
 
-            waitDecideRequest(server)
+            waitFlagsRequest(server)
             expect(sut.isFeatureEnabled("bool-value")) == true
 
             let events = getBatchedEvents(server)
@@ -249,7 +249,7 @@ class PostHogSDKTest: QuickSpec {
         it("send feature flag event with variant response for isFeatureEnabled when enabled") {
             let sut = self.getSut(preloadFeatureFlags: true, sendFeatureFlagEvent: true)
 
-            waitDecideRequest(server)
+            waitFlagsRequest(server)
             expect(sut.isFeatureEnabled("string-value")) == true
 
             let events = getBatchedEvents(server)
@@ -272,7 +272,7 @@ class PostHogSDKTest: QuickSpec {
         it("send feature flag event for getFeatureFlag when enabled") {
             let sut = self.getSut(preloadFeatureFlags: true, sendFeatureFlagEvent: true)
 
-            waitDecideRequest(server)
+            waitFlagsRequest(server)
             expect(sut.getFeatureFlag("bool-value") as? Bool) == true
 
             let events = getBatchedEvents(server)
@@ -304,7 +304,7 @@ class PostHogSDKTest: QuickSpec {
 
             sut.reloadFeatureFlags()
 
-            let requests = getDecideRequest(server)
+            let requests = getFlagsRequest(server)
 
             expect(requests.count) == 1
             let request = requests.first
@@ -365,7 +365,7 @@ class PostHogSDKTest: QuickSpec {
             let sut = self.getSut()
 
             sut.reloadFeatureFlags()
-            waitDecideRequest(server)
+            waitFlagsRequest(server)
 
             sut.capture("event")
 
@@ -553,7 +553,7 @@ class PostHogSDKTest: QuickSpec {
 
             sut.reset()
 
-            waitDecideRequest(server)
+            waitFlagsRequest(server)
             expect(sut.isFeatureEnabled("bool-value")) == true
 
             sut.close()

--- a/PostHogTests/TestUtils/MockPostHogServer.swift
+++ b/PostHogTests/TestUtils/MockPostHogServer.swift
@@ -16,9 +16,9 @@ import OHHTTPStubsSwift
 class MockPostHogServer {
     var batchRequests = [URLRequest]()
     var batchExpectation: XCTestExpectation?
-    var decideExpectation: XCTestExpectation?
+    var flagsExpectation: XCTestExpectation?
     var batchExpectationCount: Int?
-    var decideRequests = [URLRequest]()
+    var flagsRequests = [URLRequest]()
     var version: Int = 3
 
     func trackBatchRequest(_ request: URLRequest) {
@@ -29,10 +29,10 @@ class MockPostHogServer {
         }
     }
 
-    func trackDecide(_ request: URLRequest) {
-        decideRequests.append(request)
+    func trackFlags(_ request: URLRequest) {
+        flagsRequests.append(request)
 
-        decideExpectation?.fulfill()
+        flagsExpectation?.fulfill()
     }
 
     public var errorsWhileComputingFlags = false
@@ -51,7 +51,7 @@ class MockPostHogServer {
     init(version: Int = 3) {
         self.version = version
 
-        stub(condition: pathEndsWith("/decide")) { _ in
+        stub(condition: pathEndsWith("/flags")) { _ in
             if self.quotaLimitFeatureFlags {
                 return HTTPStubsResponse(
                     jsonObject: ["quotaLimited": ["feature_flags"]],
@@ -296,8 +296,8 @@ class MockPostHogServer {
         HTTPStubs.onStubActivation { request, _, _ in
             if request.url?.lastPathComponent == "batch" {
                 self.trackBatchRequest(request)
-            } else if request.url?.lastPathComponent == "decide" {
-                self.trackDecide(request)
+            } else if request.url?.lastPathComponent == "flags" {
+                self.trackFlags(request)
             }
         }
     }
@@ -316,9 +316,9 @@ class MockPostHogServer {
 
     func reset(batchCount: Int = 1) {
         batchRequests = []
-        decideRequests = []
+        flagsRequests = []
         batchExpectation = XCTestExpectation(description: "\(batchCount) batch requests to occur")
-        decideExpectation = XCTestExpectation(description: "1 decide requests to occur")
+        flagsExpectation = XCTestExpectation(description: "1 flag requests to occur")
         batchExpectationCount = batchCount
         errorsWhileComputingFlags = false
         return500 = false

--- a/PostHogTests/TestUtils/TestPostHog.swift
+++ b/PostHogTests/TestUtils/TestPostHog.swift
@@ -25,19 +25,19 @@ func getBatchedEvents(_ server: MockPostHogServer, timeout: TimeInterval = 15.0,
     return events
 }
 
-func waitDecideRequest(_ server: MockPostHogServer) {
-    let result = XCTWaiter.wait(for: [server.decideExpectation!], timeout: 15)
+func waitFlagsRequest(_ server: MockPostHogServer) {
+    let result = XCTWaiter.wait(for: [server.flagsExpectation!], timeout: 15)
 
     if result != XCTWaiter.Result.completed {
         XCTFail("The expected requests never arrived")
     }
 }
 
-func getDecideRequest(_ server: MockPostHogServer) -> [[String: Any]] {
-    waitDecideRequest(server)
+func getFlagsRequest(_ server: MockPostHogServer) -> [[String: Any]] {
+    waitFlagsRequest(server)
 
     var requests: [[String: Any]] = []
-    for request in server.decideRequests.reversed() {
+    for request in server.flagsRequests.reversed() {
         let item = server.parseRequest(request, gzip: false)
         requests.append(item!)
     }


### PR DESCRIPTION
## :bulb: Motivation and Context

Update the iOS SDK to use the new `/flags` endpoint instead of the legacy `/decide` one.
