### PR TITLE
chore: use client-id for create-github-app-token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         id: releaser
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GH_APP_POSTHOG_IOS_RELEASER_APP_ID }}
+          client-id: ${{ secrets.GH_APP_POSTHOG_IOS_RELEASER_APP_ID }}
           private-key: ${{ secrets.GH_APP_POSTHOG_IOS_RELEASER_PRIVATE_KEY }}
 
       - name: Checkout repository


### PR DESCRIPTION
## :bulb: Motivation and Context
GitHub Actions now warns that `app-id` is deprecated in `actions/create-github-app-token`.
This updates the release workflow to use `client-id` and bumps the action to v3 where needed.

## :green_heart: How did you test it?
- ran `git diff --check`

## :pencil: Checklist
- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Added the `release` label to the PR
- [ ] Ran `pnpm changeset` to generate a changeset file
