### PR TITLE
fix: unify storage path for `appGroupIdentifier` across targets

### DIFF
--- a/PostHog/PostHogStorage.swift
+++ b/PostHog/PostHogStorage.swift
@@ -47,8 +47,6 @@ func applicationSupportDirectoryURL() -> URL {
 func appGroupContainerUrl(config: PostHogConfig) -> URL? {
     guard let appGroupIdentifier = config.appGroupIdentifier else { return nil }
 
-    let bundleIdentifier = getBundleIdentifier()
-
     #if os(tvOS)
         // tvOS: Due to stricter sandbox rules, creating "Application Support" directory is not possible on tvOS
         let librarySubPath = "Library/Caches/"
@@ -59,7 +57,7 @@ func appGroupContainerUrl(config: PostHogConfig) -> URL? {
     let url = FileManager.default
         .containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier)?
         .appendingPathComponent(librarySubPath)
-        .appendingPathComponent(bundleIdentifier)
+        .appendingPathComponent(appGroupIdentifier)
 
     if let url {
         createDirectoryAtURLIfNeeded(url: url)

--- a/PostHogTests/PostHogStorageTest.swift
+++ b/PostHogTests/PostHogStorageTest.swift
@@ -25,12 +25,20 @@ class PostHogStorageTest {
 
     @Test("returns the app group container dir URL")
     func returnsTheAppGroupContainerDirURL() {
+        let appGroupIdentifier = "group.com.posthog.some_identifier"
         let config = PostHogConfig(apiKey: "123")
-        config.appGroupIdentifier = "some_identifier"
+        config.appGroupIdentifier = appGroupIdentifier
         let url = appGroupContainerUrl(config: config)!
-        let expectedSuffix = ["Library", "Application Support", testBundleIdentifier]
+
+        let expectedSuffix = ["Library", "Application Support", appGroupIdentifier]
         let actualSuffix = Array(url.pathComponents.suffix(expectedSuffix.count))
+
+        // positive check: must return the same url across the whole app group
         #expect(actualSuffix == expectedSuffix)
+
+        // negative check: guard against using bundleIdentifier, prevents spawning
+        // separate folders per bundle identifer within the app group folder
+        #expect(!actualSuffix.contains(testBundleIdentifier))
 
         let groupContainerComponent = url.pathComponents[url.pathComponents.count - 5]
         #expect(["Group Containers", "AppGroup"].contains(groupContainerComponent))


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When integrating PostHog into both my app and its widget extension, I discovered that each target was getting its own AnonymousId. Although I’d set:

```swift
let config = PostHogConfig(apiKey: ..., host: ...)
config.appGroupIdentifier = "group.com.hoppsen.current_app"
...
```

Debugging the code and folders I noticed that the code I now changed appended the `bundleIdentifer` to the folder path, which in my case resulted in multiple folders (one per target).

Because of this, the widget and the main app weren’t sharing the same AnonymousId. This change removes the bundle-ID suffix so that all targets point to one shared container under the app group.

```
// Before fix:
.../AppGroup/123456789/Library/Application%20Support/com.hoppsen.current_app/phc_...
.../AppGroup/123456789/Library/Application%20Support/com.hoppsen.current_app.WidgetExtension/phc_...

// After fix:
.../AppGroup/123456789/Library/Application%20Support/group.com.hoppsen.current_app/phc_...
```

## :green_heart: How did you test it?
I tested it within my local environment and ran the updated unit test to confirm the suffix no longer includes the bundle identifier.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] ~I updated the docs if needed.~
- [ ] No breaking change or entry added to the changelog.

---
Thanks for an amazing product! ❤️ Please let me know if I’ve misunderstood the `bundleIdentifier`’s intended role.