### PR TITLE
chore(surveys): add changeset for 'always' survey schedule

### DIFF
--- a/.changeset/little-carpets-sneeze.md
+++ b/.changeset/little-carpets-sneeze.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": minor
+---
+
+feat: support 'always' survey schedule


### PR DESCRIPTION
## 💡 Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

i just merged https://github.com/PostHog/posthog-ios/pull/491

but i think the release workflow changed recently and i didn't add a changeset to it :(

just pushing a changeset here to release!

## 💚 How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
