### PR TITLE
fix: replay orientation updates

### DIFF
--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -434,10 +434,12 @@
 
             var snapshotsData: [Any] = []
 
-            if !snapshotStatus.sentMetaEvent {
-                let size = window.bounds.size
-                let width = size.width.toInt() ?? 0
-                let height = size.height.toInt() ?? 0
+            let currentSize = window.bounds.size
+            let sizeChanged = snapshotStatus.sentMetaEvent && snapshotStatus.lastWindowSize != currentSize
+
+            if !snapshotStatus.sentMetaEvent || sizeChanged {
+                let width = currentSize.width.toInt() ?? 0
+                let height = currentSize.height.toInt() ?? 0
 
                 var data: [String: Any] = ["width": width, "height": height]
 
@@ -448,6 +450,7 @@
                 let snapshotData: [String: Any] = ["type": 4, "data": data, "timestamp": timestamp]
                 snapshotsData.append(snapshotData)
                 snapshotStatus.sentMetaEvent = true
+                snapshotStatus.lastWindowSize = currentSize
                 hasChanges = true
             }
 

--- a/PostHog/Replay/ViewTreeSnapshotStatus.swift
+++ b/PostHog/Replay/ViewTreeSnapshotStatus.swift
@@ -12,4 +12,5 @@ class ViewTreeSnapshotStatus {
     var sentMetaEvent: Bool = false
     var keyboardVisible: Bool = false
     var lastSnapshot: Bool = false
+    var lastWindowSize: CGSize = .zero
 }


### PR DESCRIPTION
## :bulb: Motivation and Context
https://posthoghelp.zendesk.com/agent/tickets/52488 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/54119) 
orientation is only captured once on mount

## :green_heart: How did you test it?
I didn't sorry vibe coded 😬 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
