### PR TITLE
feat(surveys): support event property filters

### DIFF
--- a/.changeset/thick-squids-punch.md
+++ b/.changeset/thick-squids-punch.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": minor
+---
+
+support survey event property filters

--- a/PostHog/Models/Surveys/PostHogSurveyConditions.swift
+++ b/PostHog/Models/Surveys/PostHogSurveyConditions.swift
@@ -40,8 +40,23 @@ struct PostHogSurveyActionsConditions: Decodable {
     let values: [PostHogEventCondition]
 }
 
+/// Represents a single property filter for event condition matching
+struct PostHogPropertyFilter: Decodable, Equatable {
+    /// The values to compare against
+    let values: [String]
+    /// The comparison operator
+    let matchOperator: PostHogSurveyMatchType
+
+    enum CodingKeys: String, CodingKey {
+        case values
+        case matchOperator = "operator"
+    }
+}
+
 /// Represents a single event condition used in survey targeting
 struct PostHogEventCondition: Decodable, Equatable {
     /// Name of the event (e.g., "content loaded")
     let name: String
+    /// Property filters that must match for this event condition (optional)
+    var propertyFilters: [String: PostHogPropertyFilter]? = nil
 }

--- a/PostHog/Models/Surveys/PostHogSurveyEnums.swift
+++ b/PostHog/Models/Surveys/PostHogSurveyEnums.swift
@@ -88,6 +88,8 @@ enum PostHogSurveyMatchType: Decodable, Equatable {
     case isNot
     case iContains
     case notIContains
+    case gt
+    case lt
     case unknown(value: String)
 
     init(from decoder: any Decoder) throws {
@@ -107,6 +109,10 @@ enum PostHogSurveyMatchType: Decodable, Equatable {
             self = .iContains
         case "not_icontains":
             self = .notIContains
+        case "gt":
+            self = .gt
+        case "lt":
+            self = .lt
         default:
             self = .unknown(value: valueString)
         }

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -882,7 +882,7 @@ let maxRetryDelay = 30.0
         }
 
         #if os(iOS)
-            surveysIntegration?.onEvent(event: posthogEvent.event)
+            surveysIntegration?.onEvent(event: posthogEvent.event, properties: posthogEvent.properties)
         #endif
     }
 

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -32,7 +32,7 @@
         private var allSurveys: [PostHogSurvey]?
 
         private var eventsToSurveysLock = NSLock()
-        private var eventsToSurveys: [String: [String]] = [:]
+        private var eventsToSurveys: [String: [(surveyId: String, condition: PostHogEventCondition)]] = [:]
 
         private var seenSurveyKeysLock = NSLock()
         private var seenSurveyKeys: [AnyHashable: Any]?
@@ -145,12 +145,18 @@
 
         // TODO: Decouple PostHogSDK and use registration handlers instead
         /// Called from PostHogSDK instance when an event is captured
-        func onEvent(event: String) {
-            let activatedSurveys = eventsToSurveysLock.withLock { eventsToSurveys[event] } ?? []
-            guard !activatedSurveys.isEmpty else { return }
+        func onEvent(event: String, properties: [String: Any]) {
+            let candidates = eventsToSurveysLock.withLock { eventsToSurveys[event] } ?? []
+            guard !candidates.isEmpty else { return }
+
+            let matchingSurveyIds = candidates
+                .filter { matchPropertyFilters($0.condition.propertyFilters, eventProperties: properties) }
+                .map(\.surveyId)
+
+            guard !matchingSurveyIds.isEmpty else { return }
 
             eventActivatedSurveysLock.withLock {
-                for survey in activatedSurveys {
+                for survey in matchingSurveyIds {
                     eventActivatedSurveys.insert(survey)
                 }
             }
@@ -214,10 +220,12 @@
         private func decodeAndSetSurveys(remoteConfig: [String: Any]?, callback: @escaping SurveyCallback) {
             let loadedSurveys: [PostHogSurvey] = decodeSurveys(from: remoteConfig ?? [:])
 
-            let eventMap = loadedSurveys.reduce(into: [String: [String]]()) { result, current in
-                if let surveyEvents = current.conditions?.events?.values.map(\.name) {
-                    for event in surveyEvents {
-                        result[event, default: []].append(current.id)
+            let eventMap = loadedSurveys.reduce(into: [String: [(surveyId: String, condition: PostHogEventCondition)]]()) { result, current in
+                if let surveyEvents = current.conditions?.events?.values {
+                    for eventCondition in surveyEvents {
+                        result[eventCondition.name, default: []].append(
+                            (surveyId: current.id, condition: eventCondition)
+                        )
                     }
                 }
             }
@@ -387,6 +395,24 @@
 
         private func setLastSeenSurveyDate(_ date: Date) {
             storage?.setString(forKey: .lastSeenSurveyDate, contents: toISO8601String(date))
+        }
+
+        /// Checks if the given event properties satisfy all property filters.
+        /// Returns true if propertyFilters is nil or empty (no filters = match all).
+        private func matchPropertyFilters(
+            _ propertyFilters: [String: PostHogPropertyFilter]?,
+            eventProperties: [String: Any]
+        ) -> Bool {
+            guard let propertyFilters, !propertyFilters.isEmpty else {
+                return true
+            }
+            return propertyFilters.allSatisfy { propertyName, filter in
+                guard let eventValue = eventProperties[propertyName] else {
+                    return false
+                }
+                let eventValueString = String(describing: eventValue)
+                return filter.matchOperator.matches(targets: filter.values, value: eventValueString)
+            }
         }
 
         /// Checks if a survey has been previously activated by an associated event
@@ -831,25 +857,25 @@
     private extension PostHogSurveyMatchType {
         func matches(targets: [String], value: String) -> Bool {
             switch self {
-            // any of the targets contain the value (matched lowercase)
+            // value contains any of the targets (case-insensitive)
             case .iContains:
                 targets.contains { target in
-                    target.lowercased().contains(value.lowercased())
+                    value.lowercased().contains(target.lowercased())
                 }
-            // *none* of the targets contain the value (matched lowercase)
+            // value contains *none* of the targets (case-insensitive)
             case .notIContains:
                 targets.allSatisfy { target in
-                    !target.lowercased().contains(value.lowercased())
+                    !value.lowercased().contains(target.lowercased())
                 }
-            // any of the targets match with regex
+            // value matches any of the targets as a regex pattern
             case .regex:
                 targets.contains { target in
-                    target.range(of: value, options: .regularExpression) != nil
+                    value.range(of: target, options: .regularExpression) != nil
                 }
-            // *none* if the targets match with regex
+            // value matches *none* of the targets as a regex pattern
             case .notRegex:
                 targets.allSatisfy { target in
-                    target.range(of: value, options: .regularExpression) == nil
+                    value.range(of: target, options: .regularExpression) == nil
                 }
             // any of the targets is an exact match
             case .exact:
@@ -860,6 +886,22 @@
             case .isNot:
                 targets.allSatisfy { target in
                     target != value
+                }
+            // any of the targets is numerically less than the value (value > target)
+            case .gt:
+                targets.contains { target in
+                    if let targetNum = Double(target), let valueNum = Double(value) {
+                        return valueNum > targetNum
+                    }
+                    return false
+                }
+            // any of the targets is numerically greater than the value (value < target)
+            case .lt:
+                targets.contains { target in
+                    if let targetNum = Double(target), let valueNum = Double(value) {
+                        return valueNum < targetNum
+                    }
+                    return false
                 }
             case .unknown:
                 false
@@ -953,6 +995,25 @@
 
             func testGetResponseKey(questionId: String) -> String {
                 getNewResponseKey(for: questionId)
+            }
+
+            func testMatchPropertyFilters(
+                _ propertyFilters: [String: PostHogPropertyFilter]?,
+                eventProperties: [String: Any]
+            ) -> Bool {
+                matchPropertyFilters(propertyFilters, eventProperties: eventProperties)
+            }
+
+            func testSetEventsToSurveys(_ map: [String: [(surveyId: String, condition: PostHogEventCondition)]]) {
+                eventsToSurveysLock.withLock {
+                    eventsToSurveys = map
+                }
+            }
+
+            func testIsEventActivated(surveyId: String) -> Bool {
+                eventActivatedSurveysLock.withLock {
+                    eventActivatedSurveys.contains(surveyId)
+                }
             }
 
             static func clearInstalls() {

--- a/PostHogTests/PostHogSurveysTest.swift
+++ b/PostHogTests/PostHogSurveysTest.swift
@@ -298,6 +298,26 @@ enum PostHogSurveysTest {
                 }
             }
 
+            @Test("event condition with property filters decodes correctly")
+            func eventConditionWithPropertyFiltersDecodesCorrectly() async throws {
+                let data = try loadFixture("fixture_survey_conditions_event_property_filters")
+                let sut = try PostHogApi.jsonDecoder.decode(PostHogSurvey.self, from: data)
+
+                if let events = sut.conditions?.events {
+                    #expect(events.values.count == 1)
+                    #expect(events.values[0].name == "purchase_completed")
+
+                    let filters = events.values[0].propertyFilters
+                    #expect(filters != nil)
+                    #expect(filters?["amount"]?.matchOperator == .gt)
+                    #expect(filters?["amount"]?.values == ["100"])
+                    #expect(filters?["category"]?.matchOperator == .exact)
+                    #expect(filters?["category"]?.values == ["electronics"])
+                } else {
+                    throw TestError("Expected event display condition with property filters")
+                }
+            }
+
             @Test("device type condition decodes correctly")
             func deviceTypeConditionDecodesCorrectly() async throws {
                 let data = try loadFixture("fixture_survey_conditions_device_type")
@@ -428,7 +448,7 @@ enum PostHogSurveysTest {
             let sut: PostHogSurveyMatchType = .regex
             let matches = sut.matchFunction
 
-            #expect(matches([url], regex) == shouldMatch)
+            #expect(matches([regex], url) == shouldMatch)
         }
 
         @Test("matches not_regex correctly", arguments: regexMap)
@@ -436,7 +456,7 @@ enum PostHogSurveysTest {
             let sut: PostHogSurveyMatchType = .notRegex
             let matches = sut.matchFunction
 
-            #expect(matches([url], regex) != shouldMatch)
+            #expect(matches([regex], url) != shouldMatch)
         }
 
         @Test("matches icontains correctly")
@@ -447,7 +467,7 @@ enum PostHogSurveysTest {
             #expect(matches(["Hello"], "hello") == true)
             #expect(matches(["Hello"], "HeLLo") == true)
             #expect(matches(["Hello"], "heLLo") == true)
-            #expect(matches(["Hello", "PostHogTest"], "PostHog") == true)
+            #expect(matches(["PostHog"], "PostHogTest") == true)
             #expect(matches(["Hello"], "PostHog") == false)
         }
 
@@ -459,7 +479,7 @@ enum PostHogSurveysTest {
             #expect(matches(["Hello"], "hello") == false)
             #expect(matches(["Hello"], "HeLLo") == false)
             #expect(matches(["Hello"], "heLLo") == false)
-            #expect(matches(["Hello", "PostHogTest"], "PostHog") == false)
+            #expect(matches(["PostHog"], "PostHogTest") == false)
             #expect(matches(["Hello"], "PostHog") == true)
         }
 
@@ -485,6 +505,127 @@ enum PostHogSurveysTest {
             #expect(matches(["Hello"], "heLLo") == true)
             #expect(matches(["Hello"], "Hello") == false)
             #expect(matches(["Hello", "PostHog"], "Hello") == false)
+        }
+
+        @Test("matches gt and lt correctly")
+        func matchesGtLt() {
+            #expect(PostHogSurveyMatchType.gt.matchFunction(["100"], "150") == true)
+            #expect(PostHogSurveyMatchType.gt.matchFunction(["100"], "50") == false)
+            #expect(PostHogSurveyMatchType.lt.matchFunction(["100"], "50") == true)
+            #expect(PostHogSurveyMatchType.lt.matchFunction(["100"], "150") == false)
+            #expect(PostHogSurveyMatchType.gt.matchFunction(["100"], "not_a_number") == false)
+        }
+    }
+
+    @Suite("Test matchPropertyFilters")
+    class TestMatchPropertyFilters {
+        let server: MockPostHogServer
+        let integration: PostHogSurveyIntegration
+        let postHog: PostHogSDK
+
+        init() throws {
+            server = MockPostHogServer()
+            server.start()
+
+            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9090")
+            config._surveys = true
+            config.flushAt = 1
+            config.disableReachabilityForTesting = true
+            config.disableQueueTimerForTesting = true
+            config.captureApplicationLifecycleEvents = false
+
+            let storage = PostHogStorage(config)
+            storage.reset()
+
+            postHog = PostHogSDK.with(config)
+
+            PostHogSurveyIntegration.clearInstalls()
+            integration = PostHogSurveyIntegration()
+            try integration.install(postHog)
+        }
+
+        deinit {
+            server.stop()
+            postHog.close()
+            postHog.reset()
+        }
+
+        @Test("returns true when no filters, false when property is missing")
+        func edgeCases() {
+            #expect(integration.testMatchPropertyFilters(nil, eventProperties: [:]) == true)
+            let filters = ["category": PostHogPropertyFilter(values: ["electronics"], matchOperator: .exact)]
+            #expect(integration.testMatchPropertyFilters(filters, eventProperties: [:]) == false)
+        }
+
+        @Test("icontains matches value against filter (case-insensitive)")
+        func icontainsOperatorWorks() {
+            let filters = ["query": PostHogPropertyFilter(values: ["product"], matchOperator: .iContains)]
+            #expect(integration.testMatchPropertyFilters(filters, eventProperties: ["query": "new PRODUCT features"]) == true)
+            #expect(integration.testMatchPropertyFilters(filters, eventProperties: ["query": "nothing here"]) == false)
+        }
+    }
+
+    @Suite("Test onEvent with property filters")
+    struct TestOnEventPropertyFilters {
+        let server: MockPostHogServer
+        let integration: PostHogSurveyIntegration
+        let postHog: PostHogSDK
+
+        init() throws {
+            server = MockPostHogServer()
+            server.start()
+
+            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9090")
+            config._surveys = true
+            config.flushAt = 1
+            config.disableReachabilityForTesting = true
+            config.disableQueueTimerForTesting = true
+            config.captureApplicationLifecycleEvents = false
+
+            let storage = PostHogStorage(config)
+            storage.reset()
+
+            postHog = PostHogSDK.with(config)
+
+            PostHogSurveyIntegration.clearInstalls()
+            integration = PostHogSurveyIntegration()
+            try integration.install(postHog)
+        }
+
+        @Test("activates survey when event name and properties match")
+        func eventWithPropertiesActivatesSurvey() {
+            let condition = PostHogEventCondition(
+                name: "purchase",
+                propertyFilters: ["amount": PostHogPropertyFilter(values: ["100"], matchOperator: .gt)]
+            )
+            integration.testSetEventsToSurveys(["purchase": [(surveyId: "survey-1", condition: condition)]])
+
+            integration.onEvent(event: "purchase", properties: ["amount": 150])
+            #expect(integration.testIsEventActivated(surveyId: "survey-1") == true)
+        }
+
+        @Test("activates survey when event has no property filters (backward compat)")
+        func eventWithNoFiltersActivatesSurvey() {
+            let condition = PostHogEventCondition(name: "purchase")
+            integration.testSetEventsToSurveys(["purchase": [(surveyId: "survey-1", condition: condition)]])
+
+            integration.onEvent(event: "purchase", properties: [:])
+            #expect(integration.testIsEventActivated(surveyId: "survey-1") == true)
+        }
+
+        @Test("does not activate survey when one of multiple property filters fails")
+        func partialFilterMismatchPreventsActivation() {
+            let condition = PostHogEventCondition(
+                name: "purchase",
+                propertyFilters: [
+                    "amount": PostHogPropertyFilter(values: ["100"], matchOperator: .gt),
+                    "category": PostHogPropertyFilter(values: ["electronics"], matchOperator: .exact),
+                ]
+            )
+            integration.testSetEventsToSurveys(["purchase": [(surveyId: "survey-1", condition: condition)]])
+
+            integration.onEvent(event: "purchase", properties: ["amount": 150, "category": "clothing"])
+            #expect(integration.testIsEventActivated(surveyId: "survey-1") == false)
         }
     }
 

--- a/PostHogTests/Resources/fixture_survey_conditions_event_property_filters.json
+++ b/PostHogTests/Resources/fixture_survey_conditions_event_property_filters.json
@@ -1,0 +1,34 @@
+{
+  "id": "prop-filter-survey",
+  "name": "Property filtered survey",
+  "description": "",
+  "type": "api",
+  "linked_flag_key": null,
+  "targeting_flag_key": null,
+  "questions": [
+    {
+      "id": "400",
+      "type": "open",
+      "question": "How was your purchase?",
+      "description": "",
+      "descriptionContentType": "text",
+      "originalQuestionIndex": 0
+    }
+  ],
+  "conditions": {
+    "url": "",
+    "events": {
+      "values": [
+        {
+          "name": "purchase_completed",
+          "propertyFilters": {
+            "amount": { "values": ["100"], "operator": "gt" },
+            "category": { "values": ["electronics"], "operator": "exact" }
+          }
+        }
+      ]
+    }
+  },
+  "start_date": null,
+  "end_date": null
+}


### PR DESCRIPTION
## 💡 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

ios surveys do not support event property filters

- adds support for event property filters
- reworks the match function a little to match the js sdk

closes https://github.com/PostHog/posthog-ios/issues/449

## 💚 How did you test it?

manual testing + new unit tests

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->