### PR TITLE
feat: add ObjC convenience overloads for captureException without properties param

### DIFF
--- a/.changeset/gentle-birds-swim.md
+++ b/.changeset/gentle-birds-swim.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': minor
+---
+
+Add ObjC convenience overloads for captureException methods without requiring properties parameter

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -1728,6 +1728,21 @@ let maxRetryDelay = 30.0
         capture("$exception", properties: mergedProperties)
     }
 
+    /// Capture a Swift Error or NSError without additional properties
+    ///
+    /// Convenience overload for Objective-C callers so `properties:` doesn't need to be passed as `nil`.
+    ///
+    /// - Parameter error: The error to capture (can be any Error or NSError)
+    ///
+    /// - Experimental: This is an experimental feature and may change in future releases.
+    @_spi(Experimental)
+    @objc(captureExceptionWithError:)
+    public func captureException(
+        _ error: Error
+    ) {
+        captureException(error, properties: nil)
+    }
+
     /// Capture an NSException
     ///
     /// Captures an NSException as a `$exception` event with full stack trace.
@@ -1765,6 +1780,21 @@ let maxRetryDelay = 30.0
         properties?.forEach { mergedProperties[$0.key] = $0.value }
 
         capture("$exception", properties: mergedProperties)
+    }
+
+    /// Capture an NSException without additional properties
+    ///
+    /// Convenience overload for Objective-C callers so `properties:` doesn't need to be passed as `nil`.
+    ///
+    /// - Parameter exception: The NSException to capture
+    ///
+    /// - Experimental: This is an experimental feature and may change in future releases.
+    @_spi(Experimental)
+    @objc(captureExceptionWithNSException:)
+    public func captureException(
+        _ exception: NSException
+    ) {
+        captureException(exception, properties: nil)
     }
 
     private func installIntegrations() {


### PR DESCRIPTION
## :bulb: Motivation and Context

Both `captureException` methods (`Error` and `NSException` variants) require ObjC callers to pass `properties:nil` even when they don't need additional properties. This adds convenience overloads so ObjC callers can simply use:

```objc
[[PostHog shared] captureExceptionWithError:error];
[[PostHog shared] captureExceptionWithNSException:exception];
```

instead of:

```objc
[[PostHog shared] captureExceptionWithError:error properties:nil];
[[PostHog shared] captureExceptionWithNSException:exception properties:nil];
```

## :green_heart: How did you test it?

- Built successfully for iOS Simulator via `xcodebuild`
- Verified no ObjC selector conflicts between the new and existing methods

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR