### PR TITLE
feat: add support for beforeSend function to edit or drop events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- feat: add support for beforeSend function to edit or drop events ([#357](https://github.com/PostHog/posthog-ios/pull/357))
+
 ## 3.27.0 - 2025-06-16
 
 - fix: unify storage path for `appGroupIdentifier` across targets ([#356](https://github.com/PostHog/posthog-ios/pull/356))

--- a/PostHog/Models/PostHogEvent.swift
+++ b/PostHog/Models/PostHogEvent.swift
@@ -84,7 +84,7 @@ import Foundation
     }
 }
 
-enum PostHogEventName: String, CaseIterable {
+enum PostHogKnownUnsafeEditableEvent: String {
     case snapshot = "$snapshot"
     case pageview = "$pageview"
     case pageleave = "$pageleave"
@@ -100,7 +100,7 @@ enum PostHogEventName: String, CaseIterable {
     case featureEnrollmentUpdate = "$feature_enrollment_update"
     case featureFlagCalled = "$feature_flag_called"
 
-    static func isUnsafeEditable(_ name: String) -> Bool {
-        PostHogEventName(rawValue: name) != nil
+    static func contains(_ name: String) -> Bool {
+        PostHogKnownUnsafeEditableEvent(rawValue: name) != nil
     }
 }

--- a/PostHog/Models/PostHogEvent.swift
+++ b/PostHog/Models/PostHogEvent.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public class PostHogEvent {
+@objc(PostHogEvent) public class PostHogEvent: NSObject {
     public var event: String
     public var distinctId: String
     public var properties: [String: Any]

--- a/PostHog/Models/PostHogEvent.swift
+++ b/PostHog/Models/PostHogEvent.swift
@@ -8,13 +8,13 @@
 import Foundation
 
 @objc(PostHogEvent) public class PostHogEvent: NSObject {
-    public var event: String
-    public var distinctId: String
-    public var properties: [String: Any]
-    public var timestamp: Date
-    public var uuid: UUID
+    @objc public var event: String
+    @objc public var distinctId: String
+    @objc public var properties: [String: Any]
+    @objc public var timestamp: Date
+    @objc public private(set) var uuid: UUID
     // Only used for Replay
-    public var apiKey: String?
+    var apiKey: String?
 
     init(event: String, distinctId: String, properties: [String: Any]? = nil, timestamp: Date = Date(), uuid: UUID = UUID.v7(), apiKey: String? = nil) {
         self.event = event
@@ -81,5 +81,26 @@ import Foundation
         }
 
         return json
+    }
+}
+
+enum PostHogEventName: String, CaseIterable {
+    case snapshot = "$snapshot"
+    case pageview = "$pageview"
+    case pageleave = "$pageleave"
+    case set = "$set"
+    case surveyDismissed = "survey dismissed"
+    case surveySent = "survey sent"
+    case surveyShown = "survey shown"
+    case identify = "$identify"
+    case groupidentify = "$groupidentify"
+    case createAlias = "$create_alias"
+    case clientIngestionWarning = "$$client_ingestion_warning"
+    case webExperimentApplied = "$web_experiment_applied"
+    case featureEnrollmentUpdate = "$feature_enrollment_update"
+    case featureFlagCalled = "$feature_flag_called"
+
+    static func isUnsafeEditable(_ name: String) -> Bool {
+        PostHogEventName(rawValue: name) != nil
     }
 }

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -6,6 +6,8 @@
 //
 import Foundation
 
+public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
+
 @objc(PostHogConfig) public class PostHogConfig: NSObject {
     enum Defaults {
         #if os(tvOS)
@@ -66,9 +68,13 @@ import Foundation
 
     /// Hook that allows to sanitize the event properties
     /// The hook is called before the event is cached or sent over the wire
+    @available(*, deprecated, message: "Use beforeSend instead")
     @objc public var propertiesSanitizer: PostHogPropertiesSanitizer?
     /// Determines the behavior for processing user profiles.
     @objc public var personProfiles: PostHogPersonProfiles = .identifiedOnly
+    /// Hook that allows to sanitize the event
+    /// The hook is called before the event is cached or sent over the wire
+    @objc public var beforeSend: BeforeSendBlock = { $0 }
 
     /// The identifier of the App Group that should be used to store shared analytics data.
     /// PostHog will try to get the physical location of the App Group’s shared container, otherwise fallback to the default location

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -6,7 +6,16 @@
 //
 import Foundation
 
-public typealias BeforeSendBlock = (PostHogEvent?) -> PostHogEvent?
+public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
+
+@objc public final class BoxedBeforeSendBlock: NSObject {
+    @objc public let block: BeforeSendBlock
+
+    @objc(block:)
+    public init(block: @escaping BeforeSendBlock) {
+        self.block = block
+    }
+}
 
 @objc(PostHogConfig) public class PostHogConfig: NSObject {
     enum Defaults {
@@ -72,9 +81,6 @@ public typealias BeforeSendBlock = (PostHogEvent?) -> PostHogEvent?
     @objc public var propertiesSanitizer: PostHogPropertiesSanitizer?
     /// Determines the behavior for processing user profiles.
     @objc public var personProfiles: PostHogPersonProfiles = .identifiedOnly
-    /// Hook that allows to sanitize the event
-    /// The hook is called before the event is cached or sent over the wire
-    @objc public var beforeSend: BeforeSendBlock = { $0 }
 
     /// The identifier of the App Group that should be used to store shared analytics data.
     /// PostHog will try to get the physical location of the App Group’s shared container, otherwise fallback to the default location
@@ -176,5 +182,34 @@ public typealias BeforeSendBlock = (PostHogEvent?) -> PostHogEvent?
         if #available(iOS 15.0, *) {
             _surveys = value
         }
+    }
+
+    /// Hook that allows to sanitize the event
+    /// The hook is called before the event is cached or sent over the wire
+    private var beforeSend: BeforeSendBlock = { $0 }
+
+    private static func buildBeforeSendBlock(_ blocks: [BeforeSendBlock]) -> BeforeSendBlock {
+        { event in
+            blocks.reduce(event) { event, block in
+                event.flatMap(block)
+            }
+        }
+    }
+
+    public func setBeforeSend(_ blocks: [BeforeSendBlock]) {
+        beforeSend = Self.buildBeforeSendBlock(blocks)
+    }
+
+    public func setBeforeSend(_ blocks: BeforeSendBlock...) {
+        setBeforeSend(blocks)
+    }
+
+    @available(*, unavailable, message: "Use setBeforeSend(_ blocks: BeforeSendBlock...) instead")
+    @objc public func setBeforeSend(_ blocks: [BoxedBeforeSendBlock]) {
+        setBeforeSend(blocks.map(\.block))
+    }
+
+    func runBeforeSend(_ event: PostHogEvent) -> PostHogEvent? {
+        beforeSend(event)
     }
 }

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -6,7 +6,7 @@
 //
 import Foundation
 
-public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
+public typealias BeforeSendBlock = (PostHogEvent?) -> PostHogEvent?
 
 @objc(PostHogConfig) public class PostHogConfig: NSObject {
     enum Defaults {

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -796,7 +796,7 @@ let maxRetryDelay = 30.0
 
         if resultEvent == nil {
             let originalMessage = "PostHog event \(eventName) was dropped"
-            let message = PostHogEventName.isUnsafeEditable(eventName)
+            let message = PostHogKnownUnsafeEditableEvent.contains(eventName)
                 ? "\(originalMessage). This can cause unexpected behavior."
                 : originalMessage
 

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -461,13 +461,12 @@ let maxRetryDelay = 30.0
                 userProperties: sanitizeDictionary(userProperties),
                 userPropertiesSetOnce: sanitizeDictionary(userPropertiesSetOnce)
             )
-            let sanitizedProperties = sanitizeProperties(properties)
 
-            queue.add(PostHogEvent(
-                event: "$identify",
-                distinctId: distinctId,
-                properties: sanitizedProperties
-            ))
+            guard let event = buildEvent(event: "$identify", distinctId: distinctId, properties: properties) else {
+                return
+            }
+
+            queue.add(event)
 
             remoteConfig?.reloadFeatureFlags()
 
@@ -570,7 +569,7 @@ let maxRetryDelay = 30.0
             return
         }
 
-        let isSnapshotEvent = event == "$snapshot"
+        var isSnapshotEvent = event == "$snapshot"
         let eventTimestamp = timestamp ?? now()
         let eventDistinctId = distinctId ?? getDistinctId()
 
@@ -587,22 +586,29 @@ let maxRetryDelay = 30.0
                                          groups: groups,
                                          appendSharedProps: !isSnapshotEvent,
                                          timestamp: timestamp)
-        let sanitizedProperties = sanitizeProperties(properties)
+
+        // Sanitize is now called in buildEvent
+        let posthogEvent = buildEvent(
+            event: event,
+            distinctId: eventDistinctId,
+            properties: properties,
+            timestamp: eventTimestamp
+        )
+
+        guard let posthogEvent else {
+            return
+        }
+
+        // Reevaluate if this is a snapshot event because the event might have been updated by the beforeSend hook
+        isSnapshotEvent = posthogEvent.event == "$snapshot"
 
         // if this is a $snapshot event and $session_id is missing, don't process then event
-        if isSnapshotEvent, sanitizedProperties["$session_id"] == nil {
+        if isSnapshotEvent, posthogEvent.properties["$session_id"] == nil {
             return
         }
 
         // Session Replay has its own queue
         let targetQueue = isSnapshotEvent ? replayQueue : queue
-
-        let posthogEvent = PostHogEvent(
-            event: event,
-            distinctId: eventDistinctId,
-            properties: sanitizedProperties,
-            timestamp: eventTimestamp
-        )
 
         targetQueue?.add(posthogEvent)
 
@@ -636,13 +642,12 @@ let maxRetryDelay = 30.0
         let distinctId = getDistinctId()
 
         let properties = buildProperties(distinctId: distinctId, properties: props)
-        let sanitizedProperties = sanitizeProperties(properties)
 
-        queue.add(PostHogEvent(
-            event: "$screen",
-            distinctId: distinctId,
-            properties: sanitizedProperties
-        ))
+        guard let event = buildEvent(event: "$screen", distinctId: distinctId, properties: properties) else {
+            return
+        }
+
+        queue.add(event)
     }
 
     func autocapture(
@@ -670,13 +675,12 @@ let maxRetryDelay = 30.0
         let distinctId = getDistinctId()
 
         let properties = buildProperties(distinctId: distinctId, properties: props)
-        let sanitizedProperties = sanitizeProperties(properties)
 
-        queue.add(PostHogEvent(
-            event: "$autocapture",
-            distinctId: distinctId,
-            properties: sanitizedProperties
-        ))
+        guard let event = buildEvent(event: "$autocapture", distinctId: distinctId, properties: properties) else {
+            return
+        }
+
+        queue.add(event)
     }
 
     private func sanitizeProperties(_ properties: [String: Any]) -> [String: Any] {
@@ -708,13 +712,12 @@ let maxRetryDelay = 30.0
         let distinctId = getDistinctId()
 
         let properties = buildProperties(distinctId: distinctId, properties: props)
-        let sanitizedProperties = sanitizeProperties(properties)
 
-        queue.add(PostHogEvent(
-            event: "$create_alias",
-            distinctId: distinctId,
-            properties: sanitizedProperties
-        ))
+        guard let event = buildEvent(event: "$create_alias", distinctId: distinctId, properties: properties) else {
+            return
+        }
+
+        queue.add(event)
     }
 
     private func groups(_ newGroups: [String: String]) -> [String: String] {
@@ -771,13 +774,25 @@ let maxRetryDelay = 30.0
         let distinctId = getDistinctId()
 
         let properties = buildProperties(distinctId: distinctId, properties: props)
+
+        guard let event = buildEvent(event: "$groupidentify", distinctId: distinctId, properties: properties) else {
+            return
+        }
+
+        queue.add(event)
+    }
+
+    func buildEvent(event: String, distinctId: String, properties: [String: Any], timestamp: Date = Date()) -> PostHogEvent? {
         let sanitizedProperties = sanitizeProperties(properties)
 
-        queue.add(PostHogEvent(
-            event: "$groupidentify",
+        let event = PostHogEvent(
+            event: event,
             distinctId: distinctId,
-            properties: sanitizedProperties
-        ))
+            properties: sanitizedProperties,
+            timestamp: timestamp
+        )
+
+        return config.beforeSend(event)
     }
 
     @objc(groupWithType:key:)

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -792,7 +792,7 @@ let maxRetryDelay = 30.0
             timestamp: timestamp
         )
 
-        let resultEvent = config.beforeSend(event)
+        let resultEvent = config.runBeforeSend(event)
 
         if resultEvent == nil {
             let originalMessage = "PostHog event \(eventName) was dropped"

--- a/PostHogExampleWithPods/PostHogExampleWithPods.xcodeproj/project.pbxproj
+++ b/PostHogExampleWithPods/PostHogExampleWithPods.xcodeproj/project.pbxproj
@@ -12,11 +12,10 @@
 		690FF0262AE7C5BA00A0B06B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 690FF0252AE7C5BA00A0B06B /* Assets.xcassets */; };
 		690FF0292AE7C5BA00A0B06B /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 690FF0282AE7C5BA00A0B06B /* Preview Assets.xcassets */; };
 		690FF0362AE7C61300A0B06B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690FF0352AE7C61300A0B06B /* AppDelegate.swift */; };
-		C9E5B5DE324D8151CE82217D /* Pods_PostHogExampleWithPods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43AF6FA31CF44E5BE9245799 /* Pods_PostHogExampleWithPods.framework */; };
+		E7087D98D8DE0D2DD84278DD /* Pods_PostHogExampleWithPods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8266354C5603FEBCC7C01E4B /* Pods_PostHogExampleWithPods.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		43AF6FA31CF44E5BE9245799 /* Pods_PostHogExampleWithPods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PostHogExampleWithPods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C2D1D1AA0327AA47D050EED /* Pods-PostHogExampleWithPods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PostHogExampleWithPods.release.xcconfig"; path = "Target Support Files/Pods-PostHogExampleWithPods/Pods-PostHogExampleWithPods.release.xcconfig"; sourceTree = "<group>"; };
 		690FF01E2AE7C5B900A0B06B /* PostHogExampleWithPods.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PostHogExampleWithPods.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		690FF0212AE7C5B900A0B06B /* PostHogExampleWithPodsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogExampleWithPodsApp.swift; sourceTree = "<group>"; };
@@ -24,6 +23,7 @@
 		690FF0252AE7C5BA00A0B06B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		690FF0282AE7C5BA00A0B06B /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		690FF0352AE7C61300A0B06B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		8266354C5603FEBCC7C01E4B /* Pods_PostHogExampleWithPods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PostHogExampleWithPods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9E7CD1F6231834F08BF61E6C /* Pods-PostHogExampleWithPods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PostHogExampleWithPods.debug.xcconfig"; path = "Target Support Files/Pods-PostHogExampleWithPods/Pods-PostHogExampleWithPods.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -32,7 +32,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C9E5B5DE324D8151CE82217D /* Pods_PostHogExampleWithPods.framework in Frameworks */,
+				E7087D98D8DE0D2DD84278DD /* Pods_PostHogExampleWithPods.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -89,7 +89,7 @@
 		9A20B85D4D10AA6F7B0C13FB /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				43AF6FA31CF44E5BE9245799 /* Pods_PostHogExampleWithPods.framework */,
+				8266354C5603FEBCC7C01E4B /* Pods_PostHogExampleWithPods.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -105,7 +105,7 @@
 				690FF01A2AE7C5B900A0B06B /* Sources */,
 				690FF01B2AE7C5B900A0B06B /* Frameworks */,
 				690FF01C2AE7C5B900A0B06B /* Resources */,
-				09BD9A3D139AADDAE022DD57 /* [CP] Embed Pods Frameworks */,
+				6E4C2BEF8CB8F259A129729E /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -162,7 +162,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		09BD9A3D139AADDAE022DD57 /* [CP] Embed Pods Frameworks */ = {
+		6E4C2BEF8CB8F259A129729E /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (

--- a/PostHogExampleWithPods/PostHogExampleWithPods.xcodeproj/project.pbxproj
+++ b/PostHogExampleWithPods/PostHogExampleWithPods.xcodeproj/project.pbxproj
@@ -12,10 +12,11 @@
 		690FF0262AE7C5BA00A0B06B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 690FF0252AE7C5BA00A0B06B /* Assets.xcassets */; };
 		690FF0292AE7C5BA00A0B06B /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 690FF0282AE7C5BA00A0B06B /* Preview Assets.xcassets */; };
 		690FF0362AE7C61300A0B06B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690FF0352AE7C61300A0B06B /* AppDelegate.swift */; };
-		C8454434344E03D10F62E3D1 /* Pods_PostHogExampleWithPods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F797B3856C0D3A6C42F1903F /* Pods_PostHogExampleWithPods.framework */; };
+		C9E5B5DE324D8151CE82217D /* Pods_PostHogExampleWithPods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43AF6FA31CF44E5BE9245799 /* Pods_PostHogExampleWithPods.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		43AF6FA31CF44E5BE9245799 /* Pods_PostHogExampleWithPods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PostHogExampleWithPods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C2D1D1AA0327AA47D050EED /* Pods-PostHogExampleWithPods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PostHogExampleWithPods.release.xcconfig"; path = "Target Support Files/Pods-PostHogExampleWithPods/Pods-PostHogExampleWithPods.release.xcconfig"; sourceTree = "<group>"; };
 		690FF01E2AE7C5B900A0B06B /* PostHogExampleWithPods.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PostHogExampleWithPods.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		690FF0212AE7C5B900A0B06B /* PostHogExampleWithPodsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogExampleWithPodsApp.swift; sourceTree = "<group>"; };
@@ -24,7 +25,6 @@
 		690FF0282AE7C5BA00A0B06B /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		690FF0352AE7C61300A0B06B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		9E7CD1F6231834F08BF61E6C /* Pods-PostHogExampleWithPods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PostHogExampleWithPods.debug.xcconfig"; path = "Target Support Files/Pods-PostHogExampleWithPods/Pods-PostHogExampleWithPods.debug.xcconfig"; sourceTree = "<group>"; };
-		F797B3856C0D3A6C42F1903F /* Pods_PostHogExampleWithPods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PostHogExampleWithPods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -32,7 +32,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C8454434344E03D10F62E3D1 /* Pods_PostHogExampleWithPods.framework in Frameworks */,
+				C9E5B5DE324D8151CE82217D /* Pods_PostHogExampleWithPods.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -89,7 +89,7 @@
 		9A20B85D4D10AA6F7B0C13FB /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				F797B3856C0D3A6C42F1903F /* Pods_PostHogExampleWithPods.framework */,
+				43AF6FA31CF44E5BE9245799 /* Pods_PostHogExampleWithPods.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -105,7 +105,7 @@
 				690FF01A2AE7C5B900A0B06B /* Sources */,
 				690FF01B2AE7C5B900A0B06B /* Frameworks */,
 				690FF01C2AE7C5B900A0B06B /* Resources */,
-				E4608544082294C46D768457 /* [CP] Embed Pods Frameworks */,
+				09BD9A3D139AADDAE022DD57 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -162,6 +162,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		09BD9A3D139AADDAE022DD57 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-PostHogExampleWithPods/Pods-PostHogExampleWithPods-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-PostHogExampleWithPods/Pods-PostHogExampleWithPods-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-PostHogExampleWithPods/Pods-PostHogExampleWithPods-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		ACA09137F648E598E95E500F /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -182,23 +199,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		E4608544082294C46D768457 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-PostHogExampleWithPods/Pods-PostHogExampleWithPods-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-PostHogExampleWithPods/Pods-PostHogExampleWithPods-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-PostHogExampleWithPods/Pods-PostHogExampleWithPods-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -873,7 +873,7 @@ class PostHogSDKTest: QuickSpec {
 
                     // first event is skipped by the first block
                     // second event is modified by the second block and not skipped by the third block(because it became "modified_event")
-                    // third event is modified by the third block
+                    // third event is modified by the second block
                     let expectedEvents = [
                         "modified_event",
                         "modified_event",


### PR DESCRIPTION
## :bulb: Motivation and Context
Required to filter events that the user doesn't want to send to the server.

## :green_heart: How did you test it?
Wrote a test + manual

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
