### PR TITLE
fix: skip '## Next' section when creating GitHub release body

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,7 +212,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Read from the first until the second header in the changelog file
-          LAST_CHANGELOG_ENTRY=$(awk -v defText="see CHANGELOG.md" '/^## /{if (flag) exit; flag=1} flag && /^##$/{exit} flag; END{if (!flag) print defText}' CHANGELOG.md)
+          LAST_CHANGELOG_ENTRY=$(awk -v defText="see CHANGELOG.md" '/^## Next$/{next} /^## /{if (flag) exit; flag=1; next} flag; END{if (!flag) print defText}' CHANGELOG.md)
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
The release workflow's awk command was extracting content from the first `## ` header in CHANGELOG.md, which is `## Next` (empty). This caused GitHub releases to have no meaningful body.

The fix skips the `## Next` line and extracts content from the actual version header instead.

See https://github.com/PostHog/posthog-ios/releases/tag/3.41.2 for an example of the issue.