### PR TITLE
Remove PLCrashReporter dependency (conflicts with NewRelic)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,6 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/microsoft/plcrashreporter.git", from: "1.8.0"),
         .package(url: "https://github.com/Quick/Quick.git", from: "6.0.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "12.0.0"),
         .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.0.0"),
@@ -28,7 +27,6 @@ let package = Package(
             name: "PostHog",
             dependencies: [
                 "phlibwebp",
-                .product(name: "CrashReporter", package: "plcrashreporter", condition: .when(platforms: [.iOS, .macOS, .tvOS])),
             ],
             path: "PostHog",
             resources: [

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -15,7 +15,6 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/microsoft/plcrashreporter.git", from: "1.8.0"),
         .package(url: "https://github.com/Quick/Quick.git", from: "6.0.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "12.0.0"),
         .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.0.0"),
@@ -27,7 +26,6 @@ let package = Package(
             name: "PostHog",
             dependencies: [
                 "phlibwebp",
-                .product(name: "CrashReporter", package: "plcrashreporter", condition: .when(platforms: [.iOS, .macOS, .tvOS])),
             ],
             path: "PostHog",
             resources: [

--- a/PostHog/ErrorTracking/PostHogCrashReportProcessor.swift
+++ b/PostHog/ErrorTracking/PostHogCrashReportProcessor.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-#if os(iOS) || os(macOS) || os(tvOS)
+#if canImport(CrashReporter) && (os(iOS) || os(macOS) || os(tvOS))
     import CrashReporter
 
     enum PostHogCrashReportProcessor {

--- a/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
+++ b/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-#if os(iOS) || os(macOS) || os(tvOS)
+#if canImport(CrashReporter) && (os(iOS) || os(macOS) || os(tvOS))
     import CrashReporter
 
     class PostHogErrorTrackingAutoCaptureIntegration: PostHogIntegration {


### PR DESCRIPTION
- Remove plcrashreporter from Package.swift and Package@swift-5.9.swift dependencies and target dependencies
- Guard CrashReporter imports with #if canImport(CrashReporter) so the code compiles cleanly without the module; crash-processing becomes a no-op (falls through to the existing watchOS stub)

Made-with: Cursor

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
