### PR TITLE
fix: revert version bump

### DIFF
--- a/.changeset/device-bucketing.md
+++ b/.changeset/device-bucketing.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": minor
+---
+
+Add device bucketing support for stable feature flag assignment across identity changes

--- a/.changeset/ninety-monkeys-send.md
+++ b/.changeset/ninety-monkeys-send.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Use renamed version/release on dsym upload

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,5 @@
 ## Next
 
-## 3.51.0
-
-### Minor Changes
-
-- 43769ea: Add device bucketing support for stable feature flag assignment across identity changes
-
-### Patch Changes
-
-- 43769ea: Use renamed version/release on dsym upload
-
 ## 3.50.0
 
 ### Minor Changes

--- a/PostHog.podspec
+++ b/PostHog.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PostHog"
-  s.version          = "3.51.0"
+  s.version          = "3.50.0"
   s.summary          = "The hassle-free way to add posthog to your iOS app."
 
   s.description      = <<-DESC

--- a/PostHog/PostHogVersion.swift
+++ b/PostHog/PostHogVersion.swift
@@ -9,7 +9,7 @@ import Foundation
 
 // if you change this, make sure to also change it in the podspec and check if the script scripts/bump-version.sh still works
 // This property is internal only
-public var postHogVersion = "3.51.0"
+public var postHogVersion = "3.50.0"
 
 public let postHogiOSSdkName = "posthog-ios"
 // This property is internal only

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog-ios",
-  "version": "3.51.0",
+  "version": "3.50.0",
   "private": true,
   "description": "This file exists solely for @changesets/cli to track the SDK version. It is not used for any Node.js functionality.",
   "packageManager": "pnpm@10.29.3",


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Reverting last version bump so we can then try https://github.com/PostHog/posthog-ios/pull/560 for Cocoapods release

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
