### PR TITLE
docs: align contributing guide with CI checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,25 @@
 # Contributing
 
-If you would like to contribute code to `posthog-ios` you can do so through
-GitHub by forking the repository and opening a pull request against `main`.
+If you would like to contribute code to `posthog-ios` you can do so through GitHub by forking the repository and opening a pull request against `main`.
 
-## Development Guide
+## Development guide
 
-1. Install Xcode
-2. Open the **file** `PostHog.xcodeproj` project in Xcode
-3. Run `make bootstrap` to install all dependencies.
+1. Install Xcode.
+2. Run `make bootstrap` to install the required development tools.
+3. Use the same core checks that CI runs before opening a pull request:
 
-When submitting code, please make every effort to follow existing conventions
-and style in order to keep the code as readable as possible. Please also make
-sure your code compiles by `make build`. In addition please consider adding
-unit tests covering your change, this will make your change much more likely to be accepted
+```bash
+make lint
+make test
+make buildSdk
+```
+
+- `make lint` runs the formatting and lint checks used in CI.
+- `make test` runs the SDK test suite.
+- `make buildSdk` verifies the SDK builds across supported platforms.
+
+If you prefer to work in Xcode, open `PostHog.xcodeproj`.
+
+When submitting code, please make every effort to follow existing conventions and style in order to keep the code as readable as possible. Please also consider adding unit tests covering your change, as this makes your change much more likely to be accepted.
 
 Above all, thank you for contributing!


### PR DESCRIPTION
## :bulb: Motivation and Context

The contributing guide mentioned setup and a general build command, but it did not clearly reflect the current CI lint, test, and build workflows.

This PR updates `CONTRIBUTING.md` so the recommended local verification steps match the commands we run in GitHub Actions.

## :green_heart: How did you test it?

- Not run (docs-only changes)
- Compared the updated commands against `.github/workflows/lint.yml`, `.github/workflows/test.yml`, and `.github/workflows/build.yml`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the `release` label to the PR
