### PR TITLE
fix(surveys): handle unknown types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: surveys decoding error ([#361](https://github.com/PostHog/posthog-ios/pull/361))
+
 ## 3.28.0 - 2025-06-19
 
 - feat: add support for beforeSend function to edit or drop events ([#357](https://github.com/PostHog/posthog-ios/pull/357))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- fix: surveys decoding error ([#361](https://github.com/PostHog/posthog-ios/pull/361))
+- fix: surveys decoding error ([#363](https://github.com/PostHog/posthog-ios/pull/363))
 
 ## 3.28.0 - 2025-06-19
 

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -188,6 +188,9 @@
 		DA578EA02D6858CE00B3A56C /* MockScreenViewPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA578E9F2D6858C900B3A56C /* MockScreenViewPublisher.swift */; };
 		DA5AA7192CE245D2004EFB99 /* UIApplication+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5AA7132CE245CD004EFB99 /* UIApplication+.swift */; };
 		DA5B85882CD21CBB00686389 /* AutocaptureEventProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5B85872CD21CBB00686389 /* AutocaptureEventProcessing.swift */; };
+		DA5E52E22E09930600159D20 /* fixture_survey_unknown_type.json in Resources */ = {isa = PBXBuildFile; fileRef = DA5E52E12E09930600159D20 /* fixture_survey_unknown_type.json */; };
+		DA5E52E32E09930600159D20 /* fixture_survey_unknown_question_type.json in Resources */ = {isa = PBXBuildFile; fileRef = DA5E52E02E09930600159D20 /* fixture_survey_unknown_question_type.json */; };
+		DA5E52EB2E0996C400159D20 /* PostHogSurveyEnumsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5E52EA2E0996C400159D20 /* PostHogSurveyEnumsTest.swift */; };
 		DA690C6A2DA54BCC0045FF4E /* PostHogSurveyAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA690C692DA54BC70045FF4E /* PostHogSurveyAppearance.swift */; };
 		DA690C6C2DA54BD70045FF4E /* PostHogSurveyConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA690C6B2DA54BD10045FF4E /* PostHogSurveyConditions.swift */; };
 		DA690C6E2DA54BEC0045FF4E /* PostHogSurveyQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA690C6D2DA54BE40045FF4E /* PostHogSurveyQuestion.swift */; };
@@ -706,6 +709,9 @@
 		DA578E9F2D6858C900B3A56C /* MockScreenViewPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockScreenViewPublisher.swift; sourceTree = "<group>"; };
 		DA5AA7132CE245CD004EFB99 /* UIApplication+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+.swift"; sourceTree = "<group>"; };
 		DA5B85872CD21CBB00686389 /* AutocaptureEventProcessing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutocaptureEventProcessing.swift; sourceTree = "<group>"; };
+		DA5E52E02E09930600159D20 /* fixture_survey_unknown_question_type.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = fixture_survey_unknown_question_type.json; sourceTree = "<group>"; };
+		DA5E52E12E09930600159D20 /* fixture_survey_unknown_type.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = fixture_survey_unknown_type.json; sourceTree = "<group>"; };
+		DA5E52EA2E0996C400159D20 /* PostHogSurveyEnumsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSurveyEnumsTest.swift; sourceTree = "<group>"; };
 		DA690C692DA54BC70045FF4E /* PostHogSurveyAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSurveyAppearance.swift; sourceTree = "<group>"; };
 		DA690C6B2DA54BD10045FF4E /* PostHogSurveyConditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSurveyConditions.swift; sourceTree = "<group>"; };
 		DA690C6D2DA54BE40045FF4E /* PostHogSurveyQuestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSurveyQuestion.swift; sourceTree = "<group>"; };
@@ -1104,6 +1110,7 @@
 				DACF6D5C2CD2F5BC00F14133 /* PostHogAutocaptureIntegrationSpec.swift */,
 				DA703C1D2D66346E0069097B /* PostHogAppLifeCycleIntegrationTest.swift */,
 				DAA5ED962D4043A500D437E0 /* PostHogSurveysTest.swift */,
+				DA5E52EA2E0996C400159D20 /* PostHogSurveyEnumsTest.swift */,
 				DA979D7A2CD370B700F56BAE /* PostHogAutocaptureEventTrackerSpec.swift */,
 				699C5FEE2C20242A007DB818 /* UUIDTest.swift */,
 				DAF95F602D077C1C001E82BB /* PostHogWebPTest.swift */,
@@ -1577,6 +1584,8 @@
 				DAA5EE312D4368A900D437E0 /* fixture_survey_question_multiple_choice.json */,
 				DAA5EE322D4368A900D437E0 /* fixture_survey_question_rating.json */,
 				DAA5EE332D4368A900D437E0 /* fixture_survey_question_single_choice.json */,
+				DA5E52E02E09930600159D20 /* fixture_survey_unknown_question_type.json */,
+				DA5E52E12E09930600159D20 /* fixture_survey_unknown_type.json */,
 				DAA0222F2D78158600197660 /* fixture_survey_conditions_event_repeated.json */,
 				DAA022362D78162900197660 /* fixture_survey_conditions_event.json */,
 				DAA022382D78163F00197660 /* fixture_survey_conditions_device_type.json */,
@@ -1975,6 +1984,8 @@
 				DAA0223E2D7818D800197660 /* fixture_survey_conditions_url.json in Resources */,
 				DAA022452D78202100197660 /* fixture_survey_url_match_type_regex.json in Resources */,
 				DAA0223F2D7818D800197660 /* fixture_survey_conditions_event_repeated.json in Resources */,
+				DA5E52E22E09930600159D20 /* fixture_survey_unknown_type.json in Resources */,
+				DA5E52E32E09930600159D20 /* fixture_survey_unknown_question_type.json in Resources */,
 				DAA5EE372D4368A900D437E0 /* fixture_survey_question_rating.json in Resources */,
 				DAA5EE382D4368A900D437E0 /* fixture_survey_question_single_choice.json in Resources */,
 				DAA5EE2D2D43605000D437E0 /* fixture_survey_basic.json in Resources */,
@@ -2260,6 +2271,7 @@
 				DA703C0A2D6606EA0069097B /* PostHogIntegrationInstallationTest.swift in Sources */,
 				DA0F98A22D940E8C009AB6F5 /* ApplicationViewLayoutPublisherTest.swift in Sources */,
 				3A62647129CAF67B007E8C07 /* PostHogStorageManagerTest.swift in Sources */,
+				DA5E52EB2E0996C400159D20 /* PostHogSurveyEnumsTest.swift in Sources */,
 				693E977D2C6257F9004B1030 /* ExampleSanitizer.swift in Sources */,
 				1F5558262DFC4802007643C0 /* PostHogStorageMergeTest.swift in Sources */,
 				DA4FFB152DA93C78006BAEEA /* PostHogSessionReplayTest.swift in Sources */,

--- a/PostHog/Models/PostHogEvent.swift
+++ b/PostHog/Models/PostHogEvent.swift
@@ -86,8 +86,7 @@ import Foundation
 
 enum PostHogKnownUnsafeEditableEvent: String {
     case snapshot = "$snapshot"
-    case pageview = "$pageview"
-    case pageleave = "$pageleave"
+    case screen = "$screen"
     case set = "$set"
     case surveyDismissed = "survey dismissed"
     case surveySent = "survey sent"
@@ -95,9 +94,6 @@ enum PostHogKnownUnsafeEditableEvent: String {
     case identify = "$identify"
     case groupidentify = "$groupidentify"
     case createAlias = "$create_alias"
-    case clientIngestionWarning = "$$client_ingestion_warning"
-    case webExperimentApplied = "$web_experiment_applied"
-    case featureEnrollmentUpdate = "$feature_enrollment_update"
     case featureFlagCalled = "$feature_flag_called"
 
     static func contains(_ name: String) -> Bool {

--- a/PostHog/Models/Surveys/PostHogSurveyEnums.swift
+++ b/PostHog/Models/Surveys/PostHogSurveyEnums.swift
@@ -114,6 +114,12 @@ enum PostHogSurveyMatchType: Decodable, Equatable {
 }
 
 enum PostHogSurveyAppearancePosition: Decodable, Equatable {
+    case topLeft
+    case topCenter
+    case topRight
+    case middleLeft
+    case middleCenter
+    case middleRight
     case left
     case right
     case center
@@ -124,6 +130,18 @@ enum PostHogSurveyAppearancePosition: Decodable, Equatable {
         let positionString = try container.decode(String.self)
 
         switch positionString {
+        case "top_left":
+            self = .topLeft
+        case "top_center":
+            self = .topCenter
+        case "top_right":
+            self = .topRight
+        case "middle_left":
+            self = .middleLeft
+        case "middle_center":
+            self = .middleCenter
+        case "middle_right":
+            self = .middleRight
         case "left":
             self = .left
         case "right":

--- a/PostHog/Models/Surveys/PostHogSurveyEnums.swift
+++ b/PostHog/Models/Surveys/PostHogSurveyEnums.swift
@@ -9,55 +9,226 @@ import Foundation
 
 // MARK: - Supporting Types
 
-enum PostHogSurveyType: String, Decodable {
-    case popover, api, widget
+enum PostHogSurveyType: Decodable, Equatable {
+    case popover
+    case api
+    case widget
+    case unknown(type: String)
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let typeString = try container.decode(String.self)
+
+        switch typeString {
+        case "popover":
+            self = .popover
+        case "api":
+            self = .api
+        case "widget":
+            self = .widget
+        default:
+            self = .unknown(type: typeString)
+        }
+    }
 }
 
-enum PostHogSurveyQuestionType: String, Decodable {
+enum PostHogSurveyQuestionType: Decodable {
     case open
     case link
     case rating
-    case multipleChoice = "multiple_choice"
-    case singleChoice = "single_choice"
+    case multipleChoice
+    case singleChoice
+    case unknown(type: String)
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let typeString = try container.decode(String.self)
+
+        switch typeString {
+        case "open":
+            self = .open
+        case "link":
+            self = .link
+        case "rating":
+            self = .rating
+        case "multiple_choice":
+            self = .multipleChoice
+        case "single_choice":
+            self = .singleChoice
+        default:
+            self = .unknown(type: typeString)
+        }
+    }
 }
 
-enum PostHogSurveyTextContentType: String, Decodable {
-    case html, text
+enum PostHogSurveyTextContentType: Decodable, Equatable {
+    case html
+    case text
+    case unknown(type: String)
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let typeString = try container.decode(String.self)
+
+        switch typeString {
+        case "html":
+            self = .html
+        case "text":
+            self = .text
+        default:
+            self = .unknown(type: typeString)
+        }
+    }
 }
 
-enum PostHogSurveyMatchType: String, Decodable {
+enum PostHogSurveyMatchType: Decodable, Equatable {
     case regex
-    case notRegex = "not_regex"
+    case notRegex
     case exact
-    case isNot = "is_not"
-    case iContains = "icontains"
-    case notIContains = "not_icontains"
+    case isNot
+    case iContains
+    case notIContains
+    case unknown(value: String)
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let valueString = try container.decode(String.self)
+
+        switch valueString {
+        case "regex":
+            self = .regex
+        case "not_regex":
+            self = .notRegex
+        case "exact":
+            self = .exact
+        case "is_not":
+            self = .isNot
+        case "icontains":
+            self = .iContains
+        case "not_icontains":
+            self = .notIContains
+        default:
+            self = .unknown(value: valueString)
+        }
+    }
 }
 
-enum PostHogSurveyAppearancePosition: String, Decodable {
-    case left, right, center
+enum PostHogSurveyAppearancePosition: Decodable, Equatable {
+    case left
+    case right
+    case center
+    case unknown(position: String)
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let positionString = try container.decode(String.self)
+
+        switch positionString {
+        case "left":
+            self = .left
+        case "right":
+            self = .right
+        case "center":
+            self = .center
+        default:
+            self = .unknown(position: positionString)
+        }
+    }
 }
 
-enum PostHogSurveyAppearanceWidgetType: String, Decodable {
-    case button, tab, selector
+enum PostHogSurveyAppearanceWidgetType: Decodable {
+    case button
+    case tab
+    case selector
+    case unknown(type: String)
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let typeString = try container.decode(String.self)
+
+        switch typeString {
+        case "button":
+            self = .button
+        case "tab":
+            self = .tab
+        case "selector":
+            self = .selector
+        default:
+            self = .unknown(type: typeString)
+        }
+    }
 }
 
-enum PostHogSurveyRatingDisplayType: String, Decodable {
-    case number, emoji
+enum PostHogSurveyRatingDisplayType: Decodable, Equatable {
+    case number
+    case emoji
+    case unknown(type: String)
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let typeString = try container.decode(String.self)
+
+        switch typeString {
+        case "number":
+            self = .number
+        case "emoji":
+            self = .emoji
+        default:
+            self = .unknown(type: typeString)
+        }
+    }
 }
 
-enum PostHogSurveyRatingScale: Int, Decodable {
-    case threePoint = 3
-    case fivePoint = 5
-    case sevenPoint = 7
-    case tenPoint = 10
+enum PostHogSurveyRatingScale: Decodable, Equatable {
+    case threePoint
+    case fivePoint
+    case sevenPoint
+    case tenPoint
+    case unknown(scale: Int)
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let scaleInt = try container.decode(Int.self)
+
+        switch scaleInt {
+        case 3:
+            self = .threePoint
+        case 5:
+            self = .fivePoint
+        case 7:
+            self = .sevenPoint
+        case 10:
+            self = .tenPoint
+        default:
+            self = .unknown(scale: scaleInt)
+        }
+    }
 }
 
-enum PostHogSurveyQuestionBranchingType: String, Decodable {
-    case nextQuestion = "next_question"
+enum PostHogSurveyQuestionBranchingType: Decodable {
+    case nextQuestion
     case end
-    case responseBased = "response_based"
-    case specificQuestion = "specific_question"
+    case responseBased
+    case specificQuestion
+    case unknown(type: String)
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let typeString = try container.decode(String.self)
+
+        switch typeString {
+        case "next_question":
+            self = .nextQuestion
+        case "end":
+            self = .end
+        case "response_based":
+            self = .responseBased
+        case "specific_question":
+            self = .specificQuestion
+        default:
+            self = .unknown(type: typeString)
+        }
+    }
 }
 
 enum PostHogSurveyResponse {

--- a/PostHog/Models/Surveys/PostHogSurveyEnums.swift
+++ b/PostHog/Models/Surveys/PostHogSurveyEnums.swift
@@ -32,7 +32,7 @@ enum PostHogSurveyType: Decodable, Equatable {
     }
 }
 
-enum PostHogSurveyQuestionType: Decodable {
+enum PostHogSurveyQuestionType: Decodable, Equatable {
     case open
     case link
     case rating
@@ -136,7 +136,7 @@ enum PostHogSurveyAppearancePosition: Decodable, Equatable {
     }
 }
 
-enum PostHogSurveyAppearanceWidgetType: Decodable {
+enum PostHogSurveyAppearanceWidgetType: Decodable, Equatable {
     case button
     case tab
     case selector
@@ -205,7 +205,7 @@ enum PostHogSurveyRatingScale: Decodable, Equatable {
     }
 }
 
-enum PostHogSurveyQuestionBranchingType: Decodable {
+enum PostHogSurveyQuestionBranchingType: Decodable, Equatable {
     case nextQuestion
     case end
     case responseBased

--- a/PostHog/Models/Surveys/PostHogSurveyQuestion.swift
+++ b/PostHog/Models/Surveys/PostHogSurveyQuestion.swift
@@ -34,6 +34,7 @@ enum PostHogSurveyQuestion: PostHogSurveyQuestionProperties, Decodable {
     case rating(PostHogRatingSurveyQuestion)
     case singleChoice(PostHogMultipleSurveyQuestion)
     case multipleChoice(PostHogMultipleSurveyQuestion)
+    case unknown(type: String)
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -50,44 +51,47 @@ enum PostHogSurveyQuestion: PostHogSurveyQuestionProperties, Decodable {
             self = try .singleChoice(PostHogMultipleSurveyQuestion(from: decoder))
         case .multipleChoice:
             self = try .multipleChoice(PostHogMultipleSurveyQuestion(from: decoder))
+        case let .unknown(type):
+            self = .unknown(type: type)
         }
     }
 
     var question: String {
-        wrappedQuestion.question
+        wrappedQuestion?.question ?? ""
     }
 
     var description: String? {
-        wrappedQuestion.description
+        wrappedQuestion?.description
     }
 
     var descriptionContentType: PostHogSurveyTextContentType? {
-        wrappedQuestion.descriptionContentType
+        wrappedQuestion?.descriptionContentType
     }
 
     var optional: Bool? {
-        wrappedQuestion.optional
+        wrappedQuestion?.optional
     }
 
     var buttonText: String? {
-        wrappedQuestion.buttonText
+        wrappedQuestion?.buttonText
     }
 
     var originalQuestionIndex: Int? {
-        wrappedQuestion.originalQuestionIndex
+        wrappedQuestion?.originalQuestionIndex
     }
 
     var branching: PostHogSurveyQuestionBranching? {
-        wrappedQuestion.branching
+        wrappedQuestion?.branching
     }
 
-    private var wrappedQuestion: PostHogSurveyQuestionProperties {
+    private var wrappedQuestion: PostHogSurveyQuestionProperties? {
         switch self {
         case let .open(question): question
         case let .link(question): question
         case let .rating(question): question
         case let .singleChoice(question): question
         case let .multipleChoice(question): question
+        case .unknown: nil
         }
     }
 
@@ -160,6 +164,7 @@ enum PostHogSurveyQuestionBranching: Decodable {
     case end
     case responseBased(responseValues: [String: Any])
     case specificQuestion(index: Int)
+    case unknown(type: String)
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -192,6 +197,8 @@ enum PostHogSurveyQuestionBranching: Decodable {
             }
         case .specificQuestion:
             self = try .specificQuestion(index: container.decode(Int.self, forKey: .index))
+        case let .unknown(type):
+            self = .unknown(type: type)
         }
     }
 

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -556,6 +556,8 @@
                 targets.allSatisfy { target in
                     target != value
                 }
+            case .unknown:
+                false
             }
         }
     }

--- a/PostHog/Surveys/SurveyDisplayController.swift
+++ b/PostHog/Surveys/SurveyDisplayController.swift
@@ -112,7 +112,7 @@
                     responseValues: responseValues
                 ) ?? .index(nextQuestionIndex)
 
-            case .next:
+            case .next, .unknown:
                 return .index(nextQuestionIndex)
             }
         }

--- a/PostHog/Surveys/SurveySheet.swift
+++ b/PostHog/Surveys/SurveySheet.swift
@@ -60,6 +60,8 @@
                     MultipleChoiceQuestionView(question: multipleSurveyQuestion) { resp in
                         onNextQuestionClicked(currentQuestionIndex, .multipleChoice(resp))
                     }
+                default:
+                    EmptyView()
                 }
             }
         }

--- a/PostHogTests/PostHogSurveyEnumsTest.swift
+++ b/PostHogTests/PostHogSurveyEnumsTest.swift
@@ -1,0 +1,361 @@
+//
+//  PostHogSurveyEnumsTest.swift
+//  PostHog
+//
+//  Created by Yiannis Josephides on 23/06/2025.
+//
+
+import Foundation
+@testable import PostHog
+import Testing
+
+@Suite("Test Survey Enums")
+struct PostHogSurveyEnumsTest {
+    @Test("PostHogSurveyType handles unknown values")
+    func surveyTypeHandlesUnknownValues() throws {
+        // Known values
+        let knownTypes = ["popover", "api", "widget"]
+        for typeString in knownTypes {
+            let data = """
+            "\(typeString)"
+            """.data(using: .utf8)!
+
+            let decodedType = try PostHogApi.jsonDecoder.decode(PostHogSurveyType.self, from: data)
+
+            switch typeString {
+            case "popover":
+                #expect(decodedType == .popover)
+            case "api":
+                #expect(decodedType == .api)
+            case "widget":
+                #expect(decodedType == .widget)
+            default:
+                throw TestError("Unexpected type string: \(typeString)")
+            }
+        }
+
+        // Unknown value
+        let unknownTypeString = "future_survey_type"
+        let unknownData = """
+        "\(unknownTypeString)"
+        """.data(using: .utf8)!
+
+        let decodedUnknownType = try PostHogApi.jsonDecoder.decode(PostHogSurveyType.self, from: unknownData)
+
+        if case let .unknown(type) = decodedUnknownType {
+            #expect(type == unknownTypeString)
+        } else {
+            throw TestError("Expected unknown type")
+        }
+    }
+
+    @Test("PostHogSurveyQuestionType handles unknown values")
+    func surveyQuestionTypeHandlesUnknownValues() throws {
+        // Known values
+        let knownTypes = ["open", "link", "rating", "multiple_choice", "single_choice"]
+        for typeString in knownTypes {
+            let data = """
+            "\(typeString)"
+            """.data(using: .utf8)!
+
+            let decodedType = try PostHogApi.jsonDecoder.decode(PostHogSurveyQuestionType.self, from: data)
+
+            switch typeString {
+            case "open":
+                #expect(decodedType == .open)
+            case "link":
+                #expect(decodedType == .link)
+            case "rating":
+                #expect(decodedType == .rating)
+            case "multiple_choice":
+                #expect(decodedType == .multipleChoice)
+            case "single_choice":
+                #expect(decodedType == .singleChoice)
+            default:
+                throw TestError("Unexpected type string: \(typeString)")
+            }
+        }
+
+        // Unknown value
+        let unknownTypeString = "future_question_type"
+        let unknownData = """
+        "\(unknownTypeString)"
+        """.data(using: .utf8)!
+
+        let decodedUnknownType = try PostHogApi.jsonDecoder.decode(PostHogSurveyQuestionType.self, from: unknownData)
+
+        if case let .unknown(type) = decodedUnknownType {
+            #expect(type == unknownTypeString)
+        } else {
+            throw TestError("Expected unknown type")
+        }
+    }
+
+    @Test("PostHogSurveyTextContentType handles unknown values")
+    func surveyTextContentTypeHandlesUnknownValues() throws {
+        // Known values
+        let knownTypes = ["html", "text"]
+        for typeString in knownTypes {
+            let data = """
+            "\(typeString)"
+            """.data(using: .utf8)!
+
+            let decodedType = try PostHogApi.jsonDecoder.decode(PostHogSurveyTextContentType.self, from: data)
+
+            switch typeString {
+            case "html":
+                #expect(decodedType == .html)
+            case "text":
+                #expect(decodedType == .text)
+            default:
+                throw TestError("Unexpected type string: \(typeString)")
+            }
+        }
+
+        // Unknown value
+        let unknownTypeString = "markdown"
+        let unknownData = """
+        "\(unknownTypeString)"
+        """.data(using: .utf8)!
+
+        let decodedUnknownType = try PostHogApi.jsonDecoder.decode(PostHogSurveyTextContentType.self, from: unknownData)
+
+        if case let .unknown(type) = decodedUnknownType {
+            #expect(type == unknownTypeString)
+        } else {
+            throw TestError("Expected unknown type")
+        }
+    }
+
+    @Test("PostHogSurveyMatchType handles unknown values")
+    func surveyMatchTypeHandlesUnknownValues() throws {
+        // Known values
+        let knownTypes = ["regex", "not_regex", "exact", "is_not", "icontains", "not_icontains"]
+        for valueString in knownTypes {
+            let data = """
+            "\(valueString)"
+            """.data(using: .utf8)!
+
+            let decodedType = try PostHogApi.jsonDecoder.decode(PostHogSurveyMatchType.self, from: data)
+
+            switch valueString {
+            case "regex":
+                #expect(decodedType == .regex)
+            case "not_regex":
+                #expect(decodedType == .notRegex)
+            case "exact":
+                #expect(decodedType == .exact)
+            case "is_not":
+                #expect(decodedType == .isNot)
+            case "icontains":
+                #expect(decodedType == .iContains)
+            case "not_icontains":
+                #expect(decodedType == .notIContains)
+            default:
+                throw TestError("Unexpected value string: \(valueString)")
+            }
+        }
+
+        // Unknown value
+        let unknownValueString = "fuzzy_match"
+        let unknownData = """
+        "\(unknownValueString)"
+        """.data(using: .utf8)!
+
+        let decodedUnknownType = try PostHogApi.jsonDecoder.decode(PostHogSurveyMatchType.self, from: unknownData)
+
+        if case let .unknown(value) = decodedUnknownType {
+            #expect(value == unknownValueString)
+        } else {
+            throw TestError("Expected unknown match type")
+        }
+    }
+
+    @Test("PostHogSurveyAppearancePosition handles unknown values")
+    func surveyAppearancePositionHandlesUnknownValues() throws {
+        // Known values
+        let knownPositions = ["left", "right", "center"]
+        for positionString in knownPositions {
+            let data = """
+            "\(positionString)"
+            """.data(using: .utf8)!
+
+            let decodedPosition = try PostHogApi.jsonDecoder.decode(PostHogSurveyAppearancePosition.self, from: data)
+
+            switch positionString {
+            case "left":
+                #expect(decodedPosition == .left)
+            case "right":
+                #expect(decodedPosition == .right)
+            case "center":
+                #expect(decodedPosition == .center)
+            default:
+                throw TestError("Unexpected position string: \(positionString)")
+            }
+        }
+
+        // Unknown value
+        let unknownPositionString = "bottom"
+        let unknownData = """
+        "\(unknownPositionString)"
+        """.data(using: .utf8)!
+
+        let decodedUnknownPosition = try PostHogApi.jsonDecoder.decode(PostHogSurveyAppearancePosition.self, from: unknownData)
+
+        if case let .unknown(position) = decodedUnknownPosition {
+            #expect(position == unknownPositionString)
+        } else {
+            throw TestError("Expected unknown position")
+        }
+    }
+
+    @Test("PostHogSurveyAppearanceWidgetType handles unknown values")
+    func surveyAppearanceWidgetTypeHandlesUnknownValues() throws {
+        // Known values
+        let knownTypes = ["button", "tab", "selector"]
+        for typeString in knownTypes {
+            let data = """
+            "\(typeString)"
+            """.data(using: .utf8)!
+
+            let decodedType = try PostHogApi.jsonDecoder.decode(PostHogSurveyAppearanceWidgetType.self, from: data)
+
+            switch typeString {
+            case "button":
+                #expect(decodedType == .button)
+            case "tab":
+                #expect(decodedType == .tab)
+            case "selector":
+                #expect(decodedType == .selector)
+            default:
+                throw TestError("Unexpected type string: \(typeString)")
+            }
+        }
+
+        // Unknown value
+        let unknownTypeString = "dropdown"
+        let unknownData = """
+        "\(unknownTypeString)"
+        """.data(using: .utf8)!
+
+        let decodedUnknownType = try PostHogApi.jsonDecoder.decode(PostHogSurveyAppearanceWidgetType.self, from: unknownData)
+
+        if case let .unknown(type) = decodedUnknownType {
+            #expect(type == unknownTypeString)
+        } else {
+            throw TestError("Expected unknown widget type")
+        }
+    }
+
+    @Test("PostHogSurveyRatingDisplayType handles unknown values")
+    func surveyRatingDisplayTypeHandlesUnknownValues() throws {
+        // Known values
+        let knownTypes = ["number", "emoji"]
+        for typeString in knownTypes {
+            let data = """
+            "\(typeString)"
+            """.data(using: .utf8)!
+
+            let decodedType = try PostHogApi.jsonDecoder.decode(PostHogSurveyRatingDisplayType.self, from: data)
+
+            switch typeString {
+            case "number":
+                #expect(decodedType == .number)
+            case "emoji":
+                #expect(decodedType == .emoji)
+            default:
+                throw TestError("Unexpected type string: \(typeString)")
+            }
+        }
+
+        // Unknown value
+        let unknownTypeString = "stars"
+        let unknownData = """
+        "\(unknownTypeString)"
+        """.data(using: .utf8)!
+
+        let decodedUnknownType = try PostHogApi.jsonDecoder.decode(PostHogSurveyRatingDisplayType.self, from: unknownData)
+
+        if case let .unknown(type) = decodedUnknownType {
+            #expect(type == unknownTypeString)
+        } else {
+            throw TestError("Expected unknown rating display type")
+        }
+    }
+
+    @Test("PostHogSurveyRatingScale handles unknown values")
+    func surveyRatingScaleHandlesUnknownValues() throws {
+        // Known values
+        let knownScales = [3, 5, 7, 10]
+        for scale in knownScales {
+            let data = "\(scale)".data(using: .utf8)!
+
+            let decodedScale = try PostHogApi.jsonDecoder.decode(PostHogSurveyRatingScale.self, from: data)
+
+            switch scale {
+            case 3:
+                #expect(decodedScale == .threePoint)
+            case 5:
+                #expect(decodedScale == .fivePoint)
+            case 7:
+                #expect(decodedScale == .sevenPoint)
+            case 10:
+                #expect(decodedScale == .tenPoint)
+            default:
+                throw TestError("Unexpected scale: \(scale)")
+            }
+        }
+
+        // Unknown value
+        let unknownScale = 4
+        let unknownData = "\(unknownScale)".data(using: .utf8)!
+
+        let decodedUnknownScale = try PostHogApi.jsonDecoder.decode(PostHogSurveyRatingScale.self, from: unknownData)
+
+        if case let .unknown(scale) = decodedUnknownScale {
+            #expect(scale == unknownScale)
+        } else {
+            throw TestError("Expected unknown scale")
+        }
+    }
+
+    @Test("PostHogSurveyQuestionBranchingType handles unknown values")
+    func surveyQuestionBranchingTypeHandlesUnknownValues() throws {
+        // Known values
+        let knownTypes = ["next_question", "end", "response_based", "specific_question"]
+        for typeString in knownTypes {
+            let data = """
+            "\(typeString)"
+            """.data(using: .utf8)!
+
+            let decodedType = try PostHogApi.jsonDecoder.decode(PostHogSurveyQuestionBranchingType.self, from: data)
+
+            switch typeString {
+            case "next_question":
+                #expect(decodedType == .nextQuestion)
+            case "end":
+                #expect(decodedType == .end)
+            case "response_based":
+                #expect(decodedType == .responseBased)
+            case "specific_question":
+                #expect(decodedType == .specificQuestion)
+            default:
+                throw TestError("Unexpected type string: \(typeString)")
+            }
+        }
+
+        // Unknown value
+        let unknownTypeString = "conditional_jump"
+        let unknownData = """
+        "\(unknownTypeString)"
+        """.data(using: .utf8)!
+
+        let decodedUnknownType = try PostHogApi.jsonDecoder.decode(PostHogSurveyQuestionBranchingType.self, from: unknownData)
+
+        if case let .unknown(type) = decodedUnknownType {
+            #expect(type == unknownTypeString)
+        } else {
+            throw TestError("Expected unknown branching type")
+        }
+    }
+}

--- a/PostHogTests/PostHogSurveysTest.swift
+++ b/PostHogTests/PostHogSurveysTest.swift
@@ -58,6 +58,49 @@ enum PostHogSurveysTest {
             #expect(sut.currentIterationStartDate.map(ISO8601DateFormatter().string) == "2024-12-12T18:58:22Z")
         }
 
+        @Test("survey with unknown type decodes correctly")
+        func surveyWithUnknownTypeDecodesCorrectly() throws {
+            let data = try loadFixture("fixture_survey_unknown_type")
+            let sut = try PostHogApi.jsonDecoder.decode(PostHogSurvey.self, from: data)
+
+            #expect(sut.id == "01947134-8a35-0000-549a-193b86fa2e44")
+            #expect(sut.name == "Core Web Vitals feature request")
+
+            // Verify that an unknown survey type is correctly captured
+            if case let .unknown(type) = sut.type {
+                #expect(type == "future_type_not_yet_supported")
+            } else {
+                throw TestError("Expected unknown survey type")
+            }
+
+            // Verify that other properties are still correctly decoded
+            #expect(sut.questions.count == 1)
+            #expect(sut.conditions?.url == "core-web-vitals")
+            #expect(sut.appearance?.position == .right)
+        }
+
+        @Test("survey with unknown question type decodes correctly")
+        func surveyWithUnknownQuestionTypeDecodesCorrectly() throws {
+            let data = try loadFixture("fixture_survey_unknown_question_type")
+            let sut = try PostHogApi.jsonDecoder.decode(PostHogSurvey.self, from: data)
+
+            #expect(sut.id == "01947134-8a35-0000-549a-193b86fa2e44")
+            #expect(sut.name == "Core Web Vitals feature request")
+            #expect(sut.type == .popover)
+            #expect(sut.questions.count == 1)
+
+            // Verify that an unknown question type is correctly captured
+            if case let .unknown(type) = sut.questions[0] {
+                #expect(type == "future_question_type")
+            } else {
+                throw TestError("Expected unknown question type")
+            }
+
+            // Verify that other properties are still correctly decoded
+            #expect(sut.conditions?.url == "core-web-vitals")
+            #expect(sut.appearance?.position == .right)
+        }
+
         @Suite("Survey question types decode correctly")
         struct SurveyQuestionTypeDecodeTests {
             @Test("basic question decodes correctly")

--- a/PostHogTests/Resources/fixture_survey_unknown_question_type.json
+++ b/PostHogTests/Resources/fixture_survey_unknown_question_type.json
@@ -1,0 +1,43 @@
+{
+    "id": "01947134-8a35-0000-549a-193b86fa2e44",
+    "name": "Core Web Vitals feature request",
+    "type": "popover",
+    "feature_flag_keys": [
+        { "key": "flag1", "value": "linked-flag-key" },
+        { "key": "flag2", "value": "survey-targeting-flag-key" }
+    ],
+    "targeting_flag_key": "survey-targeting-flag-key",
+    "linked_flag_key": "core-web-vitals",
+    "internal_targeting_flag_key": "survey-targeting-88af4df282-custom",
+    "questions": [
+        {
+            "type": "future_question_type",
+            "question": "What would you like to see in our Core Web Vitals product?",
+            "description": "Core Web Vitals just launched and we're interested in hearing (reading?) from you on what you think we're missing with this product",
+            "originalQuestionIndex": 0,
+            "descriptionContentType": "text"
+        }
+    ],
+    "conditions": {
+        "url": "core-web-vitals"
+    },
+    "appearance": {
+        "position": "right",
+        "fontFamily": "system-ui",
+        "whiteLabel": false,
+        "borderColor": "#c9c6c6",
+        "placeholder": "Start typing...",
+        "backgroundColor": "#eeeded",
+        "ratingButtonColor": "white",
+        "submitButtonColor": "black",
+        "submitButtonTextColor": "white",
+        "thankYouMessageHeader": "Thank you for your feedback!",
+        "displayThankYouMessage": true,
+        "ratingButtonActiveColor": "black",
+        "surveyPopupDelaySeconds": 5
+    },
+    "start_date": "2025-01-16T22:23:38.805000Z",
+    "end_date": null,
+    "current_iteration": 1,
+    "current_iteration_start_date": "2024-12-12T18:58:22Z"
+}

--- a/PostHogTests/Resources/fixture_survey_unknown_type.json
+++ b/PostHogTests/Resources/fixture_survey_unknown_type.json
@@ -1,0 +1,43 @@
+{
+    "id": "01947134-8a35-0000-549a-193b86fa2e44",
+    "name": "Core Web Vitals feature request",
+    "type": "future_type_not_yet_supported",
+    "feature_flag_keys": [
+        { "key": "flag1", "value": "linked-flag-key" },
+        { "key": "flag2", "value": "survey-targeting-flag-key" }
+    ],
+    "targeting_flag_key": "survey-targeting-flag-key",
+    "linked_flag_key": "core-web-vitals",
+    "internal_targeting_flag_key": "survey-targeting-88af4df282-custom",
+    "questions": [
+        {
+            "type": "open",
+            "question": "What would you like to see in our Core Web Vitals product?",
+            "description": "Core Web Vitals just launched and we're interested in hearing (reading?) from you on what you think we're missing with this product",
+            "originalQuestionIndex": 0,
+            "descriptionContentType": "text"
+        }
+    ],
+    "conditions": {
+        "url": "core-web-vitals"
+    },
+    "appearance": {
+        "position": "right",
+        "fontFamily": "system-ui",
+        "whiteLabel": false,
+        "borderColor": "#c9c6c6",
+        "placeholder": "Start typing...",
+        "backgroundColor": "#eeeded",
+        "ratingButtonColor": "white",
+        "submitButtonColor": "black",
+        "submitButtonTextColor": "white",
+        "thankYouMessageHeader": "Thank you for your feedback!",
+        "displayThankYouMessage": true,
+        "ratingButtonActiveColor": "black",
+        "surveyPopupDelaySeconds": 5
+    },
+    "start_date": "2025-01-16T22:23:38.805000Z",
+    "end_date": null,
+    "current_iteration": 1,
+    "current_iteration_start_date": "2024-12-12T18:58:22Z"
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

Some of the recent changes on survey object have broken surveys decoding on iOS. Most likely this PR [here](https://github.com/PostHog/posthog/pull/32292)? 

Decoding fails on `survey.appearance.position` with value `bottom-right`

Refactored the survey enum types to be a bit more resilient to future unknown values

## :green_heart: How did you test it?

- Added unit tests
- Tested locally

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
