### PR TITLE
fix: prefer identity from main app target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 - fix: avoid memory leaks on foat conversions ([#401](https://github.com/PostHog/posthog-ios/pull/401))
+- fix: app group migration now skips identity-related keys from extensions ([#402](https://github.com/PostHog/posthog-ios/pull/402))
 
 ## 3.35.0 - 2025-11-07
 


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

ticket https://posthoghelp.zendesk.com/agent/tickets/43210 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/46179)

Fixes app group migration to ensure identity from main app has priority. 
Before, when migrating extensions and main target to a shared container, identity was copied from the first container processed


## :green_heart: How did you test it?

Added a unit test
Verified in ticket above

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
