### PR TITLE
feat(surveys): support survey wait period

### DIFF
--- a/.changeset/curly-plums-dream.md
+++ b/.changeset/curly-plums-dream.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": minor
+---
+
+support survey wait period

--- a/PostHog/PostHogStorage.swift
+++ b/PostHog/PostHogStorage.swift
@@ -243,6 +243,7 @@ class PostHogStorage {
         case personProcessingEnabled = "posthog.enabledPersonProcessing"
         case remoteConfig = "posthog.remoteConfig"
         case surveySeen = "posthog.surveySeen"
+        case lastSeenSurveyDate = "posthog.lastSeenSurveyDate"
         case requestId = "posthog.requestId"
         case evaluatedAt = "posthog.evaluatedAt"
         case personPropertiesForFlags = "posthog.personPropertiesForFlags"
@@ -403,6 +404,7 @@ class PostHogStorage {
         deleteSafely(url(forKey: .personProcessingEnabled))
         deleteSafely(url(forKey: .remoteConfig))
         deleteSafely(url(forKey: .surveySeen))
+        deleteSafely(url(forKey: .lastSeenSurveyDate))
         deleteSafely(url(forKey: .requestId))
         deleteSafely(url(forKey: .personPropertiesForFlags))
         deleteSafely(url(forKey: .groupPropertiesForFlags))

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -114,6 +114,9 @@
                         let deviceTypeCheck = self.doesSurveyDeviceTypesMatch(survey: survey)
                         return deviceTypeCheck
                     }
+                    .filter { survey in // 3.5. wait period has passed
+                        self.hasWaitPeriodPassed(survey: survey)
+                    }
                     .filter { survey in // 4. and match linked flags
                         let allKeys: [String?] = [
                             [survey.linkedFlagKey],
@@ -323,6 +326,7 @@
             }
 
             storage?.setDictionary(forKey: .surveySeen, contents: seenKeys ?? [:])
+            setLastSeenSurveyDate(Date())
         }
 
         /// Returns survey seen list (and mem-cache from disk if needed)
@@ -360,6 +364,29 @@
             let matchType = getMatchTypeOrDefault(conditions.deviceTypesMatchType)
 
             return matchType.matches(targets: deviceTypes, value: deviceType)
+        }
+
+        /// Checks if the wait period has passed since the last seen survey date
+        private func hasWaitPeriodPassed(survey: PostHogSurvey) -> Bool {
+            guard let waitPeriodInDays = survey.conditions?.seenSurveyWaitPeriodInDays else {
+                return true
+            }
+            guard let lastSeenDate = getLastSeenSurveyDate() else {
+                return true
+            }
+            let now = Date()
+            let diffSeconds = abs(now.timeIntervalSince(lastSeenDate))
+            let diffDays = Int(ceil(diffSeconds / secondsPerDay))
+            return diffDays > waitPeriodInDays
+        }
+
+        private func getLastSeenSurveyDate() -> Date? {
+            guard let dateString = storage?.getString(forKey: .lastSeenSurveyDate) else { return nil }
+            return toISO8601Date(dateString)
+        }
+
+        private func setLastSeenSurveyDate(_ date: Date) {
+            storage?.setString(forKey: .lastSeenSurveyDate, contents: toISO8601String(date))
         }
 
         /// Checks if a survey has been previously activated by an associated event

--- a/PostHog/Utils/DateUtils.swift
+++ b/PostHog/Utils/DateUtils.swift
@@ -40,4 +40,6 @@ public func toISO8601Date(_ date: String) -> Date? {
     apiDateFormatter.date(from: date)
 }
 
+let secondsPerDay: Double = 86400
+
 var now: () -> Date = { Date() }

--- a/PostHogTests/PostHogSurveysTest.swift
+++ b/PostHogTests/PostHogSurveysTest.swift
@@ -1006,6 +1006,157 @@ enum PostHogSurveysTest {
         }
     }
 
+    @Suite("Test survey wait period", .serialized)
+    class TestSurveyWaitPeriod {
+        let server: MockPostHogServer
+        let postHog: PostHogSDK
+        let storage: PostHogStorage
+
+        init() {
+            let config = PostHogConfig(apiKey: "test", host: "http://localhost:9090")
+            config._surveys = true
+            postHog = PostHogSDK.with(config)
+            storage = PostHogStorage(config)
+            storage.reset()
+            server = MockPostHogServer()
+            server.start()
+        }
+
+        deinit {
+            server.stop()
+            postHog.close()
+            postHog.reset()
+        }
+
+        let activeSurveyNoWaitPeriod =
+            """
+            {
+                "id": "no-wait-period",
+                "name": "Survey without wait period",
+                "type": "popover",
+                "questions": [
+                    {
+                        "id": "1",
+                        "type": "open",
+                        "question": "What do you think?",
+                        "originalQuestionIndex": 0
+                    }
+                ],
+                "start_date": "2024-07-23T09:18:18.376000Z"
+            }
+            """
+
+        let activeSurveyWithWaitPeriod =
+            """
+            {
+                "id": "with-wait-period",
+                "name": "Survey with wait period",
+                "type": "popover",
+                "questions": [
+                    {
+                        "id": "1",
+                        "type": "open",
+                        "question": "What do you think?",
+                        "originalQuestionIndex": 0
+                    }
+                ],
+                "conditions": {
+                    "seenSurveyWaitPeriodInDays": 7
+                },
+                "start_date": "2024-07-23T09:18:18.376000Z"
+            }
+            """
+
+        private func getSut(surveys: [String]) -> PostHogSurveyIntegration {
+            server.remoteConfigSurveys = "[\(surveys.joined(separator: ","))]"
+            let sut = PostHogSurveyIntegration()
+            PostHogSurveyIntegration.clearInstalls()
+            try! sut.install(postHog)
+            return sut
+        }
+
+        @Test("survey without wait period is not filtered")
+        func surveyWithoutWaitPeriodIsNotFiltered() async {
+            let sut = getSut(surveys: [activeSurveyNoWaitPeriod])
+
+            // Set last seen date to recently
+            storage.setString(forKey: .lastSeenSurveyDate, contents: toISO8601String(Date()))
+
+            let matchedSurveys: [PostHogSurvey] = await withCheckedContinuation { continuation in
+                sut.getActiveMatchingSurveys(forceReload: true) {
+                    continuation.resume(with: .success($0))
+                }
+            }
+
+            #expect(matchedSurveys.map(\.id) == ["no-wait-period"])
+        }
+
+        @Test("survey with wait period passes when no survey was previously seen")
+        func surveyWithWaitPeriodPassesWhenNoPreviouslySeen() async {
+            let sut = getSut(surveys: [activeSurveyWithWaitPeriod])
+
+            let matchedSurveys: [PostHogSurvey] = await withCheckedContinuation { continuation in
+                sut.getActiveMatchingSurveys(forceReload: true) {
+                    continuation.resume(with: .success($0))
+                }
+            }
+
+            #expect(matchedSurveys.map(\.id) == ["with-wait-period"])
+        }
+
+        @Test("survey with wait period is filtered when period has not elapsed")
+        func surveyWithWaitPeriodIsFilteredWhenNotElapsed() async {
+            let sut = getSut(surveys: [activeSurveyWithWaitPeriod])
+
+            // Set last seen date to 1 day ago (wait period is 7 days)
+            let oneDayAgo = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+            storage.setString(forKey: .lastSeenSurveyDate, contents: toISO8601String(oneDayAgo))
+
+            let matchedSurveys: [PostHogSurvey] = await withCheckedContinuation { continuation in
+                sut.getActiveMatchingSurveys(forceReload: true) {
+                    continuation.resume(with: .success($0))
+                }
+            }
+
+            #expect(matchedSurveys.isEmpty)
+        }
+
+        @Test("survey with wait period passes when period has elapsed")
+        func surveyWithWaitPeriodPassesWhenElapsed() async {
+            let sut = getSut(surveys: [activeSurveyWithWaitPeriod])
+
+            // Set last seen date to 10 days ago (wait period is 7 days)
+            let tenDaysAgo = Calendar.current.date(byAdding: .day, value: -10, to: Date())!
+            storage.setString(forKey: .lastSeenSurveyDate, contents: toISO8601String(tenDaysAgo))
+
+            let matchedSurveys: [PostHogSurvey] = await withCheckedContinuation { continuation in
+                sut.getActiveMatchingSurveys(forceReload: true) {
+                    continuation.resume(with: .success($0))
+                }
+            }
+
+            #expect(matchedSurveys.map(\.id) == ["with-wait-period"])
+        }
+
+        @Test("survey without wait period is not affected by last seen date")
+        func surveyWithoutWaitPeriodNotAffectedByLastSeenDate() async {
+            let sut = getSut(surveys: [activeSurveyNoWaitPeriod, activeSurveyWithWaitPeriod])
+
+            // Set last seen date to 1 day ago (wait period is 7 days)
+            let oneDayAgo = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+            storage.setString(forKey: .lastSeenSurveyDate, contents: toISO8601String(oneDayAgo))
+
+            let matchedSurveys: [PostHogSurvey] = await withCheckedContinuation { continuation in
+                sut.getActiveMatchingSurveys(forceReload: true) {
+                    continuation.resume(with: .success($0))
+                }
+            }
+
+            // Only the survey without wait period should pass
+            #expect(matchedSurveys.map(\.id) == ["no-wait-period"])
+        }
+    }
+
     @Suite("Test conditional branching", .serialized)
     class TestConfitionalBranchingLogic {
         @Test("returns next question index when no branching")


### PR DESCRIPTION
## 💡 Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

adds support for survey wait period on ios

why:

1. ios does not support survey wait period
2. we do now support survey schedule 'always'
3. given the ux of the new guided editor (which sets "Frequency" as a combination of schedule=always and wait period = N days), it's very easy for a customer to accidentally have surveys showing up repeatedly

closes https://github.com/PostHog/posthog-ios/issues/498

## 💚 How did you test it?

manual testing, unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
