### PR TITLE
chore: parallelize CI workflows for faster build times

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -11,12 +11,63 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  build-platforms:
     runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: iOS
+            command: set -o pipefail && xcrun xcodebuild clean build -scheme PostHogExample -destination generic/platform=ios | xcpretty
+          - name: visionOS
+            command: set -o pipefail && xcrun xcodebuild clean build -scheme PostHogExampleVisionOS -destination generic/platform=xros | xcpretty
+          - name: ObjC
+            command: set -o pipefail && xcrun xcodebuild clean build -scheme PostHogObjCExample -destination generic/platform=ios | xcpretty
+          - name: macOS
+            command: set -o pipefail && xcrun xcodebuild clean build -scheme PostHogExampleMacOS -destination generic/platform=macos | xcpretty
+          - name: watchOS
+            command: set -o pipefail && xcrun xcodebuild clean build -scheme 'PostHogExampleWatchOS Watch App' -destination generic/platform=watchos | xcpretty
+          - name: tvOS
+            command: set -o pipefail && xcrun xcodebuild clean build -scheme PostHogExampleTvOS -destination generic/platform=tvos | xcpretty
+          - name: SPM
+            command: set -o pipefail && xcrun xcodebuild clean build -scheme PostHogExampleWithSPM -destination generic/platform=ios | xcpretty
+    name: Example (${{ matrix.name }})
     steps:
       - uses: actions/checkout@v6
       - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
           xcode-version: latest-stable
-      - name: Build Example
-        run: make buildExamples
+      - name: Build Example (${{ matrix.name }})
+        run: ${{ matrix.command }}
+
+  build-xcframework:
+    runs-on: macos-15
+    name: Example (XCFramework)
+    steps:
+      - uses: actions/checkout@v6
+      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        with:
+          xcode-version: latest-stable
+      - name: Build XCFramework Example
+        run: make buildExampleXCFramework
+
+  build-pods:
+    runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Static Lib
+            target: buildExamplePodsStaticLib
+          - name: Static Framework
+            target: buildExamplePodsStaticFramework
+          - name: Dynamic Framework
+            target: buildExamplePodsDynamicFramework
+    name: Example Pods (${{ matrix.name }})
+    steps:
+      - uses: actions/checkout@v6
+      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        with:
+          xcode-version: latest-stable
+      - name: Build Pods Example (${{ matrix.name }})
+        run: make ${{ matrix.target }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,27 @@ permissions:
 jobs:
   build:
     runs-on: macos-15-xlarge
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: ios
+            command: set -o pipefail && xcrun xcodebuild clean build -scheme PostHog -destination generic/platform=ios | xcpretty
+          - platform: macos-spm
+            command: set -o pipefail && xcrun swift build --arch arm64
+          - platform: macos
+            command: set -o pipefail && xcrun xcodebuild clean build -scheme PostHog -destination generic/platform=macos | xcpretty
+          - platform: tvos
+            command: set -o pipefail && xcrun xcodebuild clean build -scheme PostHog -destination generic/platform=tvos | xcpretty
+          - platform: watchos
+            command: set -o pipefail && xcrun xcodebuild clean build -scheme PostHog -destination generic/platform=watchos | xcpretty
+          - platform: visionos
+            command: set -o pipefail && xcrun xcodebuild clean build -scheme PostHog -destination generic/platform=xros | xcpretty
+    name: Build SDK (${{ matrix.platform }})
     steps:
       - uses: actions/checkout@v6
       - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
           xcode-version: latest-stable
-      - name: Build SDK
-        run: make buildSdk
+      - name: Build SDK (${{ matrix.platform }})
+        run: ${{ matrix.command }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,8 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Bootstrap
-        run: make bootstrap
+      - name: Install linting tools
+        run: |
+          brew install swiftlint swiftformat
 
       - name: Run lints
         run: make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,5 +18,14 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
           xcode-version: latest-stable
+      - name: Cache SPM dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            .build
+            ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.swift', 'Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
       - name: Test SDK
         run: make test


### PR DESCRIPTION
## :bulb: Motivation and Context

CI workflows for building the SDK, building examples, and linting run all steps sequentially, leading to long wall-clock times on PRs. This change parallelizes them using GitHub Actions matrix strategies.

### Changes:

- **build.yml**: Split 6 sequential platform builds (iOS, macOS SPM, macOS xcodebuild, tvOS, watchOS, visionOS) into parallel matrix jobs
- **build-examples.yml**: Split ~10 sequential example builds into 3 parallel job groups:
  - 7 platform examples via matrix
  - XCFramework example as a separate job  
  - 3 CocoaPods variants via matrix
- **lint.yml**: Replaced `make bootstrap` (installs CocoaPods, xcpretty, Periphery, etc.) with only installing SwiftLint + SwiftFormat — the only tools needed for linting
- **test.yml**: Added SPM dependency caching to skip re-downloading on cache hits

### Expected impact:
- **build.yml**: ~5-6x faster (parallel platforms vs sequential)
- **build-examples.yml**: ~7-10x faster (parallel examples vs sequential)
- **lint.yml**: ~1-2 min saved (fewer unnecessary installs)
- **test.yml**: Faster dependency resolution on cache hits

> Note: Total billable minutes stay roughly the same — same compute, just parallelized for faster wall-clock time.

## :green_heart: How did you test it?

CI will validate on this PR.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the `release` label to the PR