### PR TITLE
feat: add ability to toggle feature_flag_called event sending

### DIFF
--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -1190,6 +1190,16 @@ let maxRetryDelay = 30.0
         return value
     }
 
+    @objc public func setSendFeatureFlagEvent(_ enabled: Bool) {
+        guard isEnabled() else {
+            return
+        }
+
+        setupLock.withLock {
+            config.sendFeatureFlagEvent = enabled
+        }
+    }
+
     @objc public func isFeatureEnabled(_ key: String) -> Bool {
         let result = getFeatureFlag(key)
         return result is String ? true : (result as? Bool) ?? false


### PR DESCRIPTION
## :bulb: Motivation and Context
Provide the ability to disable and reenable automatically sent feature_flag_called event

We want to automatically report feature_flag_called event, but we need to disable this function when we read flags for sticky implementation according [to this guide](https://posthog.com/tutorials/sticky-feature-flags) to send and use this event as exposure event exactly when needed.


## :green_heart: How did you test it?
Existing unit tests. manual testing in own app


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
