### PR TITLE
chore: add Slack failure notification to version-bump job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.releaser.outputs.token }}
 
+      - name: Notify Slack - Failed
+        continue-on-error: true
+        if: ${{ failure() && needs.notify-approval-needed.outputs.slack_ts != '' }}
+        uses: PostHog/.github/.github/actions/slack-thread-reply@main
+        with:
+          slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
+          slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
+          thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
+          message: '❌ Failed to bump version for `posthog-ios@v${{ steps.apply-changesets.outputs.new-version }}`! <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>'
+          emoji_reaction: 'x'
+
   notify-rejected:
     name: Notify Slack - Rejected
     needs: [version-bump, notify-approval-needed]


### PR DESCRIPTION
## :bulb: Motivation and Context

When the `version-bump` job fails for a non-rejection reason (e.g. a script error), nobody gets notified on Slack. This happened in [this run](https://github.com/PostHog/posthog-ios/actions/runs/22760748062/job/66016502923?pr=500):

1. `version-bump` failed
2. `notify-rejected` ran but determined it wasn't a rejection → notification **skipped**
3. `publish` was **skipped** entirely (depends on `version-bump` success) → its "Notify Slack - Failed" step **never ran**

Result: silent failure with no Slack notification.

**Fix:** Add an inline "Notify Slack - Failed" step at the end of the `version-bump` job using `${{ failure() }}`, following the [posthog-js pattern](https://github.com/PostHog/posthog-js/blob/main/.github/workflows/release.yml#L336-L345).

## :green_heart: How did you test it?

YAML lint validation passed. Logic follows the proven pattern from posthog-js.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.