### PR TITLE
fix: prevent flaky tests by scoping OHHTTPStubs cleanup to per-server instance

### DIFF
--- a/PostHogTests/TestUtils/MockPostHogServer.swift
+++ b/PostHogTests/TestUtils/MockPostHogServer.swift
@@ -18,6 +18,7 @@ class MockPostHogServer {
     var batchExpectationCount: Int?
     var flagsExpectationCount: Int?
     var flagsRequests = [URLRequest]()
+    private var stubDescriptors = [HTTPStubsDescriptor]()
     var flagsResponseDelay: TimeInterval = 0
     var flagsResponseHandler: ((URLRequest) -> HTTPStubsResponse)?
     var version: Int = 3
@@ -62,7 +63,7 @@ class MockPostHogServer {
     init(version: Int = 3) {
         self.version = version
 
-        stub(condition: pathEndsWith("/flags")) { request in
+        stubDescriptors.append(stub(condition: pathEndsWith("/flags")) { request in
             if let handler = self.flagsResponseHandler {
                 let response = handler(request)
                 if self.flagsResponseDelay > 0 {
@@ -287,25 +288,25 @@ class MockPostHogServer {
                 response.responseTime = self.flagsResponseDelay
             }
             return response
-        }
+        })
 
-        stub(condition: pathEndsWith("/batch")) { _ in
+        stubDescriptors.append(stub(condition: pathEndsWith("/batch")) { _ in
             if self.return500 {
                 HTTPStubsResponse(jsonObject: [], statusCode: 500, headers: nil)
             } else {
                 HTTPStubsResponse(jsonObject: ["status": "ok"], statusCode: 200, headers: nil)
             }
-        }
+        })
 
-        stub(condition: pathEndsWith("/s")) { _ in
+        stubDescriptors.append(stub(condition: pathEndsWith("/s")) { _ in
             if self.return500 {
                 HTTPStubsResponse(jsonObject: [], statusCode: 500, headers: nil)
             } else {
                 HTTPStubsResponse(jsonObject: ["status": "ok"], statusCode: 200, headers: nil)
             }
-        }
+        })
 
-        stub(condition: pathEndsWith("/config")) { _ in
+        stubDescriptors.append(stub(condition: pathEndsWith("/config")) { _ in
             if self.return500 {
                 return HTTPStubsResponse(jsonObject: [], statusCode: 500, headers: nil)
             }
@@ -359,7 +360,7 @@ class MockPostHogServer {
                 """.data(using: .utf8)!
 
             return HTTPStubsResponse(data: configData, statusCode: 200, headers: nil)
-        }
+        })
 
         HTTPStubs.onStubActivation { request, _, _ in
             if request.url?.lastPathComponent == "batch" {
@@ -379,7 +380,10 @@ class MockPostHogServer {
     func stop() {
         reset()
 
-        HTTPStubs.removeAllStubs()
+        for descriptor in stubDescriptors {
+            HTTPStubs.removeStub(descriptor)
+        }
+        stubDescriptors.removeAll()
     }
 
     func reset(batchCount: Int = 1, flagsCount: Int? = nil) {


### PR DESCRIPTION
## :bulb: Motivation and Context

The `"Person properties are additive"` test in `PostHogFeatureFlagsTest` was flaking on CI ([example run](https://github.com/PostHog/posthog-ios/actions/runs/22894952544/job/66426581599?pr=511)) with `server.flagsRequests.count == 0` — no flag requests were recorded.

**Root cause:** `MockPostHogServer.stop()` called `HTTPStubs.removeAllStubs()`, which is a **global** operation removing ALL registered stubs across all server instances. With Swift Testing, each `@Test` creates a new class instance, and Swift ARC doesn't guarantee immediate deallocation. This means a previous test's `deinit` → `server.stop()` could fire **during** the next test, nuking its stubs. Without stubs, HTTP requests fall through to the real (non-existent) `localhost:9001`, fail silently, and `flagsRequests` stays empty.

## :green_heart: How did you test it?

- `make test` — all 365 tests pass
- `make format` / `make lint` — no issues
- Ran the test suite multiple times to verify reduced flakiness

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.