### PR TITLE
fix(replay): avoid throttling and locking on main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: session replay perforamnce improvements ([#364](https://github.com/PostHog/posthog-ios/pull/364))
+
 ## 3.28.1 - 2025-06-23
 
 - fix: surveys decoding error ([#363](https://github.com/PostHog/posthog-ios/pull/363))

--- a/PostHog/PostHogSessionManager.swift
+++ b/PostHog/PostHogSessionManager.swift
@@ -31,6 +31,7 @@ import Foundation
         registerApplicationSendEvent()
     }
 
+    private let queue = DispatchQueue(label: "com.posthog.PostHogSessionManager", target: .global(qos: .utility))
     private var sessionId: String?
     private var sessionStartTimestamp: TimeInterval?
     private var sessionActivityTimestamp: TimeInterval?
@@ -240,7 +241,9 @@ import Foundation
             applicationEventToken = applicationEventPublisher.onApplicationEvent { [weak self] _, _ in
                 // update "last active" session
                 // we want to keep track of the idle time, so we need to maintain a timestamp on the last interactions of the user with the app. UIEvents are a good place to do so since it means that the user is actively interacting with the app (e.g not just noise background activity)
-                self?.touchSession()
+                self?.queue.async {
+                    self?.touchSession()
+                }
             }
         #endif
     }

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -240,11 +240,6 @@
                 return
             }
 
-            // always make sure we have a fresh session id as early as possible
-            guard let sessionId = PostHogSessionManager.shared.getSessionId(at: date) else {
-                return
-            }
-
             // capture necessary touch information on the main thread before performing any asynchronous operations
             // - this ensures that UITouch associated objects like UIView, UIWindow, or [UIGestureRecognizer] are still valid.
             // - these objects may be released or erased by the system if accessed asynchronously, resulting in invalid/zeroed-out touch coordinates
@@ -253,6 +248,11 @@
             }
 
             PostHogReplayIntegration.dispatchQueue.async { [touchInfo, weak postHog = postHog] in
+                // always make sure we have a fresh session id as early as possible
+                guard let sessionId = PostHogSessionManager.shared.getSessionId(at: date) else {
+                    return
+                }
+
                 // captured weakly since integration may have uninstalled by now
                 guard let postHog else { return }
 
@@ -312,11 +312,6 @@
                 windowViews.object(forKey: window) ?? ViewTreeSnapshotStatus()
             }
 
-            // always make sure we have a fresh session id at correct timestamp
-            guard let sessionId = PostHogSessionManager.shared.getSessionId(at: timestampDate) else {
-                return
-            }
-
             var snapshotsData: [Any] = []
 
             if !snapshotStatus.sentMetaEvent {
@@ -345,6 +340,11 @@
             // TODO: IncrementalSnapshot, type=2
 
             PostHogReplayIntegration.dispatchQueue.async {
+                // always make sure we have a fresh session id at correct timestamp
+                guard let sessionId = PostHogSessionManager.shared.getSessionId(at: timestampDate) else {
+                    return
+                }
+
                 var wireframes: [Any] = []
                 wireframes.append(wireframe.toDict())
                 let initialOffset = ["top": 0, "left": 0]


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Helps with https://github.com/PostHog/posthog-ios/issues/321

Avoid main thread when touching session on user interactions on `PostHogSessionManager` on throttling from `ViewLayoutPublishing`

Profiling these changes on device I see the following, so I think this will help. 

### Before
![CleanShot 2025-06-25 at 13 03 10@2x](https://github.com/user-attachments/assets/64e8023e-08b5-4c5b-933b-8ac59ffc24c2)

### After
![CleanShot 2025-06-25 at 13 03 27@2x](https://github.com/user-attachments/assets/8e79cc90-0450-4d38-83d7-59242428c441)




## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
