### PR TITLE
feat: add macOS support for session replay (screenshot mode only)

### DIFF
--- a/.changeset/brave-clouds-dance.md
+++ b/.changeset/brave-clouds-dance.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": minor
+---
+
+feat: add macOS support for session replay (screenshot mode only)

--- a/PostHog/ApplicationViewLayoutPublisher.swift
+++ b/PostHog/ApplicationViewLayoutPublisher.swift
@@ -68,4 +68,67 @@
             ApplicationViewLayoutPublisher.shared.layoutSubviews()
         }
     }
+
+#elseif os(macOS)
+    import AppKit
+
+    protocol ViewLayoutPublishing: AnyObject {
+        /// Callback for getting notified when an NSView is laid out.
+        /// Note: callback guaranteed to be called on main thread
+        var onViewLayout: PostHogThrottledMulticastCallback<Void> { get }
+    }
+
+    final class ApplicationViewLayoutPublisher: ViewLayoutPublishing {
+        static let shared = ApplicationViewLayoutPublisher()
+
+        private(set) lazy var onViewLayout = PostHogThrottledMulticastCallback<Void> { [weak self] subscriberCount in
+            if subscriberCount > 0 {
+                self?.swizzleLayout()
+            } else {
+                self?.unswizzleLayout()
+            }
+        }
+
+        private var hasSwizzled: Bool = false
+
+        private func swizzleLayout() {
+            guard !hasSwizzled else { return }
+            hasSwizzled = true
+
+            swizzle(
+                forClass: NSView.self,
+                original: #selector(NSView.layout),
+                new: #selector(NSView.ph_swizzled_layout)
+            )
+        }
+
+        private func unswizzleLayout() {
+            guard hasSwizzled else { return }
+            hasSwizzled = false
+
+            swizzle(
+                forClass: NSView.self,
+                original: #selector(NSView.layout),
+                new: #selector(NSView.ph_swizzled_layout)
+            )
+        }
+
+        fileprivate func viewDidLayout() {
+            onViewLayout.invoke(())
+        }
+
+        #if TESTING
+            func simulateLayoutSubviews() {
+                viewDidLayout()
+            }
+        #endif
+    }
+
+    extension NSView {
+        @objc func ph_swizzled_layout() {
+            ph_swizzled_layout() // call original
+            ApplicationViewLayoutPublisher.shared.viewDidLayout()
+        }
+    }
+
 #endif

--- a/PostHog/DI.swift
+++ b/PostHog/DI.swift
@@ -15,13 +15,13 @@ enum DI {
         // publishes global screen view events (UIViewController.viewDidAppear)
         lazy var screenViewPublisher: ScreenViewPublishing = ApplicationScreenViewPublisher.shared
 
-        #if os(iOS) || os(tvOS)
-            // publishes global application events (UIApplication.sendEvent)
+        #if os(iOS) || os(tvOS) || os(macOS)
+            // publishes global application events (UIApplication.sendEvent on iOS/tvOS, NSEvent monitor on macOS)
             lazy var applicationEventPublisher: ApplicationEventPublishing = ApplicationEventPublisher.shared
         #endif
 
-        #if os(iOS)
-            // publishes global view layout events within a throttle interval (UIView.layoutSubviews)
+        #if os(iOS) || os(macOS)
+            // publishes global view layout events within a throttle interval (UIView.layoutSubviews on iOS, NSView.layout on macOS)
             lazy var viewLayoutPublisher: ViewLayoutPublishing = ApplicationViewLayoutPublisher.shared
         #endif
     }

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -158,11 +158,13 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
     /// or EU Host: 'https://eu.i.posthog.com'
     public static let defaultHost: String = "https://us.i.posthog.com"
 
-    #if os(iOS)
-        /// Enable Recording of Session Replays for iOS
+    #if os(iOS) || os(macOS)
+        /// Enable Recording of Session Replays for iOS and macOS
         ///
         /// Note: Ingestion controls (sampling, feature flags, and event triggers) are currently applied using AND logic.
         /// All configured conditions must be satisfied for recording to start.
+        ///
+        /// Note: On macOS, only screenshot mode is supported. Wireframe mode is not available.
         ///
         /// Default: false
         @objc public var sessionReplay: Bool = false
@@ -248,15 +250,16 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
             integrations.append(PostHogAppLifeCycleIntegration())
         }
 
-        #if os(iOS)
+        #if os(iOS) || os(macOS)
             if sessionReplay {
                 integrations.append(PostHogReplayIntegration())
             }
+        #endif
 
+        #if os(iOS)
             if _surveys {
                 integrations.append(PostHogSurveyIntegration())
             }
-
         #endif
 
         #if os(iOS) || targetEnvironment(macCatalyst)

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -167,7 +167,7 @@ class PostHogRemoteConfig {
                 }
 
                 // process session replay config
-                #if os(iOS)
+                #if os(iOS) || os(macOS)
                     let featureFlags = self.featureFlagsLock.withLock { self.featureFlags }
                     self.processSessionRecordingConfig(config, featureFlags: featureFlags ?? [:])
                 #endif
@@ -230,7 +230,7 @@ class PostHogRemoteConfig {
 
             sessionReplayLock.withLock {
                 sessionReplayFlagActive = isRecordingActive(featureFlags ?? [:], sessionReplay)
-                #if os(iOS)
+                #if os(iOS) || os(macOS)
                     recordingSampleRate = parseSampleRate(sessionReplay["sampleRate"])
                 #endif
             }
@@ -356,7 +356,7 @@ class PostHogRemoteConfig {
                     return callback(nil)
                 }
 
-                #if os(iOS)
+                #if os(iOS) || os(macOS)
                     // Use cached remote config for session recording settings since /flags no longer returns config data
                     let remoteConfig = self.remoteConfigLock.withLock { self.getCachedRemoteConfig() }
                     self.processSessionRecordingConfig(remoteConfig, featureFlags: featureFlags)
@@ -408,7 +408,7 @@ class PostHogRemoteConfig {
         }
     }
 
-    #if os(iOS)
+    #if os(iOS) || os(macOS)
         private func processSessionRecordingConfig(_ data: [String: Any]?, featureFlags: [String: Any]) {
             if let sessionRecording = data?["sessionRecording"] as? Bool {
                 sessionReplayLock.withLock {
@@ -825,7 +825,7 @@ class PostHogRemoteConfig {
         storage.remove(key: .sessionReplay)
     }
 
-    #if os(iOS)
+    #if os(iOS) || os(macOS)
         func isSessionReplayFlagActive() -> Bool {
             sessionReplayLock.withLock { sessionReplayFlagActive }
         }

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -54,8 +54,10 @@ let maxRetryDelay = 30.0
     private var sessionIdChangedToken: RegistrationToken?
     private var didEnterBackgroundToken: RegistrationToken?
 
-    #if os(iOS)
+    #if os(iOS) || os(macOS)
         private weak var replayIntegration: PostHogReplayIntegration?
+    #endif
+    #if os(iOS)
         private weak var surveysIntegration: PostHogSurveyIntegration?
     #endif
 
@@ -339,7 +341,7 @@ let maxRetryDelay = 30.0
             }
             // only Session replay requires $window_id, so we set as the same as $session_id.
             // the backend might fallback to $session_id if $window_id is not present next.
-            #if os(iOS)
+            #if os(iOS) || os(macOS)
                 if !appendSharedProps, isSessionReplayActive() {
                     props["$window_id"] = sessionId
                 }
@@ -1670,7 +1672,7 @@ let maxRetryDelay = 30.0
         }
     }
 
-    #if os(iOS)
+    #if os(iOS) || os(macOS)
         /**
          Starts session recording.
 
@@ -1765,7 +1767,7 @@ let maxRetryDelay = 30.0
         return postHog
     }
 
-    #if os(iOS)
+    #if os(iOS) || os(macOS)
         @objc public func isSessionReplayActive() -> Bool {
             if !isEnabled() {
                 return false
@@ -1917,12 +1919,14 @@ let maxRetryDelay = 30.0
                 try integration.install(self)
                 installed.append(integration)
 
-                #if os(iOS)
+                #if os(iOS) || os(macOS)
                     // TODO: Decouple these two integrations from PostHogSDK intance
                     if let replayIntegration = integration as? PostHogReplayIntegration {
                         self.replayIntegration = replayIntegration
                     }
+                #endif
 
+                #if os(iOS)
                     if let surveysIntegration = integration as? PostHogSurveyIntegration {
                         self.surveysIntegration = surveysIntegration
                     }
@@ -1937,7 +1941,7 @@ let maxRetryDelay = 30.0
         installedIntegrations = installed
     }
 
-    #if os(iOS)
+    #if os(iOS) || os(macOS)
         private func installReplayIntegration() {
             guard replayIntegration == nil else { return }
 
@@ -1961,8 +1965,10 @@ let maxRetryDelay = 30.0
         }
         installedIntegrations = []
 
-        #if os(iOS)
+        #if os(iOS) || os(macOS)
             replayIntegration = nil
+        #endif
+        #if os(iOS)
             surveysIntegration = nil
         #endif
     }
@@ -2010,7 +2016,7 @@ let maxRetryDelay = 30.0
             }
         #endif
 
-        #if os(iOS)
+        #if os(iOS) || os(macOS)
             func getReplayIntegration() -> PostHogReplayIntegration? {
                 installedIntegrations.compactMap {
                     $0 as? PostHogReplayIntegration

--- a/PostHog/Replay/ApplicationEventPublisher.swift
+++ b/PostHog/Replay/ApplicationEventPublisher.swift
@@ -65,4 +65,44 @@ import Foundation
             ApplicationEventPublisher.shared.sendEvent(event: event, date: Date())
         }
     }
+
+#elseif os(macOS)
+    import AppKit
+
+    protocol ApplicationEventPublishing: AnyObject {
+        /// Registers a callback for mouse events on macOS
+        var onApplicationEvent: PostHogMulticastCallback<ApplicationEventData> { get }
+    }
+
+    typealias ApplicationEventData = (NSEvent, Date)
+
+    final class ApplicationEventPublisher: ApplicationEventPublishing {
+        private(set) lazy var onApplicationEvent = PostHogMulticastCallback<ApplicationEventData> { [weak self] subscriberCount in
+            if subscriberCount > 0 {
+                self?.startMonitoring()
+            } else {
+                self?.stopMonitoring()
+            }
+        }
+
+        static let shared = ApplicationEventPublisher()
+
+        private var localMonitor: Any?
+
+        private func startMonitoring() {
+            guard localMonitor == nil else { return }
+            localMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .leftMouseUp, .rightMouseDown, .rightMouseUp]) { [weak self] event in
+                self?.onApplicationEvent.invoke((event, Date()))
+                return event
+            }
+        }
+
+        private func stopMonitoring() {
+            if let monitor = localMonitor {
+                NSEvent.removeMonitor(monitor)
+                localMonitor = nil
+            }
+        }
+    }
+
 #endif

--- a/PostHog/Replay/CGColor+Util.swift
+++ b/PostHog/Replay/CGColor+Util.swift
@@ -5,10 +5,14 @@
 //  Created by Manoel Aranda Neto on 21.03.24.
 //
 
-#if os(iOS)
+#if os(iOS) || os(macOS)
 
     import Foundation
-    import UIKit
+    #if os(iOS)
+        import UIKit
+    #elseif os(macOS)
+        import AppKit
+    #endif
 
     extension CGColor {
         func toRGBString() -> String? {

--- a/PostHog/Replay/CGSize+Util.swift
+++ b/PostHog/Replay/CGSize+Util.swift
@@ -5,7 +5,7 @@
 //  Created by Manoel Aranda Neto on 24.07.24.
 //
 
-#if os(iOS)
+#if os(iOS) || os(macOS)
     import Foundation
 
     extension CGSize {

--- a/PostHog/Replay/MethodSwizzler.swift
+++ b/PostHog/Replay/MethodSwizzler.swift
@@ -4,7 +4,7 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
-#if os(iOS)
+#if os(iOS) || os(macOS)
     import Foundation
 
     class MethodSwizzler<TypedIMP, TypedBlockIMP> {

--- a/PostHog/Replay/NetworkSample.swift
+++ b/PostHog/Replay/NetworkSample.swift
@@ -5,7 +5,7 @@
 //  Created by Manoel Aranda Neto on 26.03.24.
 //
 
-#if os(iOS)
+#if os(iOS) || os(macOS)
     import Foundation
 
     struct NetworkSample {

--- a/PostHog/Replay/Plugins/Console Logs/PostHogConsoleLogInterceptor.swift
+++ b/PostHog/Replay/Plugins/Console Logs/PostHogConsoleLogInterceptor.swift
@@ -5,7 +5,7 @@
 //  Created by Ioannis Josephides on 05/05/2025.
 //
 
-#if os(iOS)
+#if os(iOS) || os(macOS)
     import Foundation
 
     final class PostHogConsoleLogInterceptor {

--- a/PostHog/Replay/Plugins/Console Logs/PostHogLogEntry.swift
+++ b/PostHog/Replay/Plugins/Console Logs/PostHogLogEntry.swift
@@ -5,7 +5,7 @@
 //  Created by Ioannis Josephides on 09/05/2025.
 //
 
-#if os(iOS)
+#if os(iOS) || os(macOS)
     import Foundation
 
     /**

--- a/PostHog/Replay/Plugins/Console Logs/PostHogLogLevel.swift
+++ b/PostHog/Replay/Plugins/Console Logs/PostHogLogLevel.swift
@@ -5,7 +5,7 @@
 //  Created by Ioannis Josephides on 09/05/2025.
 //
 
-#if os(iOS)
+#if os(iOS) || os(macOS)
     import Foundation
 
     /// The severity level of a console log entry.

--- a/PostHog/Replay/Plugins/Console Logs/PostHogSessionReplayConsoleLogsPlugin.swift
+++ b/PostHog/Replay/Plugins/Console Logs/PostHogSessionReplayConsoleLogsPlugin.swift
@@ -5,7 +5,7 @@
 //  Created by Ioannis Josephides on 09/05/2025.
 //
 
-#if os(iOS)
+#if os(iOS) || os(macOS)
     import Foundation
 
     final class PostHogSessionReplayConsoleLogsPlugin: PostHogSessionReplayPlugin {

--- a/PostHog/Replay/Plugins/Network/PostHogSessionReplayNetworkPlugin.swift
+++ b/PostHog/Replay/Plugins/Network/PostHogSessionReplayNetworkPlugin.swift
@@ -5,7 +5,7 @@
 //  Created by Ioannis Josephides on 28/05/2025.
 //
 
-#if os(iOS)
+#if os(iOS) || os(macOS)
     import Foundation
 
     /// Session replay plugin that captures network requests using URLSession swizzling.

--- a/PostHog/Replay/Plugins/Network/URLSessionExtension.swift
+++ b/PostHog/Replay/Plugins/Network/URLSessionExtension.swift
@@ -1,4 +1,4 @@
-#if os(iOS)
+#if os(iOS) || os(macOS)
     import Foundation
 
     public extension URLSession {
@@ -105,7 +105,7 @@
             try await executeRequest(request: request, action: { try await upload(for: request, from: bodyData) }, postHog: postHog)
         }
 
-        @available(iOS 15.0, *)
+        @available(iOS 15.0, macOS 12.0, *)
         func postHogData(
             for request: URLRequest,
             delegate: (any URLSessionTaskDelegate)? = nil,
@@ -114,7 +114,7 @@
             try await executeRequest(request: request, action: { try await data(for: request, delegate: delegate) }, postHog: postHog)
         }
 
-        @available(iOS 15.0, *)
+        @available(iOS 15.0, macOS 12.0, *)
         func postHogData(
             from url: URL,
             delegate: (any URLSessionTaskDelegate)? = nil,
@@ -123,7 +123,7 @@
             try await executeRequest(action: { try await data(from: url, delegate: delegate) }, postHog: postHog)
         }
 
-        @available(iOS 15.0, *)
+        @available(iOS 15.0, macOS 12.0, *)
         func postHogUpload(
             for request: URLRequest,
             fromFile fileURL: URL,
@@ -133,7 +133,7 @@
             try await executeRequest(request: request, action: { try await upload(for: request, fromFile: fileURL, delegate: delegate) }, postHog: postHog)
         }
 
-        @available(iOS 15.0, *)
+        @available(iOS 15.0, macOS 12.0, *)
         func postHogUpload(
             for request: URLRequest,
             from bodyData: Data,
@@ -143,7 +143,7 @@
             try await executeRequest(request: request, action: { try await upload(for: request, from: bodyData, delegate: delegate) }, postHog: postHog)
         }
 
-        @available(iOS 15.0, *)
+        @available(iOS 15.0, macOS 12.0, *)
         func postHogDownload(
             for request: URLRequest,
             delegate: (any URLSessionTaskDelegate)? = nil,
@@ -152,7 +152,7 @@
             try await executeRequest(request: request, action: { try await download(for: request, delegate: delegate) }, postHog: postHog)
         }
 
-        @available(iOS 15.0, *)
+        @available(iOS 15.0, macOS 12.0, *)
         func postHogDownload(
             from url: URL,
             delegate: (any URLSessionTaskDelegate)? = nil,
@@ -161,7 +161,7 @@
             try await executeRequest(action: { try await download(from: url, delegate: delegate) }, postHog: postHog)
         }
 
-        @available(iOS 15.0, *)
+        @available(iOS 15.0, macOS 12.0, *)
         func postHogDownload(
             resumeFrom resumeData: Data,
             delegate: (any URLSessionTaskDelegate)? = nil,

--- a/PostHog/Replay/Plugins/Network/URLSessionInterceptor.swift
+++ b/PostHog/Replay/Plugins/Network/URLSessionInterceptor.swift
@@ -4,7 +4,7 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
-#if os(iOS)
+#if os(iOS) || os(macOS)
 
     import Foundation
 

--- a/PostHog/Replay/Plugins/Network/URLSessionSwizzler.swift
+++ b/PostHog/Replay/Plugins/Network/URLSessionSwizzler.swift
@@ -6,7 +6,7 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
-#if os(iOS)
+#if os(iOS) || os(macOS)
 
     import Foundation
 

--- a/PostHog/Replay/Plugins/PostHogSessionReplayPlugin.swift
+++ b/PostHog/Replay/Plugins/PostHogSessionReplayPlugin.swift
@@ -5,7 +5,7 @@
 //  Created by Ioannis Josephides on 12/05/2025.
 //
 
-#if os(iOS)
+#if os(iOS) || os(macOS)
     import Foundation
 
     /// Session replay plugins are used to capture specific types of meta data during a session,

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -6,11 +6,15 @@
 //
 //  Created by Manoel Aranda Neto on 19.03.24.
 //
-#if os(iOS)
+#if os(iOS) || os(macOS)
+    #if os(iOS)
+        import PhotosUI
+        import UIKit
+    #elseif os(macOS)
+        import AppKit
+    #endif
     import Foundation
-    import PhotosUI
     import SwiftUI
-    import UIKit
     import WebKit
 
     class PostHogReplayIntegration: PostHogIntegration {
@@ -28,7 +32,11 @@
         private var isEnabled: Bool = false
 
         private let windowViewsLock = NSLock()
-        private let windowViews = NSMapTable<UIWindow, ViewTreeSnapshotStatus>.weakToStrongObjects()
+        #if os(iOS)
+            private let windowViews = NSMapTable<UIWindow, ViewTreeSnapshotStatus>.weakToStrongObjects()
+        #elseif os(macOS)
+            private let windowViews = NSMapTable<NSWindow, ViewTreeSnapshotStatus>.weakToStrongObjects()
+        #endif
         private let installedPluginsLock = NSLock()
         private var applicationEventToken: RegistrationToken?
         private var applicationBackgroundedToken: RegistrationToken?
@@ -98,33 +106,35 @@
          - `TextEditor` is not affected by this change and still maps to `UITextView`
          */
 
-        /// `AsyncImage` and `Image`
-        private let swiftUIImageLayerTypes = [
-            "SwiftUI.ImageLayer",
-        ].compactMap(NSClassFromString)
+        #if os(iOS)
+            /// `AsyncImage` and `Image`
+            private let swiftUIImageLayerTypes = [
+                "SwiftUI.ImageLayer",
+            ].compactMap(NSClassFromString)
 
-        /// `Text`, `Button`, `TextEditor` views
-        private let swiftUITextBasedViewTypes = [
-            "_TtC7SwiftUIP33_863CCF9D49B535DAEB1C7D61BEE53B5914CGDrawingLayer", // Text, Button (iOS 26+)
-            "SwiftUI.CGDrawingView", // Text, Button
-            "SwiftUI.TextEditorTextView", // TextEditor
-            "SwiftUI.VerticalTextView", // TextField, vertical axis
-        ].compactMap(NSClassFromString)
+            /// `Text`, `Button`, `TextEditor` views
+            private let swiftUITextBasedViewTypes = [
+                "_TtC7SwiftUIP33_863CCF9D49B535DAEB1C7D61BEE53B5914CGDrawingLayer", // Text, Button (iOS 26+)
+                "SwiftUI.CGDrawingView", // Text, Button
+                "SwiftUI.TextEditorTextView", // TextEditor
+                "SwiftUI.VerticalTextView", // TextField, vertical axis
+            ].compactMap(NSClassFromString)
 
-        private let swiftUIGenericTypes = [
-            "_TtC7SwiftUIP33_A34643117F00277B93DEBAB70EC0697122_UIShapeHitTestingView",
-        ].compactMap(NSClassFromString)
+            private let swiftUIGenericTypes = [
+                "_TtC7SwiftUIP33_A34643117F00277B93DEBAB70EC0697122_UIShapeHitTestingView",
+            ].compactMap(NSClassFromString)
 
-        private let reactNativeTextView: AnyClass? = NSClassFromString("RCTTextView")
-        private let reactNativeImageView: AnyClass? = NSClassFromString("RCTImageView")
-        // These are usually views that don't belong to the current process and are most likely sensitive
-        private let systemSandboxedView: AnyClass? = NSClassFromString("_UIRemoteView")
+            private let reactNativeTextView: AnyClass? = NSClassFromString("RCTTextView")
+            private let reactNativeImageView: AnyClass? = NSClassFromString("RCTImageView")
+            // These are usually views that don't belong to the current process and are most likely sensitive
+            private let systemSandboxedView: AnyClass? = NSClassFromString("_UIRemoteView")
 
-        // These layer types should be safe to ignore while masking
-        private let swiftUISafeLayerTypes: [AnyClass] = [
-            "_TtC7SwiftUIP33_E19F490D25D5E0EC8A24903AF958E34115ColorShapeLayer", // Solid-color filled shapes (Circle, Rectangle, SF Symbols etc.)
-            "SwiftUI.GradientLayer", // Views like LinearGradient, RadialGradient, or AngularGradient
-        ].compactMap(NSClassFromString)
+            // These layer types should be safe to ignore while masking
+            private let swiftUISafeLayerTypes: [AnyClass] = [
+                "_TtC7SwiftUIP33_E19F490D25D5E0EC8A24903AF958E34115ColorShapeLayer", // Solid-color filled shapes (Circle, Rectangle, SF Symbols etc.)
+                "SwiftUI.GradientLayer", // Views like LinearGradient, RadialGradient, or AngularGradient
+            ].compactMap(NSClassFromString)
+        #endif
 
         static let dispatchQueue = DispatchQueue(label: "com.posthog.PostHogReplayIntegration",
                                                  target: .global(qos: .utility))
@@ -229,7 +239,7 @@
                 }
             }
 
-            // start listening to `UIApplication.sendEvent`
+            // start listening to application events
             let applicationEventPublisher = DI.main.applicationEventPublisher
             applicationEventToken = applicationEventPublisher.onApplicationEvent.subscribe { [weak self] event, date in
                 self?.handleApplicationEvent(event: event, date: date)
@@ -277,12 +287,12 @@
             resetViews()
             sessionIdChangedToken = nil
 
-            // stop listening to `UIApplication.sendEvent`
+            // stop listening to application events
             applicationEventToken = nil
-            // stop listening to Application lifecycle events
+            // stop listening to application lifecycle events
             applicationBackgroundedToken = nil
             applicationForegroundedToken = nil
-            // stop listening to `UIView.layoutSubviews` events
+            // stop listening to view layout events
             viewLayoutToken = nil
             // stop plugins
             let pluginsToStop = installedPluginsLock.withLock {
@@ -390,67 +400,186 @@
             updateEventTriggers(from: remoteConfig)
         }
 
-        private func handleApplicationEvent(event: UIEvent, date: Date) {
-            guard let postHog, postHog.isSessionReplayActive() else {
-                return
-            }
-
-            guard event.type == .touches else {
-                return
-            }
-
-            guard let window = UIApplication.getCurrentWindow() else {
-                return
-            }
-
-            guard let touches = event.touches(for: window) else {
-                return
-            }
-
-            // capture necessary touch information on the main thread before performing any asynchronous operations
-            // - this ensures that UITouch associated objects like UIView, UIWindow, or [UIGestureRecognizer] are still valid.
-            // - these objects may be released or erased by the system if accessed asynchronously, resulting in invalid/zeroed-out touch coordinates
-            let touchInfo = touches.map {
-                (phase: $0.phase, location: $0.location(in: window))
-            }
-
-            PostHogReplayIntegration.dispatchQueue.async { [touchInfo, weak postHog = postHog] in
-                // always make sure we have a fresh session id as early as possible
-                guard let sessionId = postHog?.sessionManager.getSessionId(at: date) else {
+        #if os(iOS)
+            private func handleApplicationEvent(event: UIEvent, date: Date) {
+                guard let postHog, postHog.isSessionReplayActive() else {
                     return
                 }
 
-                // captured weakly since integration may have uninstalled by now
-                guard let postHog else { return }
+                guard event.type == .touches else {
+                    return
+                }
+
+                guard let window = UIApplication.getCurrentWindow() else {
+                    return
+                }
+
+                guard let touches = event.touches(for: window) else {
+                    return
+                }
+
+                // capture necessary touch information on the main thread before performing any asynchronous operations
+                // - this ensures that UITouch associated objects like UIView, UIWindow, or [UIGestureRecognizer] are still valid.
+                // - these objects may be released or erased by the system if accessed asynchronously, resulting in invalid/zeroed-out touch coordinates
+                let touchInfo = touches.map {
+                    (phase: $0.phase, location: $0.location(in: window))
+                }
+
+                PostHogReplayIntegration.dispatchQueue.async { [touchInfo, weak postHog = postHog] in
+                    // always make sure we have a fresh session id as early as possible
+                    guard let sessionId = postHog?.sessionManager.getSessionId(at: date) else {
+                        return
+                    }
+
+                    // captured weakly since integration may have uninstalled by now
+                    guard let postHog else { return }
+
+                    var snapshotsData: [Any] = []
+                    for touch in touchInfo {
+                        let phase = touch.phase
+
+                        let type: Int
+                        if phase == .began {
+                            type = 7
+                        } else if phase == .ended {
+                            type = 9
+                        } else {
+                            continue
+                        }
+
+                        // we keep a failsafe here just in case, but this will likely never be triggered
+                        guard touch.location != .zero else {
+                            continue
+                        }
+
+                        let posX = touch.location.x.toInt() ?? 0
+                        let posY = touch.location.y.toInt() ?? 0
+
+                        // if the id is 0, BE transformer will set it to the virtual bodyId
+                        let touchData: [String: Any] = ["id": 0, "pointerType": 2, "source": 2, "type": type, "x": posX, "y": posY]
+
+                        let data: [String: Any] = ["type": 3, "data": touchData, "timestamp": date.toMillis()]
+                        snapshotsData.append(data)
+                    }
+                    if !snapshotsData.isEmpty {
+                        postHog.capture(
+                            "$snapshot",
+                            properties: [
+                                "$snapshot_source": "mobile",
+                                "$snapshot_data": snapshotsData,
+                                "$session_id": sessionId,
+                            ],
+                            timestamp: date
+                        )
+                    }
+                }
+            }
+        #elseif os(macOS)
+            private func handleApplicationEvent(event: NSEvent, date: Date) {
+                guard let postHog, postHog.isSessionReplayActive() else {
+                    return
+                }
+
+                guard let window = NSApplication.getCurrentWindow() else {
+                    return
+                }
+
+                // Map mouse events to rrweb touch event types
+                let type: Int
+                switch event.type {
+                case .leftMouseDown, .rightMouseDown:
+                    type = 7 // touchStart equivalent
+                case .leftMouseUp, .rightMouseUp:
+                    type = 9 // touchEnd equivalent
+                default:
+                    return
+                }
+
+                // Convert location to window coordinates (macOS uses bottom-left origin, flip to top-left)
+                let locationInWindow = event.locationInWindow
+                let windowHeight = window.contentView?.bounds.height ?? window.frame.height
+                let posX = locationInWindow.x.toInt() ?? 0
+                let posY = (windowHeight - locationInWindow.y).toInt() ?? 0
+
+                PostHogReplayIntegration.dispatchQueue.async { [weak postHog] in
+                    guard let sessionId = postHog?.sessionManager.getSessionId(at: date) else {
+                        return
+                    }
+
+                    guard let postHog else { return }
+
+                    let touchData: [String: Any] = ["id": 0, "pointerType": 2, "source": 2, "type": type, "x": posX, "y": posY]
+                    let data: [String: Any] = ["type": 3, "data": touchData, "timestamp": date.toMillis()]
+
+                    postHog.capture(
+                        "$snapshot",
+                        properties: [
+                            "$snapshot_source": "mobile",
+                            "$snapshot_data": [data],
+                            "$session_id": sessionId,
+                        ],
+                        timestamp: date
+                    )
+                }
+            }
+        #endif
+
+        #if os(iOS)
+            private func generateSnapshot(_ window: UIWindow, _ screenName: String? = nil, postHog: PostHogSDK) {
+                var hasChanges = false
+
+                guard let wireframe = postHog.config.sessionReplayConfig.screenshotMode ? toScreenshotWireframe(window) : toWireframe(window) else {
+                    return
+                }
+
+                // capture timestamp after snapshot was taken
+                let timestampDate = Date()
+                let timestamp = timestampDate.toMillis()
+
+                let snapshotStatus = windowViewsLock.withLock {
+                    windowViews.object(forKey: window) ?? ViewTreeSnapshotStatus()
+                }
 
                 var snapshotsData: [Any] = []
-                for touch in touchInfo {
-                    let phase = touch.phase
 
-                    let type: Int
-                    if phase == .began {
-                        type = 7
-                    } else if phase == .ended {
-                        type = 9
-                    } else {
-                        continue
+                if !snapshotStatus.sentMetaEvent {
+                    let size = window.bounds.size
+                    let width = size.width.toInt() ?? 0
+                    let height = size.height.toInt() ?? 0
+
+                    var data: [String: Any] = ["width": width, "height": height]
+
+                    if let screenName = screenName {
+                        data["href"] = screenName
                     }
 
-                    // we keep a failsafe here just in case, but this will likely never be triggered
-                    guard touch.location != .zero else {
-                        continue
-                    }
-
-                    let posX = touch.location.x.toInt() ?? 0
-                    let posY = touch.location.y.toInt() ?? 0
-
-                    // if the id is 0, BE transformer will set it to the virtual bodyId
-                    let touchData: [String: Any] = ["id": 0, "pointerType": 2, "source": 2, "type": type, "x": posX, "y": posY]
-
-                    let data: [String: Any] = ["type": 3, "data": touchData, "timestamp": date.toMillis()]
-                    snapshotsData.append(data)
+                    let snapshotData: [String: Any] = ["type": 4, "data": data, "timestamp": timestamp]
+                    snapshotsData.append(snapshotData)
+                    snapshotStatus.sentMetaEvent = true
+                    hasChanges = true
                 }
-                if !snapshotsData.isEmpty {
+
+                if hasChanges {
+                    windowViewsLock.withLock {
+                        windowViews.setObject(snapshotStatus, forKey: window)
+                    }
+                }
+
+                // TODO: IncrementalSnapshot, type=2
+
+                PostHogReplayIntegration.dispatchQueue.async {
+                    // always make sure we have a fresh session id at correct timestamp
+                    guard let sessionId = postHog.sessionManager.getSessionId(at: timestampDate) else {
+                        return
+                    }
+
+                    var wireframes: [Any] = []
+                    wireframes.append(wireframe.toDict())
+                    let initialOffset = ["top": 0, "left": 0]
+                    let data: [String: Any] = ["initialOffset": initialOffset, "wireframes": wireframes]
+                    let snapshotData: [String: Any] = ["type": 2, "data": data, "timestamp": timestamp]
+                    snapshotsData.append(snapshotData)
+
                     postHog.capture(
                         "$snapshot",
                         properties: [
@@ -458,97 +587,100 @@
                             "$snapshot_data": snapshotsData,
                             "$session_id": sessionId,
                         ],
-                        timestamp: date
+                        timestamp: timestampDate
                     )
                 }
             }
-        }
-
-        private func generateSnapshot(_ window: UIWindow, _ screenName: String? = nil, postHog: PostHogSDK) {
-            var hasChanges = false
-
-            guard let wireframe = postHog.config.sessionReplayConfig.screenshotMode ? toScreenshotWireframe(window) : toWireframe(window) else {
-                return
-            }
-
-            // capture timestamp after snapshot was taken
-            let timestampDate = Date()
-            let timestamp = timestampDate.toMillis()
-
-            let snapshotStatus = windowViewsLock.withLock {
-                windowViews.object(forKey: window) ?? ViewTreeSnapshotStatus()
-            }
-
-            var snapshotsData: [Any] = []
-
-            if !snapshotStatus.sentMetaEvent {
-                let size = window.bounds.size
-                let width = size.width.toInt() ?? 0
-                let height = size.height.toInt() ?? 0
-
-                var data: [String: Any] = ["width": width, "height": height]
-
-                if let screenName = screenName {
-                    data["href"] = screenName
-                }
-
-                let snapshotData: [String: Any] = ["type": 4, "data": data, "timestamp": timestamp]
-                snapshotsData.append(snapshotData)
-                snapshotStatus.sentMetaEvent = true
-                hasChanges = true
-            }
-
-            if hasChanges {
-                windowViewsLock.withLock {
-                    windowViews.setObject(snapshotStatus, forKey: window)
-                }
-            }
-
-            // TODO: IncrementalSnapshot, type=2
-
-            PostHogReplayIntegration.dispatchQueue.async {
-                // always make sure we have a fresh session id at correct timestamp
-                guard let sessionId = postHog.sessionManager.getSessionId(at: timestampDate) else {
+        #elseif os(macOS)
+            private func generateSnapshot(_ window: NSWindow, _ screenName: String? = nil, postHog: PostHogSDK) {
+                guard let contentView = window.contentView else {
                     return
                 }
 
-                var wireframes: [Any] = []
-                wireframes.append(wireframe.toDict())
-                let initialOffset = ["top": 0, "left": 0]
-                let data: [String: Any] = ["initialOffset": initialOffset, "wireframes": wireframes]
-                let snapshotData: [String: Any] = ["type": 2, "data": data, "timestamp": timestamp]
-                snapshotsData.append(snapshotData)
+                // macOS only supports screenshot mode
+                guard let wireframe = toScreenshotWireframe(window) else {
+                    return
+                }
 
-                postHog.capture(
-                    "$snapshot",
-                    properties: [
-                        "$snapshot_source": "mobile",
-                        "$snapshot_data": snapshotsData,
-                        "$session_id": sessionId,
-                    ],
-                    timestamp: timestampDate
-                )
+                let timestampDate = Date()
+                let timestamp = timestampDate.toMillis()
+
+                let snapshotStatus = windowViewsLock.withLock {
+                    windowViews.object(forKey: window) ?? ViewTreeSnapshotStatus()
+                }
+
+                var hasChanges = false
+                var snapshotsData: [Any] = []
+
+                if !snapshotStatus.sentMetaEvent {
+                    let size = contentView.bounds.size
+                    let width = size.width.toInt() ?? 0
+                    let height = size.height.toInt() ?? 0
+
+                    var data: [String: Any] = ["width": width, "height": height]
+
+                    if let screenName = screenName {
+                        data["href"] = screenName
+                    }
+
+                    let snapshotData: [String: Any] = ["type": 4, "data": data, "timestamp": timestamp]
+                    snapshotsData.append(snapshotData)
+                    snapshotStatus.sentMetaEvent = true
+                    hasChanges = true
+                }
+
+                if hasChanges {
+                    windowViewsLock.withLock {
+                        windowViews.setObject(snapshotStatus, forKey: window)
+                    }
+                }
+
+                PostHogReplayIntegration.dispatchQueue.async {
+                    guard let sessionId = postHog.sessionManager.getSessionId(at: timestampDate) else {
+                        return
+                    }
+
+                    var wireframes: [Any] = []
+                    wireframes.append(wireframe.toDict())
+                    let initialOffset = ["top": 0, "left": 0]
+                    let data: [String: Any] = ["initialOffset": initialOffset, "wireframes": wireframes]
+                    let snapshotData: [String: Any] = ["type": 2, "data": data, "timestamp": timestamp]
+                    snapshotsData.append(snapshotData)
+
+                    postHog.capture(
+                        "$snapshot",
+                        properties: [
+                            "$snapshot_source": "mobile",
+                            "$snapshot_data": snapshotsData,
+                            "$session_id": sessionId,
+                        ],
+                        timestamp: timestampDate
+                    )
+                }
             }
-        }
+        #endif
 
-        private func setAlignment(_ alignment: NSTextAlignment, _ style: RRStyle) {
-            if alignment == .center {
-                style.verticalAlign = "center"
-                style.horizontalAlign = "center"
-            } else if alignment == .right {
-                style.horizontalAlign = "right"
-            } else if alignment == .left {
-                style.horizontalAlign = "left"
+        #if os(iOS)
+            private func setAlignment(_ alignment: NSTextAlignment, _ style: RRStyle) {
+                if alignment == .center {
+                    style.verticalAlign = "center"
+                    style.horizontalAlign = "center"
+                } else if alignment == .right {
+                    style.horizontalAlign = "right"
+                } else if alignment == .left {
+                    style.horizontalAlign = "left"
+                }
             }
-        }
 
-        private func setPadding(_ insets: UIEdgeInsets, _ style: RRStyle) {
-            style.paddingTop = insets.top.toInt()
-            style.paddingRight = insets.right.toInt()
-            style.paddingBottom = insets.bottom.toInt()
-            style.paddingLeft = insets.left.toInt()
-        }
+            private func setPadding(_ insets: UIEdgeInsets, _ style: RRStyle) {
+                style.paddingTop = insets.top.toInt()
+                style.paddingRight = insets.right.toInt()
+                style.paddingBottom = insets.bottom.toInt()
+                style.paddingLeft = insets.left.toInt()
+            }
+        #endif
 
+        #if os(iOS)
         private func createBasicWireframe(_ view: UIView) -> RRWireframe {
             let wireframe = RRWireframe()
 
@@ -565,7 +697,22 @@
 
             return wireframe
         }
+        #elseif os(macOS)
+        private func createBasicWireframe(_ view: NSView) -> RRWireframe {
+            let wireframe = RRWireframe()
+            let frame = view.toAbsoluteRect(view.window)
 
+            wireframe.id = view.hash
+            wireframe.posX = frame.origin.x.toInt() ?? 0
+            wireframe.posY = frame.origin.y.toInt() ?? 0
+            wireframe.width = frame.size.width.toInt() ?? 0
+            wireframe.height = frame.size.height.toInt() ?? 0
+
+            return wireframe
+        }
+        #endif
+
+        #if os(iOS)
         private func findMaskableWidgets(_ view: UIView, _ window: UIWindow, _ maskableWidgets: inout [CGRect], _ maskChildren: inout Bool) {
             // User explicitly marked this view (and its subviews) as non-maskable through `.postHogNoMask()` view modifier
             if view.postHogNoMask {
@@ -1062,6 +1209,91 @@
             // this method has to be fast and do as little as possible
             generateSnapshot(window, screenName, postHog: postHog)
         }
+        #elseif os(macOS)
+        private func toScreenshotWireframe(_ window: NSWindow) -> RRWireframe? {
+            guard let contentView = window.contentView, contentView.isVisible() else {
+                return nil
+            }
+
+            let wireframe = createBasicWireframe(contentView)
+
+            var maskableWidgets: [CGRect] = []
+            findMaskableWidgets(contentView, window, &maskableWidgets)
+
+            if let image = contentView.toImage() {
+                if !image.size.hasSize() {
+                    return nil
+                }
+
+                wireframe.maskableWidgets = maskableWidgets
+                wireframe.image = image
+            }
+            wireframe.type = "screenshot"
+            return wireframe
+        }
+
+        private func findMaskableWidgets(_ view: NSView, _ window: NSWindow, _ maskableWidgets: inout [CGRect]) {
+            if let textView = view as? NSTextView {
+                if config?.sessionReplayConfig.maskAllTextInputs == true, let text = textView.string as String?, !text.isEmpty {
+                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    return
+                }
+            }
+
+            if let textField = view as? NSTextField {
+                if textField.isSensitiveText() || (config?.sessionReplayConfig.maskAllTextInputs == true && !textField.stringValue.isEmpty) {
+                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    return
+                }
+            }
+
+            if let imageView = view as? NSImageView {
+                if config?.sessionReplayConfig.maskAllImages == true, imageView.image != nil {
+                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    return
+                }
+            }
+
+            if view is WKWebView {
+                if config?.sessionReplayConfig.maskAllTextInputs == true || config?.sessionReplayConfig.maskAllImages == true {
+                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    return
+                }
+            }
+
+            if let button = view as? NSButton {
+                if config?.sessionReplayConfig.maskAllTextInputs == true, !button.title.isEmpty {
+                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    return
+                }
+            }
+
+            if view.isNoCapture() {
+                maskableWidgets.append(view.toAbsoluteRect(window))
+                return
+            }
+
+            for child in view.subviews {
+                if !child.isVisible() {
+                    continue
+                }
+                findMaskableWidgets(child, window, &maskableWidgets)
+            }
+        }
+
+        @objc private func snapshot() {
+            guard let postHog, postHog.isSessionReplayActive() else {
+                return
+            }
+
+            guard let window = NSApplication.getCurrentWindow() else {
+                return
+            }
+
+            // macOS only supports screenshot mode
+            generateSnapshot(window, nil, postHog: postHog)
+        }
+        #endif
 
         private func handleEventCaptured(event: String) {
             guard let postHog else { return }
@@ -1167,9 +1399,15 @@
         }
     }
 
-    private protocol AnyObjectUIHostingViewController: AnyObject {}
+    #if os(iOS)
+        private protocol AnyObjectUIHostingViewController: AnyObject {}
 
-    extension UIHostingController: AnyObjectUIHostingViewController {}
+        extension UIHostingController: AnyObjectUIHostingViewController {}
+    #elseif os(macOS)
+        private protocol AnyObjectNSHostingViewController: AnyObject {}
+
+        extension NSHostingController: AnyObjectNSHostingViewController {}
+    #endif
 
     #if TESTING
         extension PostHogReplayIntegration {

--- a/PostHog/Replay/PostHogSessionReplayConfig.swift
+++ b/PostHog/Replay/PostHogSessionReplayConfig.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Manoel Aranda Neto on 19.03.24.
 //
-#if os(iOS)
+#if os(iOS) || os(macOS)
     import Foundation
 
     @objc(PostHogSessionReplayConfig) public class PostHogSessionReplayConfig: NSObject {

--- a/PostHog/Replay/PostHogSessionReplayConsoleLogConfig.swift
+++ b/PostHog/Replay/PostHogSessionReplayConsoleLogConfig.swift
@@ -5,7 +5,7 @@
 //  Created by Ioannis Josephides on 09/05/2025.
 //
 
-#if os(iOS)
+#if os(iOS) || os(macOS)
     import Foundation
 
     @objc public class PostHogSessionReplayConsoleLogConfig: NSObject {

--- a/PostHog/Replay/RRWireframe.swift
+++ b/PostHog/Replay/RRWireframe.swift
@@ -10,6 +10,8 @@
 import Foundation
 #if os(iOS)
     import UIKit
+#elseif os(macOS)
+    import AppKit
 #endif
 
 class RRWireframe {
@@ -26,6 +28,9 @@ class RRWireframe {
     var value: Any? // string or number
     #if os(iOS)
         var image: UIImage?
+        var maskableWidgets: [CGRect]?
+    #elseif os(macOS)
+        var image: NSImage?
         var maskableWidgets: [CGRect]?
     #endif
     var base64: String?
@@ -56,6 +61,26 @@ class RRWireframe {
                 return redactedImage
             }
             return nil
+        }
+    #elseif os(macOS)
+        private func maskImage() -> NSImage? {
+            guard let image = image else { return nil }
+
+            let maskedImage = NSImage(size: image.size)
+            maskedImage.lockFocus()
+
+            image.draw(at: .zero, from: NSRect(origin: .zero, size: image.size), operation: .copy, fraction: 1.0)
+
+            if let maskableWidgets = maskableWidgets {
+                NSColor.black.setFill()
+                for rect in maskableWidgets {
+                    let path = NSBezierPath(roundedRect: rect, xRadius: 10, yRadius: 10)
+                    path.fill()
+                }
+            }
+
+            maskedImage.unlockFocus()
+            return maskedImage
         }
     #endif
 
@@ -92,7 +117,7 @@ class RRWireframe {
             dict["value"] = value
         }
 
-        #if os(iOS)
+        #if os(iOS) || os(macOS)
             if let image = image {
                 if let maskedImage = maskImage() {
                     base64 = maskedImage.toBase64()

--- a/PostHog/Replay/UIColor+Util.swift
+++ b/PostHog/Replay/UIColor+Util.swift
@@ -14,4 +14,20 @@
             cgColor.toRGBString()
         }
     }
+
+#elseif os(macOS)
+
+    import AppKit
+    import Foundation
+
+    extension NSColor {
+        func toRGBString() -> String? {
+            // Convert to sRGB color space first to ensure we can access RGB components
+            guard let rgbColor = usingColorSpace(.sRGB) else {
+                return cgColor.toRGBString()
+            }
+            return rgbColor.cgColor.toRGBString()
+        }
+    }
+
 #endif

--- a/PostHog/Replay/UIImage+Util.swift
+++ b/PostHog/Replay/UIImage+Util.swift
@@ -30,4 +30,35 @@
     public func imageToBase64(_ image: UIImage, _ compressionQuality: CGFloat = 0.3) -> String? {
         image.toBase64(compressionQuality)
     }
+
+#elseif os(macOS)
+    import AppKit
+    import Foundation
+
+    extension NSImage {
+        func toBase64(_ compressionQuality: CGFloat = 0.3) -> String? {
+            toWebPBase64(compressionQuality) ?? toJpegBase64(compressionQuality)
+        }
+
+        private func toWebPBase64(_ compressionQuality: CGFloat) -> String? {
+            webpData(compressionQuality: compressionQuality).map { data in
+                "data:image/webp;base64,\(data.base64EncodedString())"
+            }
+        }
+
+        private func toJpegBase64(_ compressionQuality: CGFloat) -> String? {
+            guard let tiffData = tiffRepresentation,
+                  let bitmap = NSBitmapImageRep(data: tiffData),
+                  let jpegData = bitmap.representation(using: .jpeg, properties: [.compressionFactor: compressionQuality])
+            else {
+                return nil
+            }
+            return "data:image/jpeg;base64,\(jpegData.base64EncodedString())"
+        }
+    }
+
+    public func imageToBase64(_ image: NSImage, _ compressionQuality: CGFloat = 0.3) -> String? {
+        image.toBase64(compressionQuality)
+    }
+
 #endif

--- a/PostHog/Replay/UITextInputTraits+Util.swift
+++ b/PostHog/Replay/UITextInputTraits+Util.swift
@@ -33,4 +33,48 @@
             return false
         }
     }
+
+#elseif os(macOS)
+    import AppKit
+    import Foundation
+
+    @available(macOS 14.0, *)
+    private let sensibleContentTypes: [NSTextContentType] = [
+        .newPassword, .oneTimeCode,
+        .telephoneNumber, .emailAddress, .password,
+        .username, .URL, .name, .familyName,
+        .namePrefix, .organizationName,
+        .fullStreetAddress, .streetAddressLine1,
+        .streetAddressLine2, .addressCity, .addressState,
+        .addressCityAndState, .postalCode,
+    ]
+
+    extension NSTextField {
+        func isSensitiveText() -> Bool {
+            if self is NSSecureTextField {
+                return true
+            }
+
+            if #available(macOS 14.0, *) {
+                if let contentType = contentType {
+                    return sensibleContentTypes.contains(contentType)
+                }
+            }
+
+            return false
+        }
+    }
+
+    extension NSTextView {
+        func isSensitiveText() -> Bool {
+            if #available(macOS 14.0, *) {
+                if let contentType = contentType {
+                    return sensibleContentTypes.contains(contentType)
+                }
+            }
+
+            return false
+        }
+    }
+
 #endif

--- a/PostHog/Replay/UIView+Util.swift
+++ b/PostHog/Replay/UIView+Util.swift
@@ -73,4 +73,63 @@
             convert(bounds, to: window?.layer)
         }
     }
+
+#elseif os(macOS)
+    import AppKit
+    import Foundation
+
+    extension NSView {
+        func isVisible() -> Bool {
+            if isHidden || alphaValue == 0 || frame == .zero {
+                return false
+            }
+            return true
+        }
+
+        func isNoCapture() -> Bool {
+            var isNoCapture = false
+            let identifier: String = accessibilityIdentifier()
+            if !identifier.isEmpty {
+                isNoCapture = checkLabel(identifier)
+            }
+            if !isNoCapture, let label = accessibilityLabel(), !label.isEmpty {
+                isNoCapture = checkLabel(label)
+            }
+
+            return isNoCapture
+        }
+
+        private func checkLabel(_ label: String) -> Bool {
+            label.lowercased().contains("ph-no-capture")
+        }
+
+        func toImage() -> NSImage? {
+            let bounds = bounds
+            let size = bounds.size
+
+            if !size.hasSize() {
+                return nil
+            }
+
+            guard let bitmapRep = bitmapImageRepForCachingDisplay(in: bounds) else {
+                return nil
+            }
+            cacheDisplay(in: bounds, to: bitmapRep)
+
+            let image = NSImage(size: size)
+            image.addRepresentation(bitmapRep)
+            return image
+        }
+
+        func toAbsoluteRect(_ window: NSWindow?) -> CGRect {
+            convert(bounds, to: window?.contentView)
+        }
+    }
+
+    extension CALayer {
+        func toAbsoluteRect(_ window: NSWindow?) -> CGRect {
+            convert(bounds, to: window?.contentView?.layer)
+        }
+    }
+
 #endif

--- a/PostHog/Utils/UIApplication+.swift
+++ b/PostHog/Utils/UIApplication+.swift
@@ -40,4 +40,14 @@
             return nil
         }
     }
+
+#elseif os(macOS)
+    import AppKit
+
+    extension NSApplication {
+        static func getCurrentWindow() -> NSWindow? {
+            NSApplication.shared.keyWindow ?? NSApplication.shared.mainWindow
+        }
+    }
+
 #endif

--- a/PostHog/Utils/UIImage+WebP.swift
+++ b/PostHog/Utils/UIImage+WebP.swift
@@ -6,7 +6,7 @@
 //
 // Adapted from: https://github.com/SDWebImage/SDWebImageWebPCoder/blob/master/SDWebImageWebPCoder/Classes/SDImageWebPCoder.m
 
-#if os(iOS)
+#if os(iOS) || os(macOS)
     import Accelerate
     import CoreGraphics
     import Foundation
@@ -19,120 +19,146 @@
         // @_implementationOnly: available since Swift 5.1
         @_implementationOnly import phlibwebp
     #endif
-    import UIKit
+    #if os(iOS)
+        import UIKit
+    #elseif os(macOS)
+        import AppKit
+    #endif
 
-    extension UIImage {
-        /**
-         Returns a data object that contains the image in WebP format.
+    /// Shared WebP encoding logic that operates on a CGImage
+    private func webpDataFromCGImage(_ cgImage: CGImage, compressionQuality: CGFloat) -> Data? {
+        // validate dimensions
+        let width = Int(cgImage.width)
+        let height = Int(cgImage.height)
 
-         - Parameters:
-         - compressionQuality: desired compression quality [0...1] (0=max/lowest quality, 1=low/high quality)
-         - Returns: A data object containing the WebP data, or nil if there’s a problem generating the data.
-         */
-        func webpData(compressionQuality: CGFloat) -> Data? {
-            // Early exit if image is missing
-            guard let cgImage = cgImage else {
-                return nil
-            }
-
-            // validate dimensions
-            let width = Int(cgImage.width)
-            let height = Int(cgImage.height)
-
-            guard width > 0, width <= WEBP_MAX_DIMENSION, height > 0, height <= WEBP_MAX_DIMENSION else {
-                return nil
-            }
-
-            let bitmapInfo = cgImage.bitmapInfo
-            let alphaInfo = CGImageAlphaInfo(rawValue: bitmapInfo.rawValue & CGBitmapInfo.alphaInfoMask.rawValue)
-
-            // Prepare destination format
-
-            let hasAlpha = !(
-                alphaInfo == CGImageAlphaInfo.none ||
-                    alphaInfo == CGImageAlphaInfo.noneSkipFirst ||
-                    alphaInfo == CGImageAlphaInfo.noneSkipLast
-            )
-
-            // try to use image color space if ~rgb
-            let colorSpace: CGColorSpace = cgImage.colorSpace?.model == .rgb
-                ? cgImage.colorSpace! // safe from previous check
-                : CGColorSpace(name: CGColorSpace.linearSRGB)!
-            let renderingIntent = cgImage.renderingIntent
-
-            guard let destFormat = vImage_CGImageFormat(
-                bitsPerComponent: 8,
-                bitsPerPixel: hasAlpha ? 32 : 24, // RGB888/RGBA8888
-                colorSpace: colorSpace,
-                bitmapInfo: hasAlpha
-                    ? CGBitmapInfo(rawValue: CGImageAlphaInfo.last.rawValue | CGBitmapInfo.byteOrderDefault.rawValue)
-                    : CGBitmapInfo(rawValue: CGImageAlphaInfo.none.rawValue | CGBitmapInfo.byteOrderDefault.rawValue),
-                renderingIntent: renderingIntent
-            ) else {
-                return nil
-            }
-
-            guard let dest = try? vImage_Buffer(cgImage: cgImage, format: destFormat, flags: .noFlags) else {
-                hedgeLog("Error initializing WebP image buffer")
-                return nil
-            }
-            defer { dest.data?.deallocate() }
-
-            guard let rgba = dest.data else { // byte array
-                hedgeLog("Could not get rgba byte array from destination format")
-                return nil
-            }
-            let bytesPerRow = dest.rowBytes
-
-            let quality = Float(compressionQuality * 100) // WebP quality is 0-100
-
-            var config = WebPConfig()
-            var picture = WebPPicture()
-            var writer = WebPMemoryWriter()
-
-            // get present...
-            guard WebPConfigPreset(&config, WEBP_PRESET_DEFAULT, quality) != 0, WebPPictureInit(&picture) != 0 else {
-                hedgeLog("Error initializing WebPPicture")
-                return nil
-            }
-
-            withUnsafeMutablePointer(to: &writer) { writerPointer in
-                picture.use_argb = 1 // Lossy encoding uses YUV for internal bitstream
-                picture.width = Int32(width)
-                picture.height = Int32(height)
-                picture.writer = WebPMemoryWrite
-                picture.custom_ptr = UnsafeMutableRawPointer(writerPointer)
-            }
-
-            WebPMemoryWriterInit(&writer)
-
-            defer {
-                WebPMemoryWriterClear(&writer)
-                WebPPictureFree(&picture)
-            }
-
-            let result: Int32
-            if hasAlpha {
-                // RGBA8888 - 4 channels
-                result = WebPPictureImportRGBA(&picture, rgba.bindMemory(to: UInt8.self, capacity: 4), Int32(bytesPerRow))
-            } else {
-                // RGB888 - 3 channels
-                result = WebPPictureImportRGB(&picture, rgba.bindMemory(to: UInt8.self, capacity: 3), Int32(bytesPerRow))
-            }
-
-            if result == 0 {
-                hedgeLog("Could not read WebPPicture")
-                return nil
-            }
-
-            if WebPEncode(&config, &picture) == 0 {
-                hedgeLog("Could not encode WebP image")
-                return nil
-            }
-
-            let webpData = Data(bytes: writer.mem, count: writer.size)
-
-            return webpData
+        guard width > 0, width <= WEBP_MAX_DIMENSION, height > 0, height <= WEBP_MAX_DIMENSION else {
+            return nil
         }
+
+        let bitmapInfo = cgImage.bitmapInfo
+        let alphaInfo = CGImageAlphaInfo(rawValue: bitmapInfo.rawValue & CGBitmapInfo.alphaInfoMask.rawValue)
+
+        // Prepare destination format
+
+        let hasAlpha = !(
+            alphaInfo == CGImageAlphaInfo.none ||
+                alphaInfo == CGImageAlphaInfo.noneSkipFirst ||
+                alphaInfo == CGImageAlphaInfo.noneSkipLast
+        )
+
+        // try to use image color space if ~rgb
+        let colorSpace: CGColorSpace = cgImage.colorSpace?.model == .rgb
+            ? cgImage.colorSpace! // safe from previous check
+            : CGColorSpace(name: CGColorSpace.linearSRGB)!
+        let renderingIntent = cgImage.renderingIntent
+
+        guard let destFormat = vImage_CGImageFormat(
+            bitsPerComponent: 8,
+            bitsPerPixel: hasAlpha ? 32 : 24, // RGB888/RGBA8888
+            colorSpace: colorSpace,
+            bitmapInfo: hasAlpha
+                ? CGBitmapInfo(rawValue: CGImageAlphaInfo.last.rawValue | CGBitmapInfo.byteOrderDefault.rawValue)
+                : CGBitmapInfo(rawValue: CGImageAlphaInfo.none.rawValue | CGBitmapInfo.byteOrderDefault.rawValue),
+            renderingIntent: renderingIntent
+        ) else {
+            return nil
+        }
+
+        guard let dest = try? vImage_Buffer(cgImage: cgImage, format: destFormat, flags: .noFlags) else {
+            hedgeLog("Error initializing WebP image buffer")
+            return nil
+        }
+        defer { dest.data?.deallocate() }
+
+        guard let rgba = dest.data else { // byte array
+            hedgeLog("Could not get rgba byte array from destination format")
+            return nil
+        }
+        let bytesPerRow = dest.rowBytes
+
+        let quality = Float(compressionQuality * 100) // WebP quality is 0-100
+
+        var config = WebPConfig()
+        var picture = WebPPicture()
+        var writer = WebPMemoryWriter()
+
+        // get present...
+        guard WebPConfigPreset(&config, WEBP_PRESET_DEFAULT, quality) != 0, WebPPictureInit(&picture) != 0 else {
+            hedgeLog("Error initializing WebPPicture")
+            return nil
+        }
+
+        withUnsafeMutablePointer(to: &writer) { writerPointer in
+            picture.use_argb = 1 // Lossy encoding uses YUV for internal bitstream
+            picture.width = Int32(width)
+            picture.height = Int32(height)
+            picture.writer = WebPMemoryWrite
+            picture.custom_ptr = UnsafeMutableRawPointer(writerPointer)
+        }
+
+        WebPMemoryWriterInit(&writer)
+
+        defer {
+            WebPMemoryWriterClear(&writer)
+            WebPPictureFree(&picture)
+        }
+
+        let result: Int32
+        if hasAlpha {
+            // RGBA8888 - 4 channels
+            result = WebPPictureImportRGBA(&picture, rgba.bindMemory(to: UInt8.self, capacity: 4), Int32(bytesPerRow))
+        } else {
+            // RGB888 - 3 channels
+            result = WebPPictureImportRGB(&picture, rgba.bindMemory(to: UInt8.self, capacity: 3), Int32(bytesPerRow))
+        }
+
+        if result == 0 {
+            hedgeLog("Could not read WebPPicture")
+            return nil
+        }
+
+        if WebPEncode(&config, &picture) == 0 {
+            hedgeLog("Could not encode WebP image")
+            return nil
+        }
+
+        let webpData = Data(bytes: writer.mem, count: writer.size)
+
+        return webpData
     }
+
+    #if os(iOS)
+        extension UIImage {
+            /**
+             Returns a data object that contains the image in WebP format.
+
+             - Parameters:
+             - compressionQuality: desired compression quality [0...1] (0=max/lowest quality, 1=low/high quality)
+             - Returns: A data object containing the WebP data, or nil if there's a problem generating the data.
+             */
+            func webpData(compressionQuality: CGFloat) -> Data? {
+                guard let cgImage = cgImage else {
+                    return nil
+                }
+                return webpDataFromCGImage(cgImage, compressionQuality: compressionQuality)
+            }
+        }
+    #elseif os(macOS)
+        extension NSImage {
+            /**
+             Returns a data object that contains the image in WebP format.
+
+             - Parameters:
+             - compressionQuality: desired compression quality [0...1] (0=max/lowest quality, 1=low/high quality)
+             - Returns: A data object containing the WebP data, or nil if there's a problem generating the data.
+             */
+            func webpData(compressionQuality: CGFloat) -> Data? {
+                var rect = CGRect(origin: .zero, size: size)
+                guard let cgImage = cgImage(forProposedRect: &rect, context: nil, hints: nil) else {
+                    return nil
+                }
+                return webpDataFromCGImage(cgImage, compressionQuality: compressionQuality)
+            }
+        }
+    #endif
 #endif

--- a/PostHogExample/ContentView.swift
+++ b/PostHogExample/ContentView.swift
@@ -289,7 +289,7 @@ struct ContentView: View {
                 Section("Crash Triggers") {
                     // NSException - richest info with name + reason
                     Button("Uncaught NSException") {
-                        ExceptionHandler.triggerUncaughtNSException()
+                        PHGExceptionHandler.triggerUncaughtNSException()
                     }
                     // SIGTRAP - message not captured (see PostHogCrashReportProcessor for details)
                     Button("fatalError()") {
@@ -301,11 +301,11 @@ struct ContentView: View {
                     }
                     // EXC_BAD_ACCESS - null pointer dereference
                     Button("Null Pointer") {
-                        ExceptionHandler.triggerNullPointerCrash()
+                        PHGExceptionHandler.triggerNullPointerCrash()
                     }
                     // SIGABRT - explicit abort() call
                     Button("Abort") {
-                        ExceptionHandler.triggerAbortCrash()
+                        PHGExceptionHandler.triggerAbortCrash()
                     }
                 }
 
@@ -338,8 +338,8 @@ struct ContentView: View {
                     }
 
                     Button("Trigger Real NSRangeException") {
-                        ExceptionHandler.try {
-                            ExceptionHandler.triggerSampleRangeException()
+                        PHGExceptionHandler.try {
+                            PHGExceptionHandler.triggerSampleRangeException()
                         } catch: { exception in
                             PostHogSDK.shared.captureException(exception, properties: [
                                 "is_test": true,
@@ -350,8 +350,8 @@ struct ContentView: View {
                     }
 
                     Button("Trigger Real NSInvalidArgumentException") {
-                        ExceptionHandler.try {
-                            ExceptionHandler.triggerSampleInvalidArgumentException()
+                        PHGExceptionHandler.try {
+                            PHGExceptionHandler.triggerSampleInvalidArgumentException()
                         } catch: { exception in
                             PostHogSDK.shared.captureException(exception, properties: [
                                 "is_test": true,
@@ -362,8 +362,8 @@ struct ContentView: View {
                     }
 
                     Button("Trigger Custom NSException") {
-                        ExceptionHandler.try {
-                            ExceptionHandler.triggerSampleGenericException()
+                        PHGExceptionHandler.try {
+                            PHGExceptionHandler.triggerSampleGenericException()
                         } catch: { exception in
                             PostHogSDK.shared.captureException(exception, properties: [
                                 "is_test": true,
@@ -374,8 +374,8 @@ struct ContentView: View {
                     }
 
                     Button("Trigger Chained NSException") {
-                        ExceptionHandler.try {
-                            ExceptionHandler.triggerChainedException()
+                        PHGExceptionHandler.try {
+                            PHGExceptionHandler.triggerChainedException()
                         } catch: { exception in
                             PostHogSDK.shared.captureException(exception, properties: [
                                 "is_test": true,

--- a/PostHogExample/ExceptionHandler.h
+++ b/PostHogExample/ExceptionHandler.h
@@ -9,7 +9,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface ExceptionHandler : NSObject
+@interface PHGExceptionHandler : NSObject
 
 /// Execute a block and catch any NSExceptions that occur
 /// @param tryBlock The block to execute that might throw an NSException

--- a/PostHogExample/ExceptionHandler.m
+++ b/PostHogExample/ExceptionHandler.m
@@ -7,7 +7,7 @@
 
 #import "ExceptionHandler.h"
 
-@implementation ExceptionHandler
+@implementation PHGExceptionHandler
 
 + (void)tryBlock:(void(^)(void))tryBlock 
            catch:(void(^)(NSException *exception))catchBlock {


### PR DESCRIPTION
## :bulb: Motivation and Context

Relates to https://github.com/PostHog/posthog-ios/issues/200

Session replay (`PostHogReplayIntegration`) was previously only available on iOS. This PR adds macOS support, enabling session recording for macOS applications using screenshot mode.

macOS uses AppKit instead of UIKit, so all iOS-only APIs needed platform-specific equivalents. This PR implements the full screenshot capture pipeline for macOS while keeping the existing iOS functionality untouched.

## :green_heart: How did you test it?

https://us.posthog.com/shared/sAfChT7yH7Pp3N0gRCh0mo1XBiydXQ?t=2

- `make buildSdk` passes for all 5 platforms (iOS, macOS, tvOS, watchOS, visionOS)
- Verified all `#if os(iOS)` guards were correctly updated to `#if os(iOS) || os(macOS)` for replay-related code
- Non-replay code (surveys, autocapture) remains iOS-only as before

## Changes

### SDK changes (30 files)

**Utility files** — Changed from `#if os(iOS)` to `#if os(iOS) || os(macOS)` with AppKit equivalents:
- `CGSize+Util.swift`, `CGColor+Util.swift` — Pure CoreGraphics, no UIKit dependency needed
- `UIColor+Util.swift` — Added `NSColor.toRGBString()` via sRGB color space conversion
- `UIImage+Util.swift` — Added `NSImage.toBase64()` with WebP + JPEG fallback
- `UIView+Util.swift` — Added `NSView` extensions: `isVisible()`, `isNoCapture()`, `toImage()` (using `bitmapImageRepForCachingDisplay`), `toAbsoluteRect()`
- `UITextInputTraits+Util.swift` — Added `NSTextField.isSensitiveText()` and `NSTextView.isSensitiveText()` with `NSTextContentType` checks (macOS 14.0+)
- `UIImage+WebP.swift` — Refactored to extract shared `webpDataFromCGImage()` function, with separate `UIImage`/`NSImage` extensions

**Infrastructure files:**
- `MethodSwizzler.swift` — Pure ObjC runtime, no platform dependency
- `PostHogSessionReplayConfig.swift`, `PostHogSessionReplayConsoleLogConfig.swift` — Pure Foundation types
- `PostHogSessionReplayPlugin.swift` (protocol) + all plugin files (Network, Console Logs) — Foundation/networking APIs
- `ApplicationEventPublisher.swift` — Added macOS branch using `NSEvent.addLocalMonitorForEvents(matching:)` for mouse events
- `ApplicationViewLayoutPublisher.swift` — Added macOS branch swizzling `NSView.layout()`
- `DI.swift` — Extended publishers to include macOS
- `UIApplication+.swift` — Added `NSApplication.getCurrentWindow()`

**Core files:**
- `RRWireframe.swift` — Added `NSImage` support for `image`/`maskableWidgets` properties, macOS mask rendering with `NSBezierPath`
- `PostHogReplayIntegration.swift` — The main integration:
  - macOS uses `NSWindow`/`NSView` for view hierarchy
  - Mouse events (mouseDown/mouseUp) mapped to rrweb touch events with coordinate flipping (bottom-left → top-left origin)
  - Screenshot capture via `NSView.toImage()`
  - Simplified `findMaskableWidgets` for macOS (NSTextView, NSTextField, NSImageView, NSButton, WKWebView)
  - iOS-only code (SwiftUI type detection, iOS 26 layer logic, wireframe mode) stays guarded with `#if os(iOS)`

**Integration points:**
- `PostHogConfig.swift` — `sessionReplay` and `sessionReplayConfig` available on macOS
- `PostHogSDK.swift` — `startSessionRecording()`, `stopSessionRecording()`, `isSessionReplayActive()` available on macOS
- `PostHogRemoteConfig.swift` — Session recording config processing on macOS

### Example app fix (unrelated)
- Renamed `ExceptionHandler` → `PHGExceptionHandler` to fix naming collision with macOS CarbonCore's `ExceptionHandler` typedef when building for Mac Catalyst

### Scope limitations (intentional)
- **macOS only supports screenshot mode** — wireframe mode requires mapping every AppKit widget
- **SwiftUI view modifiers** (`postHogMask()`, `postHogNoMask()`) remain iOS-only — requires `NSViewRepresentable` rewrite
- **No iOS 26 layer logic on macOS** — guarded by `@available(iOS 26.0, *)`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR