### PR TITLE
chore: add cocoapods keep alive workflow

### DIFF
--- a/.github/workflows/cocoapods-keepalive.yml
+++ b/.github/workflows/cocoapods-keepalive.yml
@@ -1,0 +1,26 @@
+name: 'CocoaPods Token Keep-Alive'
+
+on:
+  schedule:
+    # CocoaPods sessions currently expire after 3 days of inactivity (VALIDITY_LENGTH)
+    # This runs every day at midnight UTC to keep the current token alive
+    # See: https://github.com/CocoaPods/trunk.cocoapods.org/blob/a1869790e9ae2229b6985b6af4532da814202558/app/models/session.rb#L9
+    - cron: '0 0 * * *' # Runs every day at midnight UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  keepalive:
+    name: Refresh CocoaPods Session
+    runs-on: ubuntu-latest
+    env:
+      COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+
+    steps:
+      - name: Install CocoaPods
+        run: gem install cocoapods
+
+      - name: Refresh CocoaPods Session
+        run: pod trunk me


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

CocoaPods trunk sessions expire after 3 days of inactivity, which can cause our automated release workflow to fail if we don't publish a new version within that timeframe.

This adds a GH Actions workflow that runs daily to keep the session token alive by executing an authenticated call like `pod trunk me`

#skip-changelog

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
