### PR TITLE
chore: use renamed version/release on dsym upload

### DIFF
--- a/.changeset/ninety-monkeys-send.md
+++ b/.changeset/ninety-monkeys-send.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Use renamed version/release on dsym upload

--- a/build-tools/upload-symbols.sh
+++ b/build-tools/upload-symbols.sh
@@ -74,7 +74,23 @@ else
 fi
 
 if [ -z "$PH_CLI_PATH" ] || [ ! -x "$PH_CLI_PATH" ]; then
-    echo "error: posthog-cli not found, install with: npm install -g @posthog/cli"
+    echo "error: posthog-cli not found, install with: npm install -g @posthog/cli@latest"
+    exit 1
+fi
+
+# Enforce minimum posthog-cli version (required for --release-name / --release-version flags)
+MIN_POSTHOG_CLI_VERSION="0.7.7"
+PH_CLI_VERSION=$("$PH_CLI_PATH" --version 2>/dev/null | awk '{print $NF}' | tr -d 'v')
+
+if [ -z "$PH_CLI_VERSION" ]; then
+    echo "error: could not determine posthog-cli version. Upgrade: npm install -g @posthog/cli@latest"
+    exit 1
+fi
+
+# Compare versions: lowest sorted == min required means current >= min
+LOWEST=$(printf '%s\n%s\n' "$MIN_POSTHOG_CLI_VERSION" "$PH_CLI_VERSION" | sort -t. -k1,1n -k2,2n -k3,3n | head -n1)
+if [ "$LOWEST" != "$MIN_POSTHOG_CLI_VERSION" ]; then
+    echo "error: posthog-cli >= ${MIN_POSTHOG_CLI_VERSION} required (found ${PH_CLI_VERSION}). Upgrade: npm install -g @posthog/cli@latest"
     exit 1
 fi
 

--- a/build-tools/upload-symbols.sh
+++ b/build-tools/upload-symbols.sh
@@ -88,10 +88,10 @@ fi
 
 # Pass version info from Xcode build settings (overrides plist extraction)
 if [ -n "${PRODUCT_BUNDLE_IDENTIFIER}" ]; then
-    CLI_ARGS="$CLI_ARGS --project $PRODUCT_BUNDLE_IDENTIFIER"
+    CLI_ARGS="$CLI_ARGS --release-name $PRODUCT_BUNDLE_IDENTIFIER"
 fi
 if [ -n "${MARKETING_VERSION}" ]; then
-    CLI_ARGS="$CLI_ARGS --version $MARKETING_VERSION"
+    CLI_ARGS="$CLI_ARGS --release-version $MARKETING_VERSION"
 fi
 if [ -n "${CURRENT_PROJECT_VERSION}" ]; then
     CLI_ARGS="$CLI_ARGS --build $CURRENT_PROJECT_VERSION"


### PR DESCRIPTION
## :bulb: Motivation and Context
Uses renamed version/release on dsym upload addressed in https://github.com/PostHog/posthog/pull/54642
- [ ]  Wait for the above PR to merge

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [X] Ran `pnpm changeset` to generate a changeset file
- [X] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
