### PR TITLE
fix: trim whitespace from API keys and host config

### DIFF
--- a/.changeset/trim-whitespace-config-values.md
+++ b/.changeset/trim-whitespace-config-values.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': patch
+---
+
+Trim surrounding whitespace from apiKey and host config before using them.

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -218,7 +218,12 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
     public init(
         apiKey: String
     ) {
-        self.apiKey = apiKey
+        let normalizedApiKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalizedApiKey.isEmpty {
+            hedgeLog("apiKey is empty after trimming whitespace; check your project API key")
+        }
+
+        self.apiKey = normalizedApiKey
         host = URL(string: PostHogConfig.defaultHost)!
     }
 
@@ -227,8 +232,15 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
         apiKey: String,
         host: String = defaultHost
     ) {
-        self.apiKey = apiKey
-        self.host = URL(string: host) ?? URL(string: PostHogConfig.defaultHost)!
+        let normalizedApiKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalizedApiKey.isEmpty {
+            hedgeLog("apiKey is empty after trimming whitespace; check your project API key")
+        }
+
+        let normalizedHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        self.apiKey = normalizedApiKey
+        self.host = URL(string: normalizedHost.isEmpty ? PostHogConfig.defaultHost : normalizedHost) ?? URL(string: PostHogConfig.defaultHost)!
     }
 
     /// Returns an array of integrations to be installed based on current configuration

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -214,16 +214,19 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
     // internal
     public var storageManager: PostHogStorageManager?
 
-    @objc(apiKey:)
-    public init(
-        apiKey: String
-    ) {
+    private static func normalizeApiKey(_ apiKey: String) -> String {
         let normalizedApiKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         if normalizedApiKey.isEmpty {
             hedgeLog("apiKey is empty after trimming whitespace; check your project API key")
         }
+        return normalizedApiKey
+    }
 
-        self.apiKey = normalizedApiKey
+    @objc(apiKey:)
+    public init(
+        apiKey: String
+    ) {
+        self.apiKey = Self.normalizeApiKey(apiKey)
         host = URL(string: PostHogConfig.defaultHost)!
     }
 
@@ -232,14 +235,9 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
         apiKey: String,
         host: String = defaultHost
     ) {
-        let normalizedApiKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
-        if normalizedApiKey.isEmpty {
-            hedgeLog("apiKey is empty after trimming whitespace; check your project API key")
-        }
-
         let normalizedHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        self.apiKey = normalizedApiKey
+        self.apiKey = Self.normalizeApiKey(apiKey)
         self.host = URL(string: normalizedHost.isEmpty ? PostHogConfig.defaultHost : normalizedHost) ?? URL(string: PostHogConfig.defaultHost)!
     }
 

--- a/PostHogTests/PostHogConfigTest.swift
+++ b/PostHogTests/PostHogConfigTest.swift
@@ -35,6 +35,22 @@ class PostHogConfigTest: QuickSpec {
             expect(config.apiKey) == testAPIKey
         }
 
+        it("trims whitespace-sensitive config values") {
+            let config = PostHogConfig(
+                apiKey: " \n\(testAPIKey)\t ",
+                host: " \nhttps://eu.i.posthog.com/\t "
+            )
+
+            expect(config.apiKey) == testAPIKey
+            expect(config.host) == URL(string: "https://eu.i.posthog.com/")
+        }
+
+        it("defaults a blank host after trimming whitespace") {
+            let config = PostHogConfig(apiKey: testAPIKey, host: " \n\t ")
+
+            expect(config.host) == URL(string: PostHogConfig.defaultHost)
+        }
+
         it("init takes host") {
             let config = PostHogConfig(apiKey: testAPIKey, host: "localhost:9000")
 


### PR DESCRIPTION
## :bulb: Motivation and Context
This ports the whitespace-trimming fix from `posthog-go` to `posthog-ios`. It trims surrounding spaces and line breaks from the project API key and host before using them so the SDK does not silently initialize with invalid tokens or malformed hosts.

## :green_heart: How did you test it?
- `xcodebuildmcp macos build --project-path PostHog.xcodeproj --scheme PostHog`
- Added regression coverage in `PostHogTests/PostHogConfigTest.swift`
- `xcodebuildmcp macos test --project-path PostHog.xcodeproj --scheme PostHogTests --json '{"extraArgs":["-only-testing:PostHogTests/PostHogConfigTest"]}'` currently still fails on unrelated pre-existing `PostHogIntegrationInstallationTest` / `ApplicationViewLayoutPublisherTest` compile errors on `main`, before this new test can run

## :pencil: Checklist
- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
