### PR TITLE
fix: prevent duplicate application lifecycle events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: prevent duplicate application lifecycle events ([#354](https://github.com/PostHog/posthog-ios/pull/354))
+
 ## 3.26.1 - 2025-05-30
 
 - fix: clear cached flags if remote config response hasFeatureFlags is false ([#347](https://github.com/PostHog/posthog-ios/pull/347))


### PR DESCRIPTION
## :bulb: Motivation and Context
Ticket: https://posthoghelp.zendesk.com/agent/tickets/30965 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/33289)

Noticed some cases where two consecutive Application Backgrounded events were being captured. This occurs when the app is launched by the system in the background (e.g., due to background modes like location updates for example). In this scenario, the system will trigger a `didEnterBackgroundNotification` without a corresponding `didBecomeActiveNotification`

User opens the app -> Application Opened
User backgrounds the app -> Application Backgrounded
System launches the app in the background -> Application Backgrounded event

This change ensures that we skip duplicate events by tracking background state and ignoring redundant transitions 

## :green_heart: How did you test it?

Added a unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
