### PR TITLE
fix: macos device name no dns lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: macOS device name now uses hardware model instead of hostname to avoid blocking DNS lookups ([#422](https://github.com/PostHog/posthog-ios/pull/422))
+
 ## 3.37.0 - 2025-12-30
 
 - feat: add ability to override sendFeatureFlagEvent for exact feature flag call ([#396](https://github.com/PostHog/posthog-ios/pull/396))

--- a/PostHog/PostHogContext.swift
+++ b/PostHog/PostHogContext.swift
@@ -236,8 +236,9 @@ class PostHogContext {
             // Mac13,x is Mac Studio
             // Future models might follow similar patterns
             if model.hasPrefix("Mac14,2") || model.hasPrefix("Mac14,15") ||
-               model.hasPrefix("Mac15,3") || model.hasPrefix("Mac15,6") ||
-               model.hasPrefix("Mac15,7") {
+                model.hasPrefix("Mac15,3") || model.hasPrefix("Mac15,6") ||
+                model.hasPrefix("Mac15,7")
+            {
                 return "MacBook Air"
             } else if model.hasPrefix("Mac14") || model.hasPrefix("Mac15") {
                 // Default newer Mac models to MacBook Pro if not Air


### PR DESCRIPTION
## :bulb: Motivation and Context
Closes https://github.com/PostHog/posthog-ios/issues/421
lightweight version from https://github.com/devicekit/DeviceKit

## :green_heart: How did you test it?
run tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
