### PR TITLE
fix: map thank you message description content type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: map missing content type for Surveys ([#377](https://github.com/PostHog/posthog-ios/pull/377))
+
 ## 3.30.0 - 2025-07-28
 
 - feat: add person and group properties for feature flags ([#373](https://github.com/PostHog/posthog-ios/pull/373))

--- a/PostHog/Models/Surveys/PostHogSurvey+Display.swift
+++ b/PostHog/Models/Surveys/PostHogSurvey+Display.swift
@@ -110,6 +110,7 @@
                 displayThankYouMessage: displayThankYouMessage ?? true,
                 thankYouMessageHeader: thankYouMessageHeader,
                 thankYouMessageDescription: thankYouMessageDescription,
+                thankYouMessageDescriptionContentType: thankYouMessageDescriptionContentType?.toDisplayContentType(),
                 thankYouMessageCloseButtonText: thankYouMessageCloseButtonText
             )
         }

--- a/PostHog/Surveys/Models/PostHogDisplaySurveyAppearance.swift
+++ b/PostHog/Surveys/Models/PostHogDisplaySurveyAppearance.swift
@@ -52,21 +52,21 @@ import Foundation
     public let thankYouMessageCloseButtonText: String?
 
     init(
-        fontFamily: String? = nil,
-        backgroundColor: String? = nil,
-        borderColor: String? = nil,
-        submitButtonColor: String? = nil,
-        submitButtonText: String? = nil,
-        submitButtonTextColor: String? = nil,
-        descriptionTextColor: String? = nil,
-        ratingButtonColor: String? = nil,
-        ratingButtonActiveColor: String? = nil,
-        placeholder: String? = nil,
-        displayThankYouMessage: Bool = true,
-        thankYouMessageHeader: String? = nil,
-        thankYouMessageDescription: String? = nil,
-        thankYouMessageDescriptionContentType: PostHogDisplaySurveyTextContentType? = nil,
-        thankYouMessageCloseButtonText: String? = nil
+        fontFamily: String?,
+        backgroundColor: String?,
+        borderColor: String?,
+        submitButtonColor: String?,
+        submitButtonText: String?,
+        submitButtonTextColor: String?,
+        descriptionTextColor: String?,
+        ratingButtonColor: String?,
+        ratingButtonActiveColor: String?,
+        placeholder: String?,
+        displayThankYouMessage: Bool,
+        thankYouMessageHeader: String?,
+        thankYouMessageDescription: String?,
+        thankYouMessageDescriptionContentType: PostHogDisplaySurveyTextContentType?,
+        thankYouMessageCloseButtonText: String?
     ) {
         self.fontFamily = fontFamily
         self.backgroundColor = backgroundColor


### PR DESCRIPTION
## :bulb: Motivation and Context

When looking into https://github.com/PostHog/posthog-flutter/issues/194 I realised we were not mapping `thankYouMessageDescriptionContentType` to appearance display model

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
