### PR TITLE
Switch to larger machines to speed up builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-14-xlarge
     steps:
       - uses: actions/checkout@v6
       - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: macos-14
+    runs-on: macos-14-xlarge
     permissions:
       security-events: write # for uploading CodeQL results
       packages: read


### PR DESCRIPTION
Our CodeQL instrumented builds take ~50+ minutes. Switch to Apple Silicon to speed this up.

_#skip-changelog_