### PR TITLE
feat(surveys): add support for schedule 'always' setting

### DIFF
--- a/PostHog/Models/Surveys/PostHogSurvey.swift
+++ b/PostHog/Models/Surveys/PostHogSurvey.swift
@@ -38,6 +38,22 @@ struct PostHogSurvey: Decodable, Identifiable {
     let startDate: Date?
     /// End date of the survey (optional)
     let endDate: Date?
+    /// Schedule type for the survey (e.g., "once", "recurring", "always")
+    let schedule: PostHogSurveySchedule?
+}
+
+/// Schedule type for the survey
+enum PostHogSurveySchedule: String, Decodable {
+    case once
+    case recurring
+    case always
+    case unknown
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        self = PostHogSurveySchedule(rawValue: rawValue) ?? .unknown
+    }
 }
 
 struct PostHogSurveyFeatureFlagKeyValue: Equatable, Decodable {

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -796,7 +796,8 @@
         }
 
         var canActivateRepeatedly: Bool {
-            conditions?.events?.repeatedActivation == true && hasEvents
+            (conditions?.events?.repeatedActivation == true && hasEvents) ||
+                schedule == .always
         }
     }
 

--- a/PostHogTests/PostHogSurveyEventsTest.swift
+++ b/PostHogTests/PostHogSurveyEventsTest.swift
@@ -83,7 +83,8 @@ class PostHogSurveyEventsTest {
             currentIteration: currentIteration,
             currentIterationStartDate: currentIterationStartDate,
             startDate: Date(),
-            endDate: nil
+            endDate: nil,
+            schedule: nil
         )
     }
 

--- a/PostHogTests/PostHogSurveysTest.swift
+++ b/PostHogTests/PostHogSurveysTest.swift
@@ -490,7 +490,11 @@ enum PostHogSurveysTest {
 
     @Suite("Test canActivateRepeatedly")
     struct TestCanActivateRepeatedly {
-        private func getSut(repeatedActivation: Bool?, values: [PostHogEventCondition]) -> PostHogSurvey {
+        private func getSut(
+            repeatedActivation: Bool?,
+            values: [PostHogEventCondition],
+            schedule: PostHogSurveySchedule? = nil
+        ) -> PostHogSurvey {
             PostHogSurvey(
                 id: "id",
                 name: "name",
@@ -517,7 +521,8 @@ enum PostHogSurveysTest {
                 currentIteration: nil,
                 currentIterationStartDate: nil,
                 startDate: nil,
-                endDate: nil
+                endDate: nil,
+                schedule: schedule
             )
         }
 
@@ -552,6 +557,50 @@ enum PostHogSurveysTest {
                     PostHogEventCondition(name: "first event"),
                     PostHogEventCondition(name: "second event"),
                 ]
+            )
+
+            #expect(sut.canActivateRepeatedly == false)
+        }
+
+        @Test("returns true when schedule is always")
+        func returnsTrueWhenScheduleIsAlways() {
+            let sut = getSut(
+                repeatedActivation: nil,
+                values: [],
+                schedule: .always
+            )
+
+            #expect(sut.canActivateRepeatedly == true)
+        }
+
+        @Test("returns true when schedule is always even without events")
+        func returnsTrueWhenScheduleIsAlwaysEvenWithoutEvents() {
+            let sut = getSut(
+                repeatedActivation: false,
+                values: [],
+                schedule: .always
+            )
+
+            #expect(sut.canActivateRepeatedly == true)
+        }
+
+        @Test("returns false when schedule is once")
+        func returnsFalseWhenScheduleIsOnce() {
+            let sut = getSut(
+                repeatedActivation: nil,
+                values: [],
+                schedule: .once
+            )
+
+            #expect(sut.canActivateRepeatedly == false)
+        }
+
+        @Test("returns false when schedule is recurring without events")
+        func returnsFalseWhenScheduleIsRecurringWithoutEvents() {
+            let sut = getSut(
+                repeatedActivation: nil,
+                values: [],
+                schedule: .recurring
             )
 
             #expect(sut.canActivateRepeatedly == false)
@@ -1407,7 +1456,8 @@ private extension PostHogSurvey {
         currentIteration: Int? = nil,
         currentIterationStartDate: Date? = nil,
         startDate: Date? = nil,
-        endDate: Date? = nil
+        endDate: Date? = nil,
+        schedule: PostHogSurveySchedule? = nil
     ) -> PostHogSurvey {
         PostHogSurvey(
             id: id,
@@ -1423,7 +1473,8 @@ private extension PostHogSurvey {
             currentIteration: currentIteration,
             currentIterationStartDate: currentIterationStartDate,
             startDate: startDate,
-            endDate: endDate
+            endDate: endDate,
+            schedule: schedule
         )
     }
 }


### PR DESCRIPTION
Add support for the 'schedule: always' survey setting which enables surveys to display every time conditions are met, regardless of prior exposure.

Changes:
- Add schedule property to PostHogSurvey model
- Add PostHogSurveySchedule enum with once/recurring/always/unknown cases
- Update canActivateRepeatedly to return true when schedule is 'always'
- Add tests for schedule-based repeated activation

Closes #446

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
