### PR TITLE
feat: add device bucketing support for stable flag assignment

### DIFF
--- a/.changeset/device-bucketing.md
+++ b/.changeset/device-bucketing.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": minor
+---
+
+Add device bucketing support for stable feature flag assignment across identity changes

--- a/PostHog/PostHogApi.swift
+++ b/PostHog/PostHogApi.swift
@@ -188,6 +188,7 @@ class PostHogApi {
     func flags(
         distinctId: String,
         anonymousId: String?,
+        deviceId: String? = nil,
         groups: [String: String],
         personProperties: [String: Any],
         groupProperties: [String: [String: Any]]? = nil,
@@ -217,6 +218,10 @@ class PostHogApi {
 
         if let anonymousId {
             toSend["$anon_distinct_id"] = anonymousId
+        }
+
+        if let deviceId {
+            toSend["$device_id"] = deviceId
         }
 
         if !personProperties.isEmpty {

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -206,10 +206,12 @@ class PostHogRemoteConfig {
         let groups = featureFlagsLock.withLock { getGroups() }
         let distinctId = storageManager.getDistinctId()
         let anonymousId = config.reuseAnonymousId == false ? storageManager.getAnonymousId() : nil
+        let deviceId = storageManager.getDeviceId()
 
         loadFeatureFlags(
             distinctId: distinctId,
             anonymousId: anonymousId,
+            deviceId: deviceId.isEmpty ? nil : deviceId,
             groups: groups,
             callback: callback ?? { _ in }
         )
@@ -290,6 +292,7 @@ class PostHogRemoteConfig {
     func loadFeatureFlags(
         distinctId: String,
         anonymousId: String?,
+        deviceId: String? = nil,
         groups: [String: String],
         callback: @escaping ([String: Any]?) -> Void
     ) {
@@ -299,6 +302,7 @@ class PostHogRemoteConfig {
                 self.pendingFeatureFlagsRequest = PendingFeatureFlagsRequest(
                     distinctId: distinctId,
                     anonymousId: anonymousId,
+                    deviceId: deviceId,
                     groups: groups,
                     callback: callback
                 )
@@ -318,6 +322,7 @@ class PostHogRemoteConfig {
 
         api.flags(distinctId: distinctId,
                   anonymousId: anonymousId,
+                  deviceId: deviceId,
                   groups: groups,
                   personProperties: personProperties,
                   groupProperties: groupProperties.isEmpty ? nil : groupProperties)
@@ -522,6 +527,7 @@ class PostHogRemoteConfig {
             loadFeatureFlags(
                 distinctId: pending.distinctId,
                 anonymousId: pending.anonymousId,
+                deviceId: pending.deviceId,
                 groups: pending.groups,
                 callback: pending.callback
             )
@@ -855,6 +861,7 @@ class PostHogRemoteConfig {
 private struct PendingFeatureFlagsRequest {
     let distinctId: String
     let anonymousId: String?
+    let deviceId: String?
     let groups: [String: String]
     let callback: ([String: Any]?) -> Void
 }

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -108,6 +108,12 @@ let maxRetryDelay = 30.0
             let api = PostHogApi(config)
 
             config.storageManager = config.storageManager ?? PostHogStorageManager(config)
+
+            // Initialize device_id before remote config loads, so it's available for flag requests.
+            // This provides a stable identifier for device-level feature flag bucketing that
+            // survives identify() and reset(). Seeded from the anonymous ID on first init.
+            config.storageManager?.initializeDeviceId()
+
             remoteConfig = PostHogRemoteConfig(config, theStorage, api, { [weak self] in
                 self?.getDefaultPersonProperties() ?? [:]
             }, { [weak self] flagKey, flagValue in
@@ -188,6 +194,17 @@ let maxRetryDelay = 30.0
         }
 
         return config.storageManager?.getAnonymousId() ?? ""
+    }
+
+    /// Returns the stable device identifier used for device-level feature flag bucketing.
+    /// This ID persists across `identify()` and `reset()` calls, only changing on a fresh
+    /// app install, manual cache clearing, or OS-initiated storage cleanup.
+    @objc public func getDeviceId() -> String {
+        if !isEnabled() {
+            return ""
+        }
+
+        return config.storageManager?.getDeviceId() ?? ""
     }
 
     @objc public func getSessionId() -> String? {

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -109,10 +109,9 @@ let maxRetryDelay = 30.0
 
             config.storageManager = config.storageManager ?? PostHogStorageManager(config)
 
-            // Initialize device_id before remote config loads, so it's available for flag requests.
-            // This provides a stable identifier for device-level feature flag bucketing that
-            // survives identify() and reset(). Seeded from the anonymous ID on first init.
-            config.storageManager?.initializeDeviceId()
+            // Ensure device_id is initialized before remote config loads, so it's
+            // available for flag requests. Seeded from the anonymous ID on first init.
+            _ = config.storageManager?.getDeviceId()
 
             remoteConfig = PostHogRemoteConfig(config, theStorage, api, { [weak self] in
                 self?.getDefaultPersonProperties() ?? [:]

--- a/PostHog/PostHogStorage.swift
+++ b/PostHog/PostHogStorage.swift
@@ -250,6 +250,7 @@ class PostHogStorage {
         case personPropertiesForFlags = "posthog.personPropertiesForFlags"
         case groupPropertiesForFlags = "posthog.groupPropertiesForFlags"
         case errorTracking = "posthog.errorTracking"
+        case deviceId = "posthog.deviceId"
     }
 
     // The location for storing data that we always want to keep

--- a/PostHog/PostHogStorageManager.swift
+++ b/PostHog/PostHogStorageManager.swift
@@ -13,6 +13,7 @@ public class PostHogStorageManager {
 
     private let anonLock = NSLock()
     private let distinctLock = NSLock()
+    private let deviceIdLock = NSLock()
     private let identifiedLock = NSLock()
     private let personProcessingLock = NSLock()
     private let idGen: (UUID) -> UUID
@@ -20,6 +21,7 @@ public class PostHogStorageManager {
     private var distinctId: String?
     private var cachedDistinctId = false
     private var anonymousId: String?
+    private var deviceId: String?
     private var isIdentifiedValue: Bool?
     private var personProcessingEnabled: Bool?
 
@@ -56,6 +58,41 @@ public class PostHogStorageManager {
     private func setAnonId(_ id: String) {
         anonymousId = id
         storage.setString(forKey: .anonymousId, contents: id)
+    }
+
+    /// Returns the stable device identifier used for device-level feature flag bucketing.
+    /// This ID persists across identify() and reset() calls, only changing on a fresh
+    /// app install or manual cache clearing.
+    public func getDeviceId() -> String {
+        deviceIdLock.withLock {
+            if deviceId == nil {
+                deviceId = storage.getString(forKey: .deviceId)
+
+                if deviceId == nil {
+                    // Lazy init for upgrades: existing installs won't have a device_id yet,
+                    // so seed it from the current anonymous ID.
+                    let anonId = getAnonymousId()
+                    deviceId = anonId
+                    storage.setString(forKey: .deviceId, contents: anonId)
+                }
+            }
+        }
+        return deviceId ?? ""
+    }
+
+    /// Initializes device_id if not already persisted. Called during SDK setup to ensure
+    /// the device ID is seeded from the anonymous ID before any flag requests.
+    func initializeDeviceId() {
+        deviceIdLock.withLock {
+            let persisted = storage.getString(forKey: .deviceId)
+            if persisted == nil {
+                let anonId = getAnonymousId()
+                deviceId = anonId
+                storage.setString(forKey: .deviceId, contents: anonId)
+            } else {
+                deviceId = persisted
+            }
+        }
     }
 
     public func getDistinctId() -> String {

--- a/PostHog/PostHogStorageManager.swift
+++ b/PostHog/PostHogStorageManager.swift
@@ -80,21 +80,6 @@ public class PostHogStorageManager {
         return deviceId ?? ""
     }
 
-    /// Initializes device_id if not already persisted. Called during SDK setup to ensure
-    /// the device ID is seeded from the anonymous ID before any flag requests.
-    func initializeDeviceId() {
-        deviceIdLock.withLock {
-            let persisted = storage.getString(forKey: .deviceId)
-            if persisted == nil {
-                let anonId = getAnonymousId()
-                deviceId = anonId
-                storage.setString(forKey: .deviceId, contents: anonId)
-            } else {
-                deviceId = persisted
-            }
-        }
-    }
-
     public func getDistinctId() -> String {
         var distinctId: String?
         distinctLock.withLock {

--- a/PostHogTests/PostHogDeviceBucketingTests.swift
+++ b/PostHogTests/PostHogDeviceBucketingTests.swift
@@ -1,0 +1,155 @@
+//
+//  PostHogDeviceBucketingTests.swift
+//  PostHog
+//
+//  Created by Dylan Martin on 2026-04-08.
+//
+
+import Foundation
+@testable import PostHog
+import Testing
+import XCTest
+
+@Suite("Device bucketing tests", .serialized)
+class PostHogDeviceBucketingTests {
+    let server: MockPostHogServer
+
+    var cleanupJobs: [() -> Void]
+
+    func getSut(
+        reuseAnonymousId: Bool = false,
+        flushAt: Int = 1
+    ) -> PostHogSDK {
+        let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+        config.captureApplicationLifecycleEvents = false
+        config.reuseAnonymousId = reuseAnonymousId
+        config.flushAt = flushAt
+        config.maxBatchSize = flushAt
+        config.disableFlushOnBackgroundForTesting = true
+        config.preloadFeatureFlags = false
+        let sut = PostHogSDK.with(config)
+        cleanupJobs.append {
+            sut.reset()
+            sut.close()
+            deleteSafely(applicationSupportDirectoryURL())
+        }
+        return sut
+    }
+
+    init() throws {
+        server = MockPostHogServer()
+        server.start()
+        cleanupJobs = []
+    }
+
+    deinit {
+        server.reset()
+        for cleanup in cleanupJobs {
+            cleanup()
+        }
+    }
+
+    @Test("initializes device_id on first setup")
+    func initializesDeviceIdOnFirstSetup() {
+        let sut = getSut()
+        let deviceId = sut.getDeviceId()
+        #expect(!deviceId.isEmpty)
+        #expect(deviceId == sut.getAnonymousId())
+    }
+
+    @Test("preserves device_id across identify()")
+    func preservesDeviceIdAcrossIdentify() {
+        let sut = getSut()
+        let originalDeviceId = sut.getDeviceId()
+
+        sut.identify("user-123")
+
+        #expect(sut.getDeviceId() == originalDeviceId)
+        #expect(sut.getDistinctId() == "user-123")
+    }
+
+    @Test("preserves device_id across reset()")
+    func preservesDeviceIdAcrossReset() {
+        let sut = getSut()
+        let originalDeviceId = sut.getDeviceId()
+
+        sut.identify("user-123")
+        sut.reset()
+
+        #expect(sut.getDeviceId() == originalDeviceId)
+        // distinct_id should have changed back to a new anonymous ID
+        #expect(sut.getDistinctId() != "user-123")
+    }
+
+    @Test("preserves device_id across multiple identify/reset cycles")
+    func preservesDeviceIdAcrossMultipleCycles() {
+        let sut = getSut()
+        let originalDeviceId = sut.getDeviceId()
+
+        sut.identify("user-1")
+        sut.reset()
+        sut.identify("user-2")
+        sut.reset()
+
+        #expect(sut.getDeviceId() == originalDeviceId)
+    }
+
+    @Test("sends $device_id in feature flag requests")
+    func sendsDeviceIdInFlagRequests() async {
+        let sut = getSut()
+        let deviceId = sut.getDeviceId()
+
+        await withCheckedContinuation { continuation in
+            sut.reloadFeatureFlags {
+                continuation.resume()
+            }
+        }
+
+        #expect(server.flagsRequests.count > 0)
+
+        guard let lastRequest = server.flagsRequests.last,
+              let requestBody = server.parseRequest(lastRequest, gzip: false)
+        else {
+            #expect(Bool(false), "Failed to parse flags request")
+            return
+        }
+
+        #expect(requestBody["$device_id"] as? String == deviceId)
+    }
+
+    @Test("sends the same $device_id after identify()")
+    func sendsSameDeviceIdAfterIdentify() async {
+        let sut = getSut()
+        let deviceId = sut.getDeviceId()
+
+        sut.identify("user-123")
+
+        await withCheckedContinuation { continuation in
+            sut.reloadFeatureFlags {
+                continuation.resume()
+            }
+        }
+
+        #expect(server.flagsRequests.count > 0)
+
+        guard let lastRequest = server.flagsRequests.last,
+              let requestBody = server.parseRequest(lastRequest, gzip: false)
+        else {
+            #expect(Bool(false), "Failed to parse flags request")
+            return
+        }
+
+        #expect(requestBody["$device_id"] as? String == deviceId)
+    }
+
+    @Test("persists device_id across SDK restarts")
+    func persistsDeviceIdAcrossSdkRestarts() {
+        var sut = getSut()
+        let originalDeviceId = sut.getDeviceId()
+        sut.close()
+
+        // Re-init with same storage (same API key hits the same storage path)
+        sut = getSut()
+        #expect(sut.getDeviceId() == originalDeviceId)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `$device_id` support to the iOS SDK so feature flags can bucket on a stable device identifier instead of `distinct_id`
- The device ID persists across `identify()` and `reset()` calls, preventing variant flipping during identity transitions (anonymous → authenticated, logout → re-login)
- Sends `$device_id` in `/flags` request payload, matching the JS SDK's behavior from PostHog/posthog-js#3340

## Problem

Users running experiments targeting anonymous users see variant assignments flip when `identify()` or `reset()` changes the `distinct_id`. The hash changes → different bucket → different variant for the same physical device.

## Changes

- **`PostHog/PostHogStorage.swift`**: Add `deviceId` to `StorageKey` enum (intentionally preserved across `reset()`)
- **`PostHog/PostHogStorageManager.swift`**: Add cached `deviceId` with thread-safe access, `getDeviceId()` with lazy-init for upgrades, and `initializeDeviceId()` for setup-time seeding
- **`PostHog/PostHogApi.swift`**: Include `$device_id` in `/flags` request payload when present
- **`PostHog/PostHogRemoteConfig.swift`**: Thread `deviceId` through `reloadFeatureFlags()` → `loadFeatureFlags()` → `api.flags()`
- **`PostHog/PostHogSDK.swift`**: Initialize `device_id` during `setup()`, expose public `getDeviceId()` method
- **`PostHogTests/PostHogDeviceBucketingTests.swift`**: 7 new tests covering init, persistence, identify/reset preservation, multiple cycles, flag request payload, and SDK restart

## Test plan

- [x] SDK builds cleanly (`swift build`)
- [x] SwiftLint passes
- [x] 7 new device bucketing tests written (test target has pre-existing compilation errors in unrelated files on `main`)
- [ ] Manual verification with a flag configured for device bucketing on the server side