### PR TITLE
feat: Add tracing headers for URLSession requests

### DIFF
--- a/.changeset/quiet-otters-reply.md
+++ b/.changeset/quiet-otters-reply.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': minor
+---
+
+Add tracing header injection for URLSession requests.

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		3AE3FB37299162EA00AFFC18 /* PostHogApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE3FB36299162EA00AFFC18 /* PostHogApi.swift */; };
 		3AE3FB3D29924E8200AFFC18 /* PostHogSDK.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE3FB3C29924E8200AFFC18 /* PostHogSDK.swift */; };
 		3AE3FB3F29924F4F00AFFC18 /* PostHogConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE3FB3E29924F4F00AFFC18 /* PostHogConfig.swift */; };
+		DB7100012F80000100000001 /* PostHogTracingHeadersIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7100022F80000100000001 /* PostHogTracingHeadersIntegration.swift */; };
 		3AE3FB432992985A00AFFC18 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE3FB422992985A00AFFC18 /* Reachability.swift */; };
 		3AE3FB472992AB0000AFFC18 /* Hedgelog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE3FB462992AB0000AFFC18 /* Hedgelog.swift */; };
 		3AE3FB49299391DF00AFFC18 /* PostHogStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE3FB48299391DF00AFFC18 /* PostHogStorage.swift */; };
@@ -105,7 +106,6 @@
 		69F518382BB2BA0100F52C14 /* PostHogSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69F518372BB2BA0100F52C14 /* PostHogSwizzler.swift */; };
 		A1B2C3D401234567DEADBEEF /* PostHogDeepLinkHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D501234567DEADBEEF /* PostHogDeepLinkHelper.swift */; };
 		A1B2C3D601234567DEADBEEF /* PostHogDeepLinkListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D701234567DEADBEEF /* PostHogDeepLinkListener.swift */; };
-		A1B2C3D801234567DEADBEEF /* PostHogDeepLinkIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D901234567DEADBEEF /* PostHogDeepLinkIntegrationTests.swift */; };
 		CL000001CDE129010001FF01 /* PostHogFeatureFlagResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = CL000001CDE129010001FF00 /* PostHogFeatureFlagResult.swift */; };
 		DA0B66A52D64EC00006F5FF3 /* ph_sharpyuv_csp.h in Headers */ = {isa = PBXBuildFile; fileRef = DA0B66982D64EC00006F5FF3 /* ph_sharpyuv_csp.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA0B66A62D64EC00006F5FF3 /* ph_sharpyuv_dsp.h in Headers */ = {isa = PBXBuildFile; fileRef = DA0B66992D64EC00006F5FF3 /* ph_sharpyuv_dsp.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -174,6 +174,7 @@
 		DA27AE712F56050B002A59CE /* SessionRecordingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA27AE702F56050B002A59CE /* SessionRecordingView.swift */; };
 		DA27AEC12F56B3E3002A59CE /* PostHogSessionReplayEventTriggersTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA27AEC02F56B3E3002A59CE /* PostHogSessionReplayEventTriggersTest.swift */; };
 		DA27AEC92F56B3F3002A59CE /* PostHogSamplingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA27AEC82F56B3F3002A59CE /* PostHogSamplingTest.swift */; };
+		DB7100042F80000100000001 /* PostHogTracingHeadersTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7100052F80000100000001 /* PostHogTracingHeadersTest.swift */; };
 		DA30AE692D3EFB4F00465A64 /* Optional+Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA30AE682D3EFB4F00465A64 /* Optional+Util.swift */; };
 		DA30AE812D3FE63F00465A64 /* PostHogSurvey.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA30AE802D3FE63F00465A64 /* PostHogSurvey.swift */; };
 		DA37933C2DBA571D005C6AA3 /* PostHogSurveysConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3793352DBA5718005C6AA3 /* PostHogSurveysConfig.swift */; };
@@ -590,6 +591,7 @@
 		3AE3FB36299162EA00AFFC18 /* PostHogApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogApi.swift; sourceTree = "<group>"; };
 		3AE3FB3C29924E8200AFFC18 /* PostHogSDK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSDK.swift; sourceTree = "<group>"; };
 		3AE3FB3E29924F4F00AFFC18 /* PostHogConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogConfig.swift; sourceTree = "<group>"; };
+		DB7100022F80000100000001 /* PostHogTracingHeadersIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogTracingHeadersIntegration.swift; sourceTree = "<group>"; };
 		3AE3FB422992985A00AFFC18 /* Reachability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
 		3AE3FB462992AB0000AFFC18 /* Hedgelog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hedgelog.swift; sourceTree = "<group>"; };
 		3AE3FB48299391DF00AFFC18 /* PostHogStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogStorage.swift; sourceTree = "<group>"; };
@@ -680,7 +682,6 @@
 		69F518372BB2BA0100F52C14 /* PostHogSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSwizzler.swift; sourceTree = "<group>"; };
 		A1B2C3D501234567DEADBEEF /* PostHogDeepLinkHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogDeepLinkHelper.swift; sourceTree = "<group>"; };
 		A1B2C3D701234567DEADBEEF /* PostHogDeepLinkListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogDeepLinkListener.swift; sourceTree = "<group>"; };
-		A1B2C3D901234567DEADBEEF /* PostHogDeepLinkIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogDeepLinkIntegrationTests.swift; sourceTree = "<group>"; };
 		CL000001CDE129010001FF00 /* PostHogFeatureFlagResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogFeatureFlagResult.swift; sourceTree = "<group>"; };
 		DA0B66792D64EC00006F5FF3 /* ph_backward_references_enc.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ph_backward_references_enc.h; sourceTree = "<group>"; };
 		DA0B667A2D64EC00006F5FF3 /* ph_bit_reader_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ph_bit_reader_utils.h; sourceTree = "<group>"; };
@@ -749,6 +750,7 @@
 		DA27AE702F56050B002A59CE /* SessionRecordingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRecordingView.swift; sourceTree = "<group>"; };
 		DA27AEC02F56B3E3002A59CE /* PostHogSessionReplayEventTriggersTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSessionReplayEventTriggersTest.swift; sourceTree = "<group>"; };
 		DA27AEC82F56B3F3002A59CE /* PostHogSamplingTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSamplingTest.swift; sourceTree = "<group>"; };
+		DB7100052F80000100000001 /* PostHogTracingHeadersTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogTracingHeadersTest.swift; sourceTree = "<group>"; };
 		DA30AE682D3EFB4F00465A64 /* Optional+Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Util.swift"; sourceTree = "<group>"; };
 		DA30AE802D3FE63F00465A64 /* PostHogSurvey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSurvey.swift; sourceTree = "<group>"; };
 		DA3793352DBA5718005C6AA3 /* PostHogSurveysConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSurveysConfig.swift; sourceTree = "<group>"; };
@@ -1178,6 +1180,7 @@
 				693E977A2C625208004B1030 /* PostHogPropertiesSanitizer.swift */,
 				69ED1A5B2C7F15F300FE7A91 /* PostHogSessionManager.swift */,
 				69ED1A9E2C8F451B00FE7A91 /* PostHogPersonProfiles.swift */,
+				DB7100032F80000100000001 /* Tracing */,
 				DAB565D82D14C51E0088F720 /* SwiftUI */,
 			);
 			path = PostHog;
@@ -1187,6 +1190,7 @@
 			isa = PBXGroup;
 			children = (
 				DA27AEC82F56B3F3002A59CE /* PostHogSamplingTest.swift */,
+				DB7100052F80000100000001 /* PostHogTracingHeadersTest.swift */,
 				DA27AEC02F56B3E3002A59CE /* PostHogSessionReplayEventTriggersTest.swift */,
 				1F55581F2DFC47E8007643C0 /* PostHogStorageMergeTest.swift */,
 				DA4FFBB42DAD5AF9006BAEEA /* PostHogIdentityTests.swift */,
@@ -1207,7 +1211,6 @@
 				690FF0E22AEFD12900A0B06B /* PostHogConfigTest.swift */,
 				690FF0E82AEFD3BD00A0B06B /* PostHogQueueTest.swift */,
 				690FF0F42AF0F06100A0B06B /* PostHogSDKTest.swift */,
-				A1B2C3D901234567DEADBEEF /* PostHogDeepLinkIntegrationTests.swift */,
 				DA6F24812D4A6CA100CA2777 /* PostHogApiTest.swift */,
 				DA578E9D2D6858B200B3A56C /* PostHogScreenViewIntegrationTest.swift */,
 				DACF6D5C2CD2F5BC00F14133 /* PostHogAutocaptureIntegrationSpec.swift */,
@@ -1701,6 +1704,14 @@
 				A1B2C3D701234567DEADBEEF /* PostHogDeepLinkListener.swift */,
 			);
 			path = SwiftUI;
+			sourceTree = "<group>";
+		};
+		DB7100032F80000100000001 /* Tracing */ = {
+			isa = PBXGroup;
+			children = (
+				DB7100022F80000100000001 /* PostHogTracingHeadersIntegration.swift */,
+			);
+			path = Tracing;
 			sourceTree = "<group>";
 		};
 		DAB9E23B2DE8901D00E62DB9 /* Network */ = {
@@ -2240,6 +2251,7 @@
 				69F517EA2BAC684F00F52C14 /* RRStyle.swift in Sources */,
 				DA0CA6F12CFF6B6300AF9500 /* UIWindow+.swift in Sources */,
 				DAB9E23C2DE8901D00E62DB9 /* PostHogSessionReplayNetworkPlugin.swift in Sources */,
+				DB7100012F80000100000001 /* PostHogTracingHeadersIntegration.swift in Sources */,
 				DAB9E23D2DE8901D00E62DB9 /* URLSessionExtension.swift in Sources */,
 				DAB9E23E2DE8901D00E62DB9 /* URLSessionSwizzler.swift in Sources */,
 				DAB9E23F2DE8901D00E62DB9 /* URLSessionInterceptor.swift in Sources */,
@@ -2457,7 +2469,6 @@
 				DA979D7B2CD370B700F56BAE /* PostHogAutocaptureEventTrackerSpec.swift in Sources */,
 				DA0C944B2D54CDD000BFD9FB /* PostHogStorageMigrationTest.swift in Sources */,
 				690FF0F52AF0F06100A0B06B /* PostHogSDKTest.swift in Sources */,
-				A1B2C3D801234567DEADBEEF /* PostHogDeepLinkIntegrationTests.swift in Sources */,
 				690FF0E12AEFC59100A0B06B /* PostHogFileBackedQueueTest.swift in Sources */,
 				DA578E9C2D68578500B3A56C /* MockApplicationLifecyclePublisher.swift in Sources */,
 				DA4FFBB52DAD5B01006BAEEA /* PostHogIdentityTests.swift in Sources */,
@@ -2493,6 +2504,7 @@
 				3AE3FB4B2993A68500AFFC18 /* PostHogStorageTest.swift in Sources */,
 				DAD39DF62D56178D002A1A69 /* UtilsTest.swift in Sources */,
 				DA27AEC92F56B3F3002A59CE /* PostHogSamplingTest.swift in Sources */,
+				DB7100042F80000100000001 /* PostHogTracingHeadersTest.swift in Sources */,
 				3A580B4329E489D000C5C6F3 /* URLSession+body.swift in Sources */,
 				DA1D29602D10C810003A31DA /* PostHogSessionManagerTest.swift in Sources */,
 				DA703C1E2D6634770069097B /* PostHogAppLifeCycleIntegrationTest.swift in Sources */,

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -188,7 +188,7 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
         /// - Hostname matching is exact and does not include ports or subdomain wildcards
         /// - iOS does not send `X-POSTHOG-WINDOW-ID` because mobile apps do not have a per-window/tab concept
         /// - Existing values for these headers will be overwritten
-        @objc public var addTracingHeaders: [String]?
+        @objc public var tracingHeaders: [String]?
 
         /// Enable Recording of Session Replays for iOS
         ///
@@ -310,7 +310,7 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
         }
 
         #if os(iOS)
-            if addTracingHeaders?.isEmpty == false {
+            if tracingHeaders?.isEmpty == false {
                 integrations.append(PostHogTracingHeadersIntegration())
             }
 

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -176,6 +176,20 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
     public static let defaultHost: String = "https://us.i.posthog.com"
 
     #if os(iOS)
+        /// When set, PostHog injects tracing headers into `URLSession` requests whose
+        /// destination hostname exactly matches one of the configured hostnames.
+        ///
+        /// Injected headers on iOS:
+        /// - `X-POSTHOG-DISTINCT-ID`
+        /// - `X-POSTHOG-SESSION-ID`
+        ///
+        /// Notes:
+        /// - Requires `enableSwizzling = true`
+        /// - Hostname matching is exact and does not include ports or subdomain wildcards
+        /// - iOS does not send `X-POSTHOG-WINDOW-ID` because mobile apps do not have a per-window/tab concept
+        /// - Existing values for these headers will be overwritten
+        @objc public var addTracingHeaders: [String]?
+
         /// Enable Recording of Session Replays for iOS
         ///
         /// Note: Ingestion controls (sampling, feature flags, and event triggers) are currently applied using AND logic.
@@ -296,6 +310,10 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
         }
 
         #if os(iOS)
+            if addTracingHeaders?.isEmpty == false {
+                integrations.append(PostHogTracingHeadersIntegration())
+            }
+
             if sessionReplay {
                 integrations.append(PostHogReplayIntegration())
             }

--- a/PostHog/Replay/Plugins/Network/PostHogSessionReplayNetworkPlugin.swift
+++ b/PostHog/Replay/Plugins/Network/PostHogSessionReplayNetworkPlugin.swift
@@ -22,6 +22,9 @@
 
             let interceptor = URLSessionInterceptor(
                 shouldCapture: shouldCaptureNetworkSample,
+                shouldCaptureRequest: { [weak self] request in
+                    self?.shouldCaptureNetworkRequest(request) ?? false
+                },
                 onCapture: handleNetworkSample,
                 getSessionId: { [weak self] date in
                     self?.postHog?.sessionManager.getSessionId(at: date)
@@ -90,9 +93,103 @@
             return false
         }
 
+        /// Mirrors the browser SDK's replay network capture filtering by ignoring
+        /// PostHog's own ingestion requests relative to the configured API host.
+        static func shouldIgnoreNetworkRequest(url: URL?, apiHost: URL, snapshotEndpoint: String) -> Bool {
+            guard let url, matchesAPIHost(url, apiHost: apiHost) else {
+                return false
+            }
+
+            let path = strippingAPIHostPathPrefix(from: url.path, apiHostPath: apiHost.path)
+            let ignoredPaths = [snapshotEndpoint, "/batch", "/e/", "/i/"]
+
+            return ignoredPaths.contains { ignoredPath in
+                pathMatches(path, ignoredPath: ignoredPath)
+            }
+        }
+
+        private static func matchesAPIHost(_ url: URL, apiHost: URL) -> Bool {
+            url.scheme?.lowercased() == apiHost.scheme?.lowercased()
+                && url.host?.lowercased() == apiHost.host?.lowercased()
+                && effectivePort(for: url) == effectivePort(for: apiHost)
+        }
+
+        private static func effectivePort(for url: URL) -> Int? {
+            if let port = url.port {
+                return port
+            }
+
+            switch url.scheme?.lowercased() {
+            case "http":
+                return 80
+            case "https":
+                return 443
+            default:
+                return nil
+            }
+        }
+
+        private static func strippingAPIHostPathPrefix(from path: String, apiHostPath: String) -> String {
+            let normalizedAPIHostPath = normalizedAPIHostPathPrefix(apiHostPath)
+
+            guard !normalizedAPIHostPath.isEmpty,
+                  path == normalizedAPIHostPath || path.hasPrefix("\(normalizedAPIHostPath)/")
+            else {
+                return path
+            }
+
+            let strippedPath = String(path.dropFirst(normalizedAPIHostPath.count))
+            if strippedPath.isEmpty {
+                return "/"
+            }
+
+            return strippedPath.hasPrefix("/") ? strippedPath : "/\(strippedPath)"
+        }
+
+        private static func normalizedAPIHostPathPrefix(_ path: String) -> String {
+            guard !path.isEmpty, path != "/" else {
+                return ""
+            }
+
+            return path.hasSuffix("/") ? String(path.dropLast()) : path
+        }
+
+        private static func pathMatches(_ path: String, ignoredPath: String) -> Bool {
+            let normalizedIgnoredPath = normalizedIgnoredPathPrefix(ignoredPath)
+            guard !normalizedIgnoredPath.isEmpty else {
+                return false
+            }
+
+            if normalizedIgnoredPath.hasSuffix("/") {
+                let exactPath = String(normalizedIgnoredPath.dropLast())
+                return path == exactPath || path.hasPrefix(normalizedIgnoredPath)
+            }
+
+            return path == normalizedIgnoredPath || path.hasPrefix("\(normalizedIgnoredPath)/")
+        }
+
+        private static func normalizedIgnoredPathPrefix(_ path: String) -> String {
+            let trimmedPath = path.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedPath.isEmpty else {
+                return ""
+            }
+
+            return trimmedPath.hasPrefix("/") ? trimmedPath : "/\(trimmedPath)"
+        }
+
         private func shouldCaptureNetworkSample() -> Bool {
             guard let postHog else { return false }
             return isActive && postHog.config.sessionReplayConfig.captureNetworkTelemetry && postHog.isSessionReplayActive()
+        }
+
+        private func shouldCaptureNetworkRequest(_ request: URLRequest) -> Bool {
+            guard let postHog else { return false }
+
+            return !Self.shouldIgnoreNetworkRequest(
+                url: request.url,
+                apiHost: postHog.config.host,
+                snapshotEndpoint: postHog.config.snapshotEndpoint
+            )
         }
 
         private func handleNetworkSample(sample: NetworkSample) {

--- a/PostHog/Replay/Plugins/Network/PostHogSessionReplayNetworkPlugin.swift
+++ b/PostHog/Replay/Plugins/Network/PostHogSessionReplayNetworkPlugin.swift
@@ -10,7 +10,8 @@
 
     /// Session replay plugin that captures network requests using URLSession swizzling.
     final class PostHogSessionReplayNetworkPlugin: PostHogSessionReplayPlugin {
-        private var sessionSwizzler: URLSessionSwizzler?
+        private var interceptor: URLSessionInterceptor?
+        private var registrationId: UUID?
         private weak var postHog: PostHogSDK?
         private var isActive = false
 
@@ -18,15 +19,25 @@
 
         func start(postHog: PostHogSDK) {
             self.postHog = postHog
+
+            let interceptor = URLSessionInterceptor(
+                shouldCapture: shouldCaptureNetworkSample,
+                onCapture: handleNetworkSample,
+                getSessionId: { [weak self] date in
+                    self?.postHog?.sessionManager.getSessionId(at: date)
+                }
+            )
+
             do {
-                sessionSwizzler = try URLSessionSwizzler(
-                    shouldCapture: shouldCaptureNetworkSample,
-                    onCapture: handleNetworkSample,
-                    getSessionId: { [weak self] date in
-                        self?.postHog?.sessionManager.getSessionId(at: date)
+                registrationId = try URLSessionInstrumentation.shared.register(
+                    taskCreated: { [weak interceptor] task, session in
+                        interceptor?.taskCreated(task: task, session: session)
+                    },
+                    taskCompleted: { [weak interceptor] task, error in
+                        interceptor?.taskCompleted(task: task, error: error)
                     }
                 )
-                sessionSwizzler?.swizzle()
+                self.interceptor = interceptor
                 hedgeLog("[Session Replay] Network telemetry plugin started")
                 isActive = true
             } catch {
@@ -35,8 +46,12 @@
         }
 
         func stop() {
-            sessionSwizzler?.unswizzle()
-            sessionSwizzler = nil
+            if let registrationId {
+                URLSessionInstrumentation.shared.unregister(registrationId)
+            }
+            registrationId = nil
+            interceptor?.stop()
+            interceptor = nil
             postHog = nil
             isActive = false
             hedgeLog("[Session Replay] Network telemetry plugin stopped")

--- a/PostHog/Replay/Plugins/Network/URLSessionInterceptor.swift
+++ b/PostHog/Replay/Plugins/Network/URLSessionInterceptor.swift
@@ -11,11 +11,18 @@
     class URLSessionInterceptor {
         private let tasksLock = NSLock()
         private let shouldCapture: () -> Bool
+        private let shouldCaptureRequest: (URLRequest) -> Bool
         private let onCapture: (NetworkSample) -> Void
         private let getSessionId: (Date) -> String?
 
-        init(shouldCapture: @escaping () -> Bool, onCapture: @escaping (NetworkSample) -> Void, getSessionId: @escaping (Date) -> String?) {
+        init(
+            shouldCapture: @escaping () -> Bool,
+            shouldCaptureRequest: @escaping (URLRequest) -> Bool,
+            onCapture: @escaping (NetworkSample) -> Void,
+            getSessionId: @escaping (Date) -> String?
+        ) {
             self.shouldCapture = shouldCapture
+            self.shouldCaptureRequest = shouldCaptureRequest
             self.onCapture = onCapture
             self.getSessionId = getSessionId
         }
@@ -34,7 +41,7 @@
                 return
             }
 
-            guard let request = task.originalRequest else {
+            guard let request = task.originalRequest, shouldCaptureRequest(request) else {
                 return
             }
 

--- a/PostHog/Replay/Plugins/Network/URLSessionSwizzler.swift
+++ b/PostHog/Replay/Plugins/Network/URLSessionSwizzler.swift
@@ -10,40 +10,236 @@
 
     import Foundation
 
+    final class URLSessionInstrumentation {
+        typealias RequestModifier = (URLRequest) -> URLRequest
+        typealias TaskCreatedHandler = (URLSessionTask, URLSession?) -> Void
+        typealias TaskCompletedHandler = (URLSessionTask, Error?) -> Void
+
+        static let shared = URLSessionInstrumentation()
+
+        private static let requestModifiedKey = "com.posthog.URLSessionInstrumentation.requestModified"
+
+        private struct Registration {
+            let requestModifier: RequestModifier?
+            let taskCreated: TaskCreatedHandler?
+            let taskCompleted: TaskCompletedHandler?
+        }
+
+        private let lock = NSLock()
+        private var registrations: [UUID: Registration] = [:]
+        private var swizzler: URLSessionSwizzler?
+
+        private init() {}
+
+        func register(
+            requestModifier: RequestModifier? = nil,
+            taskCreated: TaskCreatedHandler? = nil,
+            taskCompleted: TaskCompletedHandler? = nil
+        ) throws -> UUID {
+            let id = UUID()
+            let registration = Registration(
+                requestModifier: requestModifier,
+                taskCreated: taskCreated,
+                taskCompleted: taskCompleted
+            )
+
+            let shouldInstallSwizzler = lock.withLock {
+                let shouldInstall = registrations.isEmpty
+                registrations[id] = registration
+                return shouldInstall
+            }
+
+            guard shouldInstallSwizzler else {
+                return id
+            }
+
+            do {
+                let swizzler = try URLSessionSwizzler(
+                    modifyRequest: { [weak self] request in
+                        self?.modifyRequest(request) ?? request
+                    },
+                    onTaskCreated: { [weak self] task, session in
+                        self?.notifyTaskCreated(task: task, session: session)
+                    },
+                    onTaskCompleted: { [weak self] task, error in
+                        self?.notifyTaskCompleted(task: task, error: error)
+                    }
+                )
+                swizzler.swizzle()
+                lock.withLock {
+                    self.swizzler = swizzler
+                }
+                return id
+            } catch {
+                lock.withLock {
+                    registrations.removeValue(forKey: id)
+                }
+                throw error
+            }
+        }
+
+        func unregister(_ id: UUID) {
+            var swizzlerToRemove: URLSessionSwizzler?
+
+            lock.withLock {
+                registrations.removeValue(forKey: id)
+                if registrations.isEmpty {
+                    swizzlerToRemove = swizzler
+                    swizzler = nil
+                }
+            }
+
+            swizzlerToRemove?.unswizzle()
+        }
+
+        private func modifyRequest(_ request: URLRequest) -> URLRequest {
+            guard URLProtocol.property(forKey: Self.requestModifiedKey, in: request) == nil else {
+                return request
+            }
+
+            let modifiers = lock.withLock {
+                registrations.values.compactMap(\.requestModifier)
+            }
+
+            guard !modifiers.isEmpty else {
+                return request
+            }
+
+            let modifiedRequest = modifiers.reduce(request) { currentRequest, modifier in
+                modifier(currentRequest)
+            }
+
+            guard let mutableRequest = (modifiedRequest as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
+                return modifiedRequest
+            }
+
+            URLProtocol.setProperty(true, forKey: Self.requestModifiedKey, in: mutableRequest)
+            return mutableRequest as URLRequest
+        }
+
+        private func notifyTaskCreated(task: URLSessionTask, session: URLSession?) {
+            let handlers = lock.withLock {
+                registrations.values.compactMap(\.taskCreated)
+            }
+
+            for handler in handlers {
+                handler(task, session)
+            }
+        }
+
+        private func notifyTaskCompleted(task: URLSessionTask, error: Error?) {
+            let handlers = lock.withLock {
+                registrations.values.compactMap(\.taskCompleted)
+            }
+
+            for handler in handlers {
+                handler(task, error)
+            }
+        }
+    }
+
     class URLSessionSwizzler {
-        /// `URLSession.dataTask(with:completionHandler:)` (for `URLRequest`) swizzling.
+        typealias DataCompletionHandler = (Data?, URLResponse?, Error?) -> Void
+        typealias DownloadCompletionHandler = (URL?, URLResponse?, Error?) -> Void
+
         private let dataTaskWithURLRequestAndCompletion: DataTaskWithURLRequestAndCompletion
-        /// `URLSession.dataTask(with:)` (for `URLRequest`) swizzling.
         private let dataTaskWithURLRequest: DataTaskWithURLRequest
+        private let dataTaskWithURLAndCompletion: DataTaskWithURLAndCompletion
+        private let dataTaskWithURL: DataTaskWithURL
 
-        /// `URLSession.dataTask(with:completionHandler:)` (for `URL`) swizzling. Only applied on iOS 13 and above.
-        private let dataTaskWithURLAndCompletion: DataTaskWithURLAndCompletion?
-        /// `URLSession.dataTask(with:)` (for `URL`) swizzling. Only applied on iOS 13 and above.
-        private let dataTaskWithURL: DataTaskWithURL?
+        private let uploadTaskWithRequestAndDataAndCompletion: UploadTaskWithRequestAndDataAndCompletion
+        private let uploadTaskWithRequestAndFileAndCompletion: UploadTaskWithRequestAndFileAndCompletion
+        private let uploadTaskWithStreamedRequest: UploadTaskWithStreamedRequest
+        private let uploadTaskWithRequestAndData: UploadTaskWithRequestAndData
+        private let uploadTaskWithRequestAndFile: UploadTaskWithRequestAndFile
 
-        private let interceptor: URLSessionInterceptor
+        private let downloadTaskWithRequestAndCompletion: DownloadTaskWithRequestAndCompletion
+        private let downloadTaskWithURLAndCompletion: DownloadTaskWithURLAndCompletion
+        private let downloadTaskWithRequest: DownloadTaskWithRequest
+        private let downloadTaskWithURL: DownloadTaskWithURL
+        private let taskResume: TaskResume?
 
         private var hasSwizzled = false
 
-        init(shouldCapture: @escaping () -> Bool, onCapture: @escaping (NetworkSample) -> Void, getSessionId: @escaping (Date) -> String?) throws {
-            interceptor = URLSessionInterceptor(
-                shouldCapture: shouldCapture,
-                onCapture: onCapture,
-                getSessionId: getSessionId
+        init(
+            modifyRequest: @escaping (URLRequest) -> URLRequest,
+            onTaskCreated: @escaping (URLSessionTask, URLSession?) -> Void,
+            onTaskCompleted: @escaping (URLSessionTask, Error?) -> Void
+        ) throws {
+            dataTaskWithURLRequestAndCompletion = try DataTaskWithURLRequestAndCompletion.build(
+                modifyRequest: modifyRequest,
+                onTaskCreated: onTaskCreated,
+                onTaskCompleted: onTaskCompleted
+            )
+            dataTaskWithURLRequest = try DataTaskWithURLRequest.build(
+                modifyRequest: modifyRequest,
+                onTaskCreated: onTaskCreated
+            )
+            dataTaskWithURLAndCompletion = try DataTaskWithURLAndCompletion.build(modifyRequest: modifyRequest)
+            dataTaskWithURL = try DataTaskWithURL.build(modifyRequest: modifyRequest)
+
+            uploadTaskWithRequestAndDataAndCompletion = try UploadTaskWithRequestAndDataAndCompletion.build(
+                modifyRequest: modifyRequest,
+                onTaskCreated: onTaskCreated,
+                onTaskCompleted: onTaskCompleted
+            )
+            uploadTaskWithRequestAndFileAndCompletion = try UploadTaskWithRequestAndFileAndCompletion.build(
+                modifyRequest: modifyRequest,
+                onTaskCreated: onTaskCreated,
+                onTaskCompleted: onTaskCompleted
+            )
+            uploadTaskWithStreamedRequest = try UploadTaskWithStreamedRequest.build(
+                modifyRequest: modifyRequest,
+                onTaskCreated: onTaskCreated
+            )
+            uploadTaskWithRequestAndData = try UploadTaskWithRequestAndData.build(
+                modifyRequest: modifyRequest,
+                onTaskCreated: onTaskCreated
+            )
+            uploadTaskWithRequestAndFile = try UploadTaskWithRequestAndFile.build(
+                modifyRequest: modifyRequest,
+                onTaskCreated: onTaskCreated
             )
 
-            dataTaskWithURLAndCompletion = try DataTaskWithURLAndCompletion.build(interceptor: interceptor)
-            dataTaskWithURL = try DataTaskWithURL.build(interceptor: interceptor)
+            downloadTaskWithRequestAndCompletion = try DownloadTaskWithRequestAndCompletion.build(
+                modifyRequest: modifyRequest,
+                onTaskCreated: onTaskCreated,
+                onTaskCompleted: onTaskCompleted
+            )
+            downloadTaskWithURLAndCompletion = try DownloadTaskWithURLAndCompletion.build(modifyRequest: modifyRequest)
+            downloadTaskWithRequest = try DownloadTaskWithRequest.build(
+                modifyRequest: modifyRequest,
+                onTaskCreated: onTaskCreated
+            )
+            downloadTaskWithURL = try DownloadTaskWithURL.build(modifyRequest: modifyRequest)
 
-            dataTaskWithURLRequestAndCompletion = try DataTaskWithURLRequestAndCompletion.build(interceptor: interceptor)
-            dataTaskWithURLRequest = try DataTaskWithURLRequest.build(interceptor: interceptor)
+            // Async/await URLSession convenience APIs are iOS 15+, so only install the
+            // task-level resume fallback on those OS versions.
+            if #available(iOS 15, *) {
+                taskResume = try TaskResume.build(modifyRequest: modifyRequest)
+            } else {
+                taskResume = nil
+            }
         }
 
         func swizzle() {
             dataTaskWithURLRequestAndCompletion.swizzle()
-            dataTaskWithURLAndCompletion?.swizzle()
             dataTaskWithURLRequest.swizzle()
-            dataTaskWithURL?.swizzle()
+            dataTaskWithURLAndCompletion.swizzle()
+            dataTaskWithURL.swizzle()
+
+            uploadTaskWithRequestAndDataAndCompletion.swizzle()
+            uploadTaskWithRequestAndFileAndCompletion.swizzle()
+            uploadTaskWithStreamedRequest.swizzle()
+            uploadTaskWithRequestAndData.swizzle()
+            uploadTaskWithRequestAndFile.swizzle()
+
+            downloadTaskWithRequestAndCompletion.swizzle()
+            downloadTaskWithURLAndCompletion.swizzle()
+            downloadTaskWithRequest.swizzle()
+            downloadTaskWithURL.swizzle()
+            taskResume?.swizzle()
+
             hasSwizzled = true
         }
 
@@ -51,127 +247,142 @@
             if !hasSwizzled {
                 return
             }
+
             dataTaskWithURLRequestAndCompletion.unswizzle()
             dataTaskWithURLRequest.unswizzle()
-            dataTaskWithURLAndCompletion?.unswizzle()
-            dataTaskWithURL?.unswizzle()
+            dataTaskWithURLAndCompletion.unswizzle()
+            dataTaskWithURL.unswizzle()
+
+            uploadTaskWithRequestAndDataAndCompletion.unswizzle()
+            uploadTaskWithRequestAndFileAndCompletion.unswizzle()
+            uploadTaskWithStreamedRequest.unswizzle()
+            uploadTaskWithRequestAndData.unswizzle()
+            uploadTaskWithRequestAndFile.unswizzle()
+
+            downloadTaskWithRequestAndCompletion.unswizzle()
+            downloadTaskWithURLAndCompletion.unswizzle()
+            downloadTaskWithRequest.unswizzle()
+            downloadTaskWithURL.unswizzle()
+            taskResume?.unswizzle()
+
             hasSwizzled = false
         }
 
-        // MARK: - Swizzlings
+        class TaskResume: MethodSwizzler<
+            @convention(c) (URLSessionTask, Selector) -> Void,
+            @convention(block) (URLSessionTask) -> Void
+        > {
+            private static let selector = #selector(URLSessionTask.resume)
+            private static let currentRequestKey = "currentRequest"
 
-        typealias CompletionHandler = (Data?, URLResponse?, Error?) -> Void
+            private let method: FoundMethod
+            private let modifyRequest: (URLRequest) -> URLRequest
 
-        /// Swizzles the `URLSession.dataTask(with:completionHandler:)` for `URLRequest`.
+            static func build(modifyRequest: @escaping (URLRequest) -> URLRequest) throws -> TaskResume {
+                try TaskResume(
+                    selector: selector,
+                    klass: URLSessionTask.self,
+                    modifyRequest: modifyRequest
+                )
+            }
+
+            private init(selector: Selector, klass: AnyClass, modifyRequest: @escaping (URLRequest) -> URLRequest) throws {
+                method = try Self.findMethod(with: selector, in: klass)
+                self.modifyRequest = modifyRequest
+                super.init()
+            }
+
+            func swizzle() {
+                typealias Signature = @convention(block) (URLSessionTask) -> Void
+                swizzle(method) { previousImplementation -> Signature in { task in
+                    self.modifyTaskRequests(task)
+                    previousImplementation(task, Self.selector)
+                }
+                }
+            }
+
+            private func modifyTaskRequests(_ task: URLSessionTask) {
+                // Only rewrite `currentRequest` for the async/await fallback path.
+                // This is the request closest to what will go over the wire and avoids
+                // mutating `originalRequest` unnecessarily. Use KVC instead of invoking
+                // a private setter selector directly.
+                if let currentRequest = task.currentRequest {
+                    task.setValue(modifyRequest(currentRequest) as NSURLRequest, forKey: Self.currentRequestKey)
+                }
+            }
+        }
+
+        // MARK: - Data tasks
+
         class DataTaskWithURLRequestAndCompletion: MethodSwizzler<
-            @convention(c) (URLSession, Selector, URLRequest, CompletionHandler?) -> URLSessionDataTask,
-            @convention(block) (URLSession, URLRequest, CompletionHandler?) -> URLSessionDataTask
+            @convention(c) (URLSession, Selector, URLRequest, DataCompletionHandler?) -> URLSessionDataTask,
+            @convention(block) (URLSession, URLRequest, DataCompletionHandler?) -> URLSessionDataTask
         > {
             private static let selector = #selector(
-                URLSession.dataTask(with:completionHandler:) as (URLSession) -> (URLRequest, @escaping CompletionHandler) -> URLSessionDataTask
+                URLSession.dataTask(with:completionHandler:) as (URLSession) -> (URLRequest, @escaping DataCompletionHandler) -> URLSessionDataTask
             )
 
             private let method: FoundMethod
-            private let interceptor: URLSessionInterceptor
+            private let modifyRequest: (URLRequest) -> URLRequest
+            private let onTaskCreated: (URLSessionTask, URLSession?) -> Void
+            private let onTaskCompleted: (URLSessionTask, Error?) -> Void
 
-            static func build(interceptor: URLSessionInterceptor) throws -> DataTaskWithURLRequestAndCompletion {
+            static func build(
+                modifyRequest: @escaping (URLRequest) -> URLRequest,
+                onTaskCreated: @escaping (URLSessionTask, URLSession?) -> Void,
+                onTaskCompleted: @escaping (URLSessionTask, Error?) -> Void
+            ) throws -> DataTaskWithURLRequestAndCompletion {
                 try DataTaskWithURLRequestAndCompletion(
                     selector: selector,
                     klass: URLSession.self,
-                    interceptor: interceptor
+                    modifyRequest: modifyRequest,
+                    onTaskCreated: onTaskCreated,
+                    onTaskCompleted: onTaskCompleted
                 )
             }
 
-            private init(selector: Selector, klass: AnyClass, interceptor: URLSessionInterceptor) throws {
+            private init(
+                selector: Selector,
+                klass: AnyClass,
+                modifyRequest: @escaping (URLRequest) -> URLRequest,
+                onTaskCreated: @escaping (URLSessionTask, URLSession?) -> Void,
+                onTaskCompleted: @escaping (URLSessionTask, Error?) -> Void
+            ) throws {
                 method = try Self.findMethod(with: selector, in: klass)
-                self.interceptor = interceptor
+                self.modifyRequest = modifyRequest
+                self.onTaskCreated = onTaskCreated
+                self.onTaskCompleted = onTaskCompleted
                 super.init()
             }
 
             func swizzle() {
-                typealias Signature = @convention(block) (URLSession, URLRequest, CompletionHandler?) -> URLSessionDataTask
+                typealias Signature = @convention(block) (URLSession, URLRequest, DataCompletionHandler?) -> URLSessionDataTask
                 swizzle(method) { previousImplementation -> Signature in { session, urlRequest, completionHandler -> URLSessionDataTask in
+                    let modifiedRequest = self.modifyRequest(urlRequest)
                     let task: URLSessionDataTask
+
                     if completionHandler != nil {
                         var taskReference: URLSessionDataTask?
-                        let newCompletionHandler: CompletionHandler = { data, response, error in
-                            if let task = taskReference { // sanity check, should always succeed
-                                self.interceptor.taskCompleted(task: task, error: error)
+                        let newCompletionHandler: DataCompletionHandler = { data, response, error in
+                            if let task = taskReference {
+                                self.onTaskCompleted(task, error)
                             }
                             completionHandler?(data, response, error)
                         }
 
-                        task = previousImplementation(session, Self.selector, urlRequest, newCompletionHandler)
+                        task = previousImplementation(session, Self.selector, modifiedRequest, newCompletionHandler)
                         taskReference = task
                     } else {
-                        // The `completionHandler` can be `nil` in two cases:
-                        // - on iOS 11 or 12, where `dataTask(with:)` (for `URL` and `URLRequest`) calls
-                        //   the `dataTask(with:completionHandler:)` (for `URLRequest`) internally by nullifying the completion block.
-                        // - when `[session dataTaskWithURL:completionHandler:]` is called in Objective-C with explicitly passing
-                        //   `nil` as the `completionHandler` (it produces a warning, but compiles).
-                        task = previousImplementation(session, Self.selector, urlRequest, completionHandler)
+                        task = previousImplementation(session, Self.selector, modifiedRequest, completionHandler)
                     }
-                    self.interceptor.taskCreated(task: task, session: session)
+
+                    self.onTaskCreated(task, session)
                     return task
                 }
                 }
             }
         }
 
-        /// Swizzles the `URLSession.dataTask(with:completionHandler:)` for `URL`.
-        class DataTaskWithURLAndCompletion: MethodSwizzler<
-            @convention(c) (URLSession, Selector, URL, CompletionHandler?) -> URLSessionDataTask,
-            @convention(block) (URLSession, URL, CompletionHandler?) -> URLSessionDataTask
-        > {
-            private static let selector = #selector(
-                URLSession.dataTask(with:completionHandler:) as (URLSession) -> (URL, @escaping CompletionHandler) -> URLSessionDataTask
-            )
-
-            private let method: FoundMethod
-            private let interceptor: URLSessionInterceptor
-
-            static func build(interceptor: URLSessionInterceptor) throws -> DataTaskWithURLAndCompletion {
-                try DataTaskWithURLAndCompletion(
-                    selector: selector,
-                    klass: URLSession.self,
-                    interceptor: interceptor
-                )
-            }
-
-            private init(selector: Selector, klass: AnyClass, interceptor: URLSessionInterceptor) throws {
-                method = try Self.findMethod(with: selector, in: klass)
-                self.interceptor = interceptor
-                super.init()
-            }
-
-            func swizzle() {
-                typealias Signature = @convention(block) (URLSession, URL, CompletionHandler?) -> URLSessionDataTask
-                swizzle(method) { previousImplementation -> Signature in { session, url, completionHandler -> URLSessionDataTask in
-                    let task: URLSessionDataTask
-                    if completionHandler != nil {
-                        var taskReference: URLSessionDataTask?
-                        let newCompletionHandler: CompletionHandler = { data, response, error in
-                            if let task = taskReference { // sanity check, should always succeed
-                                self.interceptor.taskCompleted(task: task, error: error)
-                            }
-                            completionHandler?(data, response, error)
-                        }
-                        task = previousImplementation(session, Self.selector, url, newCompletionHandler)
-                        taskReference = task
-                    } else {
-                        // The `completionHandler` can be `nil` in one case:
-                        // - when `[session dataTaskWithURL:completionHandler:]` is called in Objective-C with explicitly passing
-                        //   `nil` as the `completionHandler` (it produces a warning, but compiles).
-                        task = previousImplementation(session, Self.selector, url, completionHandler)
-                    }
-                    self.interceptor.taskCreated(task: task, session: session)
-                    return task
-                }
-                }
-            }
-        }
-
-        /// Swizzles the `URLSession.dataTask(with:)` for `URLRequest`.
         class DataTaskWithURLRequest: MethodSwizzler<
             @convention(c) (URLSession, Selector, URLRequest) -> URLSessionDataTask,
             @convention(block) (URLSession, URLRequest) -> URLSessionDataTask
@@ -181,34 +392,82 @@
             )
 
             private let method: FoundMethod
-            private let interceptor: URLSessionInterceptor
+            private let modifyRequest: (URLRequest) -> URLRequest
+            private let onTaskCreated: (URLSessionTask, URLSession?) -> Void
 
-            static func build(interceptor: URLSessionInterceptor) throws -> DataTaskWithURLRequest {
+            static func build(
+                modifyRequest: @escaping (URLRequest) -> URLRequest,
+                onTaskCreated: @escaping (URLSessionTask, URLSession?) -> Void
+            ) throws -> DataTaskWithURLRequest {
                 try DataTaskWithURLRequest(
                     selector: selector,
                     klass: URLSession.self,
-                    interceptor: interceptor
+                    modifyRequest: modifyRequest,
+                    onTaskCreated: onTaskCreated
                 )
             }
 
-            private init(selector: Selector, klass: AnyClass, interceptor: URLSessionInterceptor) throws {
+            private init(
+                selector: Selector,
+                klass: AnyClass,
+                modifyRequest: @escaping (URLRequest) -> URLRequest,
+                onTaskCreated: @escaping (URLSessionTask, URLSession?) -> Void
+            ) throws {
                 method = try Self.findMethod(with: selector, in: klass)
-                self.interceptor = interceptor
+                self.modifyRequest = modifyRequest
+                self.onTaskCreated = onTaskCreated
                 super.init()
             }
 
             func swizzle() {
                 typealias Signature = @convention(block) (URLSession, URLRequest) -> URLSessionDataTask
                 swizzle(method) { previousImplementation -> Signature in { session, urlRequest -> URLSessionDataTask in
-                    let task = previousImplementation(session, Self.selector, urlRequest)
-                    self.interceptor.taskCreated(task: task, session: session)
+                    let task = previousImplementation(session, Self.selector, self.modifyRequest(urlRequest))
+                    self.onTaskCreated(task, session)
                     return task
                 }
                 }
             }
         }
 
-        /// Swizzles the `URLSession.dataTask(with:)` for `URL`.
+        class DataTaskWithURLAndCompletion: MethodSwizzler<
+            @convention(c) (URLSession, Selector, URL, DataCompletionHandler?) -> URLSessionDataTask,
+            @convention(block) (URLSession, URL, DataCompletionHandler?) -> URLSessionDataTask
+        > {
+            private static let selector = #selector(
+                URLSession.dataTask(with:completionHandler:) as (URLSession) -> (URL, @escaping DataCompletionHandler) -> URLSessionDataTask
+            )
+
+            private let method: FoundMethod
+            private let modifyRequest: (URLRequest) -> URLRequest
+
+            static func build(modifyRequest: @escaping (URLRequest) -> URLRequest) throws -> DataTaskWithURLAndCompletion {
+                try DataTaskWithURLAndCompletion(
+                    selector: selector,
+                    klass: URLSession.self,
+                    modifyRequest: modifyRequest
+                )
+            }
+
+            private init(selector: Selector, klass: AnyClass, modifyRequest: @escaping (URLRequest) -> URLRequest) throws {
+                method = try Self.findMethod(with: selector, in: klass)
+                self.modifyRequest = modifyRequest
+                super.init()
+            }
+
+            func swizzle() {
+                typealias Signature = @convention(block) (URLSession, URL, DataCompletionHandler?) -> URLSessionDataTask
+                swizzle(method) { _ -> Signature in { session, url, completionHandler -> URLSessionDataTask in
+                    let request = self.modifyRequest(URLRequest(url: url))
+                    if let completionHandler {
+                        return session.dataTask(with: request, completionHandler: completionHandler)
+                    }
+                    return session.dataTask(with: request)
+                }
+                }
+            }
+        }
+
         class DataTaskWithURL: MethodSwizzler<
             @convention(c) (URLSession, Selector, URL) -> URLSessionDataTask,
             @convention(block) (URLSession, URL) -> URLSessionDataTask
@@ -218,28 +477,497 @@
             )
 
             private let method: FoundMethod
-            private let interceptor: URLSessionInterceptor
+            private let modifyRequest: (URLRequest) -> URLRequest
 
-            static func build(interceptor: URLSessionInterceptor) throws -> DataTaskWithURL {
+            static func build(modifyRequest: @escaping (URLRequest) -> URLRequest) throws -> DataTaskWithURL {
                 try DataTaskWithURL(
                     selector: selector,
                     klass: URLSession.self,
-                    interceptor: interceptor
+                    modifyRequest: modifyRequest
                 )
             }
 
-            private init(selector: Selector, klass: AnyClass, interceptor: URLSessionInterceptor) throws {
+            private init(selector: Selector, klass: AnyClass, modifyRequest: @escaping (URLRequest) -> URLRequest) throws {
                 method = try Self.findMethod(with: selector, in: klass)
-                self.interceptor = interceptor
+                self.modifyRequest = modifyRequest
                 super.init()
             }
 
             func swizzle() {
                 typealias Signature = @convention(block) (URLSession, URL) -> URLSessionDataTask
-                swizzle(method) { previousImplementation -> Signature in { session, url -> URLSessionDataTask in
-                    let task = previousImplementation(session, Self.selector, url)
-                    self.interceptor.taskCreated(task: task, session: session)
+                swizzle(method) { _ -> Signature in { session, url -> URLSessionDataTask in
+                    session.dataTask(with: self.modifyRequest(URLRequest(url: url)))
+                }
+                }
+            }
+        }
+
+        // MARK: - Upload tasks
+
+        class UploadTaskWithRequestAndDataAndCompletion: MethodSwizzler<
+            @convention(c) (URLSession, Selector, URLRequest, Data?, DataCompletionHandler?) -> URLSessionUploadTask,
+            @convention(block) (URLSession, URLRequest, Data?, DataCompletionHandler?) -> URLSessionUploadTask
+        > {
+            private static let selector = #selector(
+                URLSession.uploadTask(with:from:completionHandler:) as (URLSession) -> (URLRequest, Data?, @escaping DataCompletionHandler) -> URLSessionUploadTask
+            )
+
+            private let method: FoundMethod
+            private let modifyRequest: (URLRequest) -> URLRequest
+            private let onTaskCreated: (URLSessionTask, URLSession?) -> Void
+            private let onTaskCompleted: (URLSessionTask, Error?) -> Void
+
+            static func build(
+                modifyRequest: @escaping (URLRequest) -> URLRequest,
+                onTaskCreated: @escaping (URLSessionTask, URLSession?) -> Void,
+                onTaskCompleted: @escaping (URLSessionTask, Error?) -> Void
+            ) throws -> UploadTaskWithRequestAndDataAndCompletion {
+                try UploadTaskWithRequestAndDataAndCompletion(
+                    selector: selector,
+                    klass: URLSession.self,
+                    modifyRequest: modifyRequest,
+                    onTaskCreated: onTaskCreated,
+                    onTaskCompleted: onTaskCompleted
+                )
+            }
+
+            private init(
+                selector: Selector,
+                klass: AnyClass,
+                modifyRequest: @escaping (URLRequest) -> URLRequest,
+                onTaskCreated: @escaping (URLSessionTask, URLSession?) -> Void,
+                onTaskCompleted: @escaping (URLSessionTask, Error?) -> Void
+            ) throws {
+                method = try Self.findMethod(with: selector, in: klass)
+                self.modifyRequest = modifyRequest
+                self.onTaskCreated = onTaskCreated
+                self.onTaskCompleted = onTaskCompleted
+                super.init()
+            }
+
+            func swizzle() {
+                typealias Signature = @convention(block) (URLSession, URLRequest, Data?, DataCompletionHandler?) -> URLSessionUploadTask
+                swizzle(method) { previousImplementation -> Signature in { session, urlRequest, bodyData, completionHandler -> URLSessionUploadTask in
+                    let modifiedRequest = self.modifyRequest(urlRequest)
+                    let task: URLSessionUploadTask
+
+                    if completionHandler != nil {
+                        var taskReference: URLSessionUploadTask?
+                        let newCompletionHandler: DataCompletionHandler = { data, response, error in
+                            if let task = taskReference {
+                                self.onTaskCompleted(task, error)
+                            }
+                            completionHandler?(data, response, error)
+                        }
+
+                        task = previousImplementation(session, Self.selector, modifiedRequest, bodyData, newCompletionHandler)
+                        taskReference = task
+                    } else {
+                        task = previousImplementation(session, Self.selector, modifiedRequest, bodyData, completionHandler)
+                    }
+
+                    self.onTaskCreated(task, session)
                     return task
+                }
+                }
+            }
+        }
+
+        class UploadTaskWithRequestAndFileAndCompletion: MethodSwizzler<
+            @convention(c) (URLSession, Selector, URLRequest, URL, DataCompletionHandler?) -> URLSessionUploadTask,
+            @convention(block) (URLSession, URLRequest, URL, DataCompletionHandler?) -> URLSessionUploadTask
+        > {
+            private static let selector = #selector(
+                URLSession.uploadTask(with:fromFile:completionHandler:) as (URLSession) -> (URLRequest, URL, @escaping DataCompletionHandler) -> URLSessionUploadTask
+            )
+
+            private let method: FoundMethod
+            private let modifyRequest: (URLRequest) -> URLRequest
+            private let onTaskCreated: (URLSessionTask, URLSession?) -> Void
+            private let onTaskCompleted: (URLSessionTask, Error?) -> Void
+
+            static func build(
+                modifyRequest: @escaping (URLRequest) -> URLRequest,
+                onTaskCreated: @escaping (URLSessionTask, URLSession?) -> Void,
+                onTaskCompleted: @escaping (URLSessionTask, Error?) -> Void
+            ) throws -> UploadTaskWithRequestAndFileAndCompletion {
+                try UploadTaskWithRequestAndFileAndCompletion(
+                    selector: selector,
+                    klass: URLSession.self,
+                    modifyRequest: modifyRequest,
+                    onTaskCreated: onTaskCreated,
+                    onTaskCompleted: onTaskCompleted
+                )
+            }
+
+            private init(
+                selector: Selector,
+                klass: AnyClass,
+                modifyRequest: @escaping (URLRequest) -> URLRequest,
+                onTaskCreated: @escaping (URLSessionTask, URLSession?) -> Void,
+                onTaskCompleted: @escaping (URLSessionTask, Error?) -> Void
+            ) throws {
+                method = try Self.findMethod(with: selector, in: klass)
+                self.modifyRequest = modifyRequest
+                self.onTaskCreated = onTaskCreated
+                self.onTaskCompleted = onTaskCompleted
+                super.init()
+            }
+
+            func swizzle() {
+                typealias Signature = @convention(block) (URLSession, URLRequest, URL, DataCompletionHandler?) -> URLSessionUploadTask
+                swizzle(method) { previousImplementation -> Signature in { session, urlRequest, fileURL, completionHandler -> URLSessionUploadTask in
+                    let modifiedRequest = self.modifyRequest(urlRequest)
+                    let task: URLSessionUploadTask
+
+                    if completionHandler != nil {
+                        var taskReference: URLSessionUploadTask?
+                        let newCompletionHandler: DataCompletionHandler = { data, response, error in
+                            if let task = taskReference {
+                                self.onTaskCompleted(task, error)
+                            }
+                            completionHandler?(data, response, error)
+                        }
+
+                        task = previousImplementation(session, Self.selector, modifiedRequest, fileURL, newCompletionHandler)
+                        taskReference = task
+                    } else {
+                        task = previousImplementation(session, Self.selector, modifiedRequest, fileURL, completionHandler)
+                    }
+
+                    self.onTaskCreated(task, session)
+                    return task
+                }
+                }
+            }
+        }
+
+        class UploadTaskWithStreamedRequest: MethodSwizzler<
+            @convention(c) (URLSession, Selector, URLRequest) -> URLSessionUploadTask,
+            @convention(block) (URLSession, URLRequest) -> URLSessionUploadTask
+        > {
+            private static let selector = #selector(
+                URLSession.uploadTask(withStreamedRequest:) as (URLSession) -> (URLRequest) -> URLSessionUploadTask
+            )
+
+            private let method: FoundMethod
+            private let modifyRequest: (URLRequest) -> URLRequest
+            private let onTaskCreated: (URLSessionTask, URLSession?) -> Void
+
+            static func build(
+                modifyRequest: @escaping (URLRequest) -> URLRequest,
+                onTaskCreated: @escaping (URLSessionTask, URLSession?) -> Void
+            ) throws -> UploadTaskWithStreamedRequest {
+                try UploadTaskWithStreamedRequest(
+                    selector: selector,
+                    klass: URLSession.self,
+                    modifyRequest: modifyRequest,
+                    onTaskCreated: onTaskCreated
+                )
+            }
+
+            private init(
+                selector: Selector,
+                klass: AnyClass,
+                modifyRequest: @escaping (URLRequest) -> URLRequest,
+                onTaskCreated: @escaping (URLSessionTask, URLSession?) -> Void
+            ) throws {
+                method = try Self.findMethod(with: selector, in: klass)
+                self.modifyRequest = modifyRequest
+                self.onTaskCreated = onTaskCreated
+                super.init()
+            }
+
+            func swizzle() {
+                typealias Signature = @convention(block) (URLSession, URLRequest) -> URLSessionUploadTask
+                swizzle(method) { previousImplementation -> Signature in { session, urlRequest -> URLSessionUploadTask in
+                    let task = previousImplementation(session, Self.selector, self.modifyRequest(urlRequest))
+                    self.onTaskCreated(task, session)
+                    return task
+                }
+                }
+            }
+        }
+
+        class UploadTaskWithRequestAndData: MethodSwizzler<
+            @convention(c) (URLSession, Selector, URLRequest, Data) -> URLSessionUploadTask,
+            @convention(block) (URLSession, URLRequest, Data) -> URLSessionUploadTask
+        > {
+            private static let selector = #selector(
+                URLSession.uploadTask(with:from:) as (URLSession) -> (URLRequest, Data) -> URLSessionUploadTask
+            )
+
+            private let method: FoundMethod
+            private let modifyRequest: (URLRequest) -> URLRequest
+            private let onTaskCreated: (URLSessionTask, URLSession?) -> Void
+
+            static func build(
+                modifyRequest: @escaping (URLRequest) -> URLRequest,
+                onTaskCreated: @escaping (URLSessionTask, URLSession?) -> Void
+            ) throws -> UploadTaskWithRequestAndData {
+                try UploadTaskWithRequestAndData(
+                    selector: selector,
+                    klass: URLSession.self,
+                    modifyRequest: modifyRequest,
+                    onTaskCreated: onTaskCreated
+                )
+            }
+
+            private init(
+                selector: Selector,
+                klass: AnyClass,
+                modifyRequest: @escaping (URLRequest) -> URLRequest,
+                onTaskCreated: @escaping (URLSessionTask, URLSession?) -> Void
+            ) throws {
+                method = try Self.findMethod(with: selector, in: klass)
+                self.modifyRequest = modifyRequest
+                self.onTaskCreated = onTaskCreated
+                super.init()
+            }
+
+            func swizzle() {
+                typealias Signature = @convention(block) (URLSession, URLRequest, Data) -> URLSessionUploadTask
+                swizzle(method) { previousImplementation -> Signature in { session, urlRequest, bodyData -> URLSessionUploadTask in
+                    let task = previousImplementation(session, Self.selector, self.modifyRequest(urlRequest), bodyData)
+                    self.onTaskCreated(task, session)
+                    return task
+                }
+                }
+            }
+        }
+
+        class UploadTaskWithRequestAndFile: MethodSwizzler<
+            @convention(c) (URLSession, Selector, URLRequest, URL) -> URLSessionUploadTask,
+            @convention(block) (URLSession, URLRequest, URL) -> URLSessionUploadTask
+        > {
+            private static let selector = #selector(
+                URLSession.uploadTask(with:fromFile:) as (URLSession) -> (URLRequest, URL) -> URLSessionUploadTask
+            )
+
+            private let method: FoundMethod
+            private let modifyRequest: (URLRequest) -> URLRequest
+            private let onTaskCreated: (URLSessionTask, URLSession?) -> Void
+
+            static func build(
+                modifyRequest: @escaping (URLRequest) -> URLRequest,
+                onTaskCreated: @escaping (URLSessionTask, URLSession?) -> Void
+            ) throws -> UploadTaskWithRequestAndFile {
+                try UploadTaskWithRequestAndFile(
+                    selector: selector,
+                    klass: URLSession.self,
+                    modifyRequest: modifyRequest,
+                    onTaskCreated: onTaskCreated
+                )
+            }
+
+            private init(
+                selector: Selector,
+                klass: AnyClass,
+                modifyRequest: @escaping (URLRequest) -> URLRequest,
+                onTaskCreated: @escaping (URLSessionTask, URLSession?) -> Void
+            ) throws {
+                method = try Self.findMethod(with: selector, in: klass)
+                self.modifyRequest = modifyRequest
+                self.onTaskCreated = onTaskCreated
+                super.init()
+            }
+
+            func swizzle() {
+                typealias Signature = @convention(block) (URLSession, URLRequest, URL) -> URLSessionUploadTask
+                swizzle(method) { previousImplementation -> Signature in { session, urlRequest, fileURL -> URLSessionUploadTask in
+                    let task = previousImplementation(session, Self.selector, self.modifyRequest(urlRequest), fileURL)
+                    self.onTaskCreated(task, session)
+                    return task
+                }
+                }
+            }
+        }
+
+        // MARK: - Download tasks
+
+        class DownloadTaskWithRequestAndCompletion: MethodSwizzler<
+            @convention(c) (URLSession, Selector, URLRequest, DownloadCompletionHandler?) -> URLSessionDownloadTask,
+            @convention(block) (URLSession, URLRequest, DownloadCompletionHandler?) -> URLSessionDownloadTask
+        > {
+            private static let selector = #selector(
+                URLSession.downloadTask(with:completionHandler:) as (URLSession) -> (URLRequest, @escaping DownloadCompletionHandler) -> URLSessionDownloadTask
+            )
+
+            private let method: FoundMethod
+            private let modifyRequest: (URLRequest) -> URLRequest
+            private let onTaskCreated: (URLSessionTask, URLSession?) -> Void
+            private let onTaskCompleted: (URLSessionTask, Error?) -> Void
+
+            static func build(
+                modifyRequest: @escaping (URLRequest) -> URLRequest,
+                onTaskCreated: @escaping (URLSessionTask, URLSession?) -> Void,
+                onTaskCompleted: @escaping (URLSessionTask, Error?) -> Void
+            ) throws -> DownloadTaskWithRequestAndCompletion {
+                try DownloadTaskWithRequestAndCompletion(
+                    selector: selector,
+                    klass: URLSession.self,
+                    modifyRequest: modifyRequest,
+                    onTaskCreated: onTaskCreated,
+                    onTaskCompleted: onTaskCompleted
+                )
+            }
+
+            private init(
+                selector: Selector,
+                klass: AnyClass,
+                modifyRequest: @escaping (URLRequest) -> URLRequest,
+                onTaskCreated: @escaping (URLSessionTask, URLSession?) -> Void,
+                onTaskCompleted: @escaping (URLSessionTask, Error?) -> Void
+            ) throws {
+                method = try Self.findMethod(with: selector, in: klass)
+                self.modifyRequest = modifyRequest
+                self.onTaskCreated = onTaskCreated
+                self.onTaskCompleted = onTaskCompleted
+                super.init()
+            }
+
+            func swizzle() {
+                typealias Signature = @convention(block) (URLSession, URLRequest, DownloadCompletionHandler?) -> URLSessionDownloadTask
+                swizzle(method) { previousImplementation -> Signature in { session, urlRequest, completionHandler -> URLSessionDownloadTask in
+                    let modifiedRequest = self.modifyRequest(urlRequest)
+                    let task: URLSessionDownloadTask
+
+                    if completionHandler != nil {
+                        var taskReference: URLSessionDownloadTask?
+                        let newCompletionHandler: DownloadCompletionHandler = { url, response, error in
+                            if let task = taskReference {
+                                self.onTaskCompleted(task, error)
+                            }
+                            completionHandler?(url, response, error)
+                        }
+
+                        task = previousImplementation(session, Self.selector, modifiedRequest, newCompletionHandler)
+                        taskReference = task
+                    } else {
+                        task = previousImplementation(session, Self.selector, modifiedRequest, completionHandler)
+                    }
+
+                    self.onTaskCreated(task, session)
+                    return task
+                }
+                }
+            }
+        }
+
+        class DownloadTaskWithURLAndCompletion: MethodSwizzler<
+            @convention(c) (URLSession, Selector, URL, DownloadCompletionHandler?) -> URLSessionDownloadTask,
+            @convention(block) (URLSession, URL, DownloadCompletionHandler?) -> URLSessionDownloadTask
+        > {
+            private static let selector = #selector(
+                URLSession.downloadTask(with:completionHandler:) as (URLSession) -> (URL, @escaping DownloadCompletionHandler) -> URLSessionDownloadTask
+            )
+
+            private let method: FoundMethod
+            private let modifyRequest: (URLRequest) -> URLRequest
+
+            static func build(modifyRequest: @escaping (URLRequest) -> URLRequest) throws -> DownloadTaskWithURLAndCompletion {
+                try DownloadTaskWithURLAndCompletion(
+                    selector: selector,
+                    klass: URLSession.self,
+                    modifyRequest: modifyRequest
+                )
+            }
+
+            private init(selector: Selector, klass: AnyClass, modifyRequest: @escaping (URLRequest) -> URLRequest) throws {
+                method = try Self.findMethod(with: selector, in: klass)
+                self.modifyRequest = modifyRequest
+                super.init()
+            }
+
+            func swizzle() {
+                typealias Signature = @convention(block) (URLSession, URL, DownloadCompletionHandler?) -> URLSessionDownloadTask
+                swizzle(method) { _ -> Signature in { session, url, completionHandler -> URLSessionDownloadTask in
+                    let request = self.modifyRequest(URLRequest(url: url))
+                    if let completionHandler {
+                        return session.downloadTask(with: request, completionHandler: completionHandler)
+                    }
+                    return session.downloadTask(with: request)
+                }
+                }
+            }
+        }
+
+        class DownloadTaskWithRequest: MethodSwizzler<
+            @convention(c) (URLSession, Selector, URLRequest) -> URLSessionDownloadTask,
+            @convention(block) (URLSession, URLRequest) -> URLSessionDownloadTask
+        > {
+            private static let selector = #selector(
+                URLSession.downloadTask(with:) as (URLSession) -> (URLRequest) -> URLSessionDownloadTask
+            )
+
+            private let method: FoundMethod
+            private let modifyRequest: (URLRequest) -> URLRequest
+            private let onTaskCreated: (URLSessionTask, URLSession?) -> Void
+
+            static func build(
+                modifyRequest: @escaping (URLRequest) -> URLRequest,
+                onTaskCreated: @escaping (URLSessionTask, URLSession?) -> Void
+            ) throws -> DownloadTaskWithRequest {
+                try DownloadTaskWithRequest(
+                    selector: selector,
+                    klass: URLSession.self,
+                    modifyRequest: modifyRequest,
+                    onTaskCreated: onTaskCreated
+                )
+            }
+
+            private init(
+                selector: Selector,
+                klass: AnyClass,
+                modifyRequest: @escaping (URLRequest) -> URLRequest,
+                onTaskCreated: @escaping (URLSessionTask, URLSession?) -> Void
+            ) throws {
+                method = try Self.findMethod(with: selector, in: klass)
+                self.modifyRequest = modifyRequest
+                self.onTaskCreated = onTaskCreated
+                super.init()
+            }
+
+            func swizzle() {
+                typealias Signature = @convention(block) (URLSession, URLRequest) -> URLSessionDownloadTask
+                swizzle(method) { previousImplementation -> Signature in { session, urlRequest -> URLSessionDownloadTask in
+                    let task = previousImplementation(session, Self.selector, self.modifyRequest(urlRequest))
+                    self.onTaskCreated(task, session)
+                    return task
+                }
+                }
+            }
+        }
+
+        class DownloadTaskWithURL: MethodSwizzler<
+            @convention(c) (URLSession, Selector, URL) -> URLSessionDownloadTask,
+            @convention(block) (URLSession, URL) -> URLSessionDownloadTask
+        > {
+            private static let selector = #selector(
+                URLSession.downloadTask(with:) as (URLSession) -> (URL) -> URLSessionDownloadTask
+            )
+
+            private let method: FoundMethod
+            private let modifyRequest: (URLRequest) -> URLRequest
+
+            static func build(modifyRequest: @escaping (URLRequest) -> URLRequest) throws -> DownloadTaskWithURL {
+                try DownloadTaskWithURL(
+                    selector: selector,
+                    klass: URLSession.self,
+                    modifyRequest: modifyRequest
+                )
+            }
+
+            private init(selector: Selector, klass: AnyClass, modifyRequest: @escaping (URLRequest) -> URLRequest) throws {
+                method = try Self.findMethod(with: selector, in: klass)
+                self.modifyRequest = modifyRequest
+                super.init()
+            }
+
+            func swizzle() {
+                typealias Signature = @convention(block) (URLSession, URL) -> URLSessionDownloadTask
+                swizzle(method) { _ -> Signature in { session, url -> URLSessionDownloadTask in
+                    session.downloadTask(with: self.modifyRequest(URLRequest(url: url)))
                 }
                 }
             }

--- a/PostHog/Tracing/PostHogTracingHeadersIntegration.swift
+++ b/PostHog/Tracing/PostHogTracingHeadersIntegration.swift
@@ -53,8 +53,6 @@
 
         private weak var postHog: PostHogSDK?
         private var registrationId: UUID?
-        private let normalizedHostnamesLock = NSLock()
-        private var cachedHostnames: [String] = []
         private var normalizedHostnames = Set<String>()
 
         func install(_ postHog: PostHogSDK) -> PostHogIntegrationInstallResult {
@@ -71,6 +69,7 @@
             }
 
             self.postHog = postHog
+            normalizedHostnames = PostHogTracingHeaders.normalizeHostnames(postHog.config.tracingHeaders ?? [])
             start()
             return .installed
         }
@@ -79,6 +78,7 @@
             if self.postHog === postHog || self.postHog == nil {
                 stop()
                 self.postHog = nil
+                normalizedHostnames = []
                 Self.integrationInstalledLock.withLock {
                     Self.integrationInstalled = false
                 }
@@ -119,23 +119,10 @@
 
             return PostHogTracingHeaders.addingHeaders(
                 to: request,
-                hostnames: getNormalizedHostnames(for: postHog),
+                hostnames: normalizedHostnames,
                 distinctId: postHog.getDistinctId(),
                 sessionId: postHog.sessionManager.getSessionId(readOnly: true)
             )
-        }
-
-        private func getNormalizedHostnames(for postHog: PostHogSDK) -> Set<String> {
-            let hostnames = postHog.config.addTracingHeaders ?? []
-
-            return normalizedHostnamesLock.withLock {
-                if hostnames != cachedHostnames {
-                    cachedHostnames = hostnames
-                    normalizedHostnames = PostHogTracingHeaders.normalizeHostnames(hostnames)
-                }
-
-                return normalizedHostnames
-            }
         }
     }
 

--- a/PostHog/Tracing/PostHogTracingHeadersIntegration.swift
+++ b/PostHog/Tracing/PostHogTracingHeadersIntegration.swift
@@ -1,0 +1,154 @@
+#if os(iOS)
+    import Foundation
+
+    private enum PostHogTracingHeaders {
+        static let distinctId = "X-POSTHOG-DISTINCT-ID"
+        static let sessionId = "X-POSTHOG-SESSION-ID"
+
+        static func addingHeaders(
+            to request: URLRequest,
+            hostnames: Set<String>,
+            distinctId: String,
+            sessionId: String?
+        ) -> URLRequest {
+            guard shouldAddHeaders(to: request.url, hostnames: hostnames) else {
+                return request
+            }
+
+            var request = request
+
+            if let sessionId, !sessionId.isEmpty {
+                request.setValue(sessionId, forHTTPHeaderField: Self.sessionId)
+            }
+
+            if !distinctId.isEmpty {
+                request.setValue(distinctId, forHTTPHeaderField: Self.distinctId)
+            }
+
+            return request
+        }
+
+        static func normalizeHostnames(_ hostnames: [String]) -> Set<String> {
+            Set(
+                hostnames
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+                    .filter { !$0.isEmpty }
+            )
+        }
+
+        private static func shouldAddHeaders(to url: URL?, hostnames: Set<String>) -> Bool {
+            guard let requestHost = url?.host?.lowercased(), !hostnames.isEmpty else {
+                return false
+            }
+
+            return hostnames.contains(requestHost)
+        }
+    }
+
+    final class PostHogTracingHeadersIntegration: PostHogIntegration {
+        var requiresSwizzling: Bool { true }
+
+        private static let integrationInstalledLock = NSLock()
+        private static var integrationInstalled = false
+
+        private weak var postHog: PostHogSDK?
+        private var registrationId: UUID?
+        private let normalizedHostnamesLock = NSLock()
+        private var cachedHostnames: [String] = []
+        private var normalizedHostnames = Set<String>()
+
+        func install(_ postHog: PostHogSDK) throws {
+            try Self.integrationInstalledLock.withLock {
+                if Self.integrationInstalled {
+                    throw InternalPostHogError(description: "Tracing headers integration already installed to another PostHogSDK instance.")
+                }
+                Self.integrationInstalled = true
+            }
+
+            self.postHog = postHog
+
+            do {
+                try startInstrumentation()
+            } catch {
+                Self.integrationInstalledLock.withLock {
+                    Self.integrationInstalled = false
+                }
+                self.postHog = nil
+                throw error
+            }
+        }
+
+        func uninstall(_ postHog: PostHogSDK) {
+            if self.postHog === postHog || self.postHog == nil {
+                stop()
+                self.postHog = nil
+                Self.integrationInstalledLock.withLock {
+                    Self.integrationInstalled = false
+                }
+            }
+        }
+
+        func start() {
+            do {
+                try startInstrumentation()
+            } catch {
+                hedgeLog("Tracing headers integration failed to start: \(error)")
+            }
+        }
+
+        func stop() {
+            guard let registrationId else {
+                return
+            }
+
+            URLSessionInstrumentation.shared.unregister(registrationId)
+            self.registrationId = nil
+        }
+
+        private func startInstrumentation() throws {
+            guard registrationId == nil else {
+                return
+            }
+
+            registrationId = try URLSessionInstrumentation.shared.register(requestModifier: { [weak self] request in
+                self?.addTracingHeaders(to: request) ?? request
+            })
+        }
+
+        private func addTracingHeaders(to request: URLRequest) -> URLRequest {
+            guard let postHog else {
+                return request
+            }
+
+            return PostHogTracingHeaders.addingHeaders(
+                to: request,
+                hostnames: getNormalizedHostnames(for: postHog),
+                distinctId: postHog.getDistinctId(),
+                sessionId: postHog.sessionManager.getSessionId(readOnly: true)
+            )
+        }
+
+        private func getNormalizedHostnames(for postHog: PostHogSDK) -> Set<String> {
+            let hostnames = postHog.config.addTracingHeaders ?? []
+
+            return normalizedHostnamesLock.withLock {
+                if hostnames != cachedHostnames {
+                    cachedHostnames = hostnames
+                    normalizedHostnames = PostHogTracingHeaders.normalizeHostnames(hostnames)
+                }
+
+                return normalizedHostnames
+            }
+        }
+    }
+
+    #if TESTING
+        extension PostHogTracingHeadersIntegration {
+            static func clearInstalls() {
+                integrationInstalledLock.withLock {
+                    integrationInstalled = false
+                }
+            }
+        }
+    #endif
+#endif

--- a/PostHog/Tracing/PostHogTracingHeadersIntegration.swift
+++ b/PostHog/Tracing/PostHogTracingHeadersIntegration.swift
@@ -57,25 +57,22 @@
         private var cachedHostnames: [String] = []
         private var normalizedHostnames = Set<String>()
 
-        func install(_ postHog: PostHogSDK) throws {
-            try Self.integrationInstalledLock.withLock {
+        func install(_ postHog: PostHogSDK) -> PostHogIntegrationInstallResult {
+            let didInstall = Self.integrationInstalledLock.withLock {
                 if Self.integrationInstalled {
-                    throw InternalPostHogError(description: "Tracing headers integration already installed to another PostHogSDK instance.")
+                    return false
                 }
                 Self.integrationInstalled = true
+                return true
+            }
+
+            guard didInstall else {
+                return .skipped(.alreadyInstalled)
             }
 
             self.postHog = postHog
-
-            do {
-                try startInstrumentation()
-            } catch {
-                Self.integrationInstalledLock.withLock {
-                    Self.integrationInstalled = false
-                }
-                self.postHog = nil
-                throw error
-            }
+            start()
+            return .installed
         }
 
         func uninstall(_ postHog: PostHogSDK) {

--- a/PostHogTests/PostHogConfigTest.swift
+++ b/PostHogTests/PostHogConfigTest.swift
@@ -97,7 +97,7 @@ class PostHogConfigTest: QuickSpec {
             context("when initialized with default tracing headers configuration") {
                 it("should disable tracing headers by default") {
                     let sut = PostHogConfig(apiKey: testAPIKey)
-                    expect(sut.addTracingHeaders).to(beNil())
+                    expect(sut.tracingHeaders).to(beNil())
                 }
             }
 

--- a/PostHogTests/PostHogConfigTest.swift
+++ b/PostHogTests/PostHogConfigTest.swift
@@ -94,6 +94,13 @@ class PostHogConfigTest: QuickSpec {
                 }
             }
 
+            context("when initialized with default tracing headers configuration") {
+                it("should disable tracing headers by default") {
+                    let sut = PostHogConfig(apiKey: testAPIKey)
+                    expect(sut.addTracingHeaders).to(beNil())
+                }
+            }
+
             context("when customized") {
                 it("should allow disabling autocapture") {
                     let config = PostHogConfig(projectToken: testProjectToken)

--- a/PostHogTests/PostHogRemoteConfigTest.swift
+++ b/PostHogTests/PostHogRemoteConfigTest.swift
@@ -761,40 +761,52 @@ enum PostHogRemoteConfigTest {
 
     @Suite("Test Error Tracking Config")
     class TestErrorTrackingConfig: BaseTestClass {
+        private func makeIsolatedConfig(disableRemoteConfigForTesting: Bool = true) -> PostHogConfig {
+            let config = PostHogConfig(projectToken: "\(testProjectToken)-\(UUID().uuidString)", host: "http://localhost:9001")
+            config.disableRemoteConfigForTesting = disableRemoteConfigForTesting
+            return config
+        }
+
         @Test("returns isAutocaptureExceptionsEnabled false by default")
         func returnsAutocaptureExceptionsDisabledByDefault() {
-            let sut = getSut()
+            let config = makeIsolatedConfig()
+            let storage = PostHogStorage(config)
+            defer { storage.reset() }
+
+            let sut = getSut(storage: storage, config: config)
 
             #expect(sut.isAutocaptureExceptionsEnabled() == false)
         }
 
         @Test("returns isAutocaptureExceptionsEnabled true from cached config")
         func returnsAutocaptureExceptionsEnabledFromCache() {
+            let config = makeIsolatedConfig()
             let storage = PostHogStorage(config)
             defer { storage.reset() }
 
             storage.setDictionary(forKey: .errorTracking, contents: ["autocaptureExceptions": true])
 
-            let sut = getSut(storage: storage)
+            let sut = getSut(storage: storage, config: config)
 
             #expect(sut.isAutocaptureExceptionsEnabled() == true)
         }
 
         @Test("returns isAutocaptureExceptionsEnabled false from cached config when disabled")
         func returnsAutocaptureExceptionsDisabledFromCache() {
+            let config = makeIsolatedConfig()
             let storage = PostHogStorage(config)
             defer { storage.reset() }
 
             storage.setDictionary(forKey: .errorTracking, contents: ["autocaptureExceptions": false])
 
-            let sut = getSut(storage: storage)
+            let sut = getSut(storage: storage, config: config)
 
             #expect(sut.isAutocaptureExceptionsEnabled() == false)
         }
 
         @Test("enables autocapture exceptions from remote config dict")
         func enablesAutocaptureExceptionsFromRemoteConfigDict() async {
-            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
+            let config = makeIsolatedConfig(disableRemoteConfigForTesting: false)
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
 
@@ -824,7 +836,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("disables autocapture exceptions from remote config dict")
         func disablesAutocaptureExceptionsFromRemoteConfigDict() async {
-            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
+            let config = makeIsolatedConfig(disableRemoteConfigForTesting: false)
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
 
@@ -853,7 +865,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("disables autocapture exceptions when errorTracking is boolean false")
         func disablesAutocaptureExceptionsWhenErrorTrackingIsBooleanFalse() async {
-            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
+            let config = makeIsolatedConfig(disableRemoteConfigForTesting: false)
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
 
@@ -889,7 +901,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("disables autocapture exceptions when errorTracking key is missing")
         func disablesAutocaptureExceptionsWhenErrorTrackingKeyIsMissing() async {
-            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
+            let config = makeIsolatedConfig(disableRemoteConfigForTesting: false)
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
 

--- a/PostHogTests/PostHogSessionReplayPluginTest.swift
+++ b/PostHogTests/PostHogSessionReplayPluginTest.swift
@@ -5,6 +5,16 @@
 
     @Suite("Session Replay Plugin Remote Config Tests")
     class PostHogSessionReplayPluginTests {
+        struct IgnoredNetworkRequestCase: CustomTestStringConvertible {
+            let name: String
+            let requestURL: String
+            let apiHost: String
+            let snapshotEndpoint: String
+            let expected: Bool
+
+            var testDescription: String { name }
+        }
+
         // MARK: - Console Logs Plugin Tests
 
         @Test("Console logs plugin disabled when remote config is nil")
@@ -129,6 +139,84 @@
                 "capturePerformance": false,
             ]
             #expect(PostHogSessionReplayNetworkPlugin.isEnabledRemotely(remoteConfig: config) == false)
+        }
+
+        @Test("Network replay capture ignores PostHog ingestion requests", arguments: [
+            IgnoredNetworkRequestCase(
+                name: "ignores snapshot ingestion on the configured host",
+                requestURL: "https://us.i.posthog.com/s/?ip=1",
+                apiHost: "https://us.i.posthog.com",
+                snapshotEndpoint: "/s/",
+                expected: true
+            ),
+            IgnoredNetworkRequestCase(
+                name: "ignores batch ingestion on the configured host",
+                requestURL: "https://us.i.posthog.com/batch",
+                apiHost: "https://us.i.posthog.com",
+                snapshotEndpoint: "/s/",
+                expected: true
+            ),
+            IgnoredNetworkRequestCase(
+                name: "ignores replay ingestion behind a reverse proxy path",
+                requestURL: "https://app.posthog.com/ingest/s/?ip=1",
+                apiHost: "https://app.posthog.com/ingest",
+                snapshotEndpoint: "/s/",
+                expected: true
+            ),
+            IgnoredNetworkRequestCase(
+                name: "ignores batch ingestion behind a reverse proxy path",
+                requestURL: "https://app.posthog.com/ingest/batch",
+                apiHost: "https://app.posthog.com/ingest",
+                snapshotEndpoint: "/s/",
+                expected: true
+            ),
+            IgnoredNetworkRequestCase(
+                name: "ignores a remotely configured snapshot endpoint",
+                requestURL: "https://us.i.posthog.com/newS/?ip=1",
+                apiHost: "https://us.i.posthog.com",
+                snapshotEndpoint: "/newS/",
+                expected: true
+            ),
+            IgnoredNetworkRequestCase(
+                name: "ignores legacy ingestion paths on the configured host",
+                requestURL: "https://us.i.posthog.com/i/v0/e/?ip=1",
+                apiHost: "https://us.i.posthog.com",
+                snapshotEndpoint: "/s/",
+                expected: true
+            ),
+            IgnoredNetworkRequestCase(
+                name: "does not ignore non ingestion paths on the configured host",
+                requestURL: "https://us.i.posthog.com/flags?v=2",
+                apiHost: "https://us.i.posthog.com",
+                snapshotEndpoint: "/s/",
+                expected: false
+            ),
+            IgnoredNetworkRequestCase(
+                name: "does not ignore requests outside the reverse proxy base path",
+                requestURL: "https://app.posthog.com/ingest-extra/batch",
+                apiHost: "https://app.posthog.com/ingest",
+                snapshotEndpoint: "/s/",
+                expected: false
+            ),
+            IgnoredNetworkRequestCase(
+                name: "does not ignore third party hosts with similar paths",
+                requestURL: "https://api.example.com/batch",
+                apiHost: "https://us.i.posthog.com",
+                snapshotEndpoint: "/s/",
+                expected: false
+            ),
+        ])
+        func networkReplayCaptureIgnoresPostHogIngestionRequests(_ testCase: IgnoredNetworkRequestCase) throws {
+            let requestURL = try #require(URL(string: testCase.requestURL))
+            let apiHost = try #require(URL(string: testCase.apiHost))
+
+            #expect(
+                PostHogSessionReplayNetworkPlugin.shouldIgnoreNetworkRequest(
+                    url: requestURL,
+                    apiHost: apiHost,
+                    snapshotEndpoint: testCase.snapshotEndpoint
+                ) == testCase.expected
+            )
         }
     }
 #endif

--- a/PostHogTests/PostHogTracingHeadersTest.swift
+++ b/PostHogTests/PostHogTracingHeadersTest.swift
@@ -71,7 +71,7 @@
 
         @Test("adds distinct and session tracing headers to listed hosts for classic URLSession APIs", arguments: classicCases)
         func addsHeadersToListedHostsForClassicURLSessionAPIs(_ testCase: ClassicTracingCase) async throws {
-            try await withTracingSut(addTracingHeaders: [Self.primaryHost]) { sut in
+            try await withTracingSut(tracingHeaders: [Self.primaryHost]) { sut in
                 let capture = CapturedRequest()
                 stubRequest(host: Self.primaryHost, capture: capture)
 
@@ -85,7 +85,7 @@
 
         @Test("normalizes configured hostnames while keeping exact host matching")
         func normalizesConfiguredHostnamesWhileKeepingExactHostMatching() async throws {
-            try await withTracingSut(addTracingHeaders: ["  API.EXAMPLE.COM  "]) { sut in
+            try await withTracingSut(tracingHeaders: ["  API.EXAMPLE.COM  "]) { sut in
                 let matchingCapture = CapturedRequest()
                 stubRequest(host: Self.primaryHost, capture: matchingCapture)
 
@@ -112,7 +112,7 @@
                 return
             }
 
-            try await withTracingSut(addTracingHeaders: [Self.primaryHost]) { sut in
+            try await withTracingSut(tracingHeaders: [Self.primaryHost]) { sut in
                 let capture = CapturedRequest()
                 stubRequest(host: Self.primaryHost, capture: capture)
 
@@ -153,7 +153,7 @@
 
         @Test("does not add tracing headers to unlisted hosts for URL data tasks")
         func doesNotAddHeadersToUnlistedHostsForURLDataTasks() async throws {
-            try await withTracingSut(addTracingHeaders: [Self.primaryHost]) { _ in
+            try await withTracingSut(tracingHeaders: [Self.primaryHost]) { _ in
                 let capture = CapturedRequest()
                 stubRequest(host: Self.otherHost, capture: capture)
 
@@ -166,7 +166,7 @@
 
         @Test("keeps distinct id header but omits session tracing headers when the session has ended")
         func omitsSessionHeadersWhenSessionHasEnded() async throws {
-            try await withTracingSut(addTracingHeaders: [Self.primaryHost]) { sut in
+            try await withTracingSut(tracingHeaders: [Self.primaryHost]) { sut in
                 sut.endSession()
 
                 let capture = CapturedRequest()
@@ -180,13 +180,13 @@
         }
 
         private func withTracingSut<T>(
-            addTracingHeaders: [String],
+            tracingHeaders: [String],
             _ body: (PostHogSDK) async throws -> T
         ) async throws -> T {
             PostHogTracingHeadersIntegration.clearInstalls()
             HTTPStubs.removeAllStubs()
 
-            let sut = makeSut(addTracingHeaders: addTracingHeaders)
+            let sut = makeSut(tracingHeaders: tracingHeaders)
             defer {
                 sut.close()
                 HTTPStubs.removeAllStubs()
@@ -267,9 +267,9 @@
             try #require(URL(string: "https://\(host)/test"))
         }
 
-        private func makeSut(addTracingHeaders: [String]) -> PostHogSDK {
+        private func makeSut(tracingHeaders: [String]) -> PostHogSDK {
             let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
-            config.addTracingHeaders = addTracingHeaders
+            config.tracingHeaders = tracingHeaders
             config.captureApplicationLifecycleEvents = false
             config.captureScreenViews = false
             config.disableReachabilityForTesting = true

--- a/PostHogTests/PostHogTracingHeadersTest.swift
+++ b/PostHogTests/PostHogTracingHeadersTest.swift
@@ -5,8 +5,8 @@
     @testable import PostHog
     import Testing
 
-    struct ClassicTracingCase: CustomTestStringConvertible, Sendable {
-        enum Invocation: Sendable {
+    struct ClassicTracingCase: CustomTestStringConvertible {
+        enum Invocation {
             case dataTaskWithRequest
             case dataTaskWithURL
             case dataTaskWithCustomSession
@@ -20,8 +20,8 @@
         var testDescription: String { name }
     }
 
-    struct AsyncTracingCase: CustomTestStringConvertible, Sendable {
-        enum Invocation: Sendable {
+    struct AsyncTracingCase: CustomTestStringConvertible {
+        enum Invocation {
             case dataForRequest
             case dataFromURL
             case uploadForRequest

--- a/PostHogTests/PostHogTracingHeadersTest.swift
+++ b/PostHogTests/PostHogTracingHeadersTest.swift
@@ -38,6 +38,22 @@
         var testDescription: String { name }
     }
 
+    struct WrapperTracingCase: CustomTestStringConvertible {
+        enum Invocation {
+            case postHogDataForRequest
+            case postHogDataFromURL
+            case postHogUploadForRequest
+            case postHogUploadFileForRequest
+            case postHogDownloadForRequest
+            case postHogDownloadFromURL
+        }
+
+        let name: String
+        let invocation: Invocation
+
+        var testDescription: String { name }
+    }
+
     @Suite("Tracing headers", .serialized)
     struct PostHogTracingHeadersTest {
         private static let primaryHost = "api.example.com"
@@ -67,6 +83,15 @@
             .init(name: "download(from:)", invocation: .downloadFromURL),
             .init(name: "bytes(for:)", invocation: .bytesForRequest),
             .init(name: "bytes(from:)", invocation: .bytesFromURL),
+        ]
+
+        private static let wrapperCases: [WrapperTracingCase] = [
+            .init(name: "postHogData(for:)", invocation: .postHogDataForRequest),
+            .init(name: "postHogData(from:)", invocation: .postHogDataFromURL),
+            .init(name: "postHogUpload(for:from:)", invocation: .postHogUploadForRequest),
+            .init(name: "postHogUpload(for:fromFile:)", invocation: .postHogUploadFileForRequest),
+            .init(name: "postHogDownload(for:)", invocation: .postHogDownloadForRequest),
+            .init(name: "postHogDownload(from:)", invocation: .postHogDownloadFromURL),
         ]
 
         @Test("adds distinct and session tracing headers to listed hosts for classic URLSession APIs", arguments: classicCases)
@@ -124,6 +149,24 @@
             }
         }
 
+        @Test("adds distinct and session tracing headers to PostHog URLSession wrapper APIs", arguments: wrapperCases)
+        func addsHeadersToPostHogURLSessionWrapperAPIs(_ testCase: WrapperTracingCase) async throws {
+            guard #available(iOS 15.0, *) else {
+                return
+            }
+
+            try await withTracingSut(tracingHeaders: [Self.primaryHost]) { sut in
+                let capture = CapturedRequest()
+                stubRequest(host: Self.primaryHost, capture: capture)
+
+                try await invokeWrapperTracingCase(testCase)
+
+                let capturedRequest = try #require(capture.request)
+                let sessionId = try #require(sut.getSessionId())
+                assertTracingHeaders(capturedRequest, sut: sut, expectedSessionId: sessionId)
+            }
+        }
+
         @Test("applies request modifiers only once for URL overloads")
         func appliesRequestModifiersOnlyOnceForURLOverloads() async throws {
             HTTPStubs.removeAllStubs()
@@ -149,6 +192,48 @@
 
             #expect(modifierInvocationCount.value == 1)
             #expect(capturedRequest.value(forHTTPHeaderField: "X-POSTHOG-MODIFIER-COUNT") == "1")
+        }
+
+        @Test("request modifiers coexist with task lifecycle handlers")
+        func requestModifiersCoexistWithTaskLifecycleHandlers() async throws {
+            HTTPStubs.removeAllStubs()
+
+            let taskCreatedCount = Counter()
+            let taskCompletedCount = Counter()
+            let createdTaskRequest = CapturedRequest()
+            let registrationId = try URLSessionInstrumentation.shared.register(
+                requestModifier: { request in
+                    var request = request
+                    request.setValue("true", forHTTPHeaderField: "X-POSTHOG-MODIFIED")
+                    return request
+                },
+                taskCreated: { task, _ in
+                    taskCreatedCount.incrementAndGet()
+                    if let request = task.originalRequest {
+                        createdTaskRequest.set(request)
+                    }
+                },
+                taskCompleted: { _, _ in
+                    taskCompletedCount.incrementAndGet()
+                }
+            )
+            defer {
+                URLSessionInstrumentation.shared.unregister(registrationId)
+                HTTPStubs.removeAllStubs()
+            }
+
+            let capture = CapturedRequest()
+            stubRequest(host: Self.primaryHost, capture: capture)
+
+            try await performDataTask(with: URLRequest(url: try makeURL(host: Self.primaryHost)))
+
+            let capturedRequest = try #require(capture.request)
+            let taskRequest = try #require(createdTaskRequest.request)
+
+            #expect(taskCreatedCount.value == 1)
+            #expect(taskCompletedCount.value == 1)
+            #expect(capturedRequest.value(forHTTPHeaderField: "X-POSTHOG-MODIFIED") == "true")
+            #expect(taskRequest.value(forHTTPHeaderField: "X-POSTHOG-MODIFIED") == "true")
         }
 
         @Test("does not add tracing headers to unlisted hosts for URL data tasks")
@@ -242,6 +327,29 @@
             case .bytesFromURL:
                 let (bytes, _) = try await URLSession.shared.bytes(from: url)
                 try await consumeFirstByte(from: bytes)
+            }
+        }
+
+        @available(iOS 15.0, *)
+        private func invokeWrapperTracingCase(_ testCase: WrapperTracingCase) async throws {
+            let url = try makeURL(host: Self.primaryHost)
+            let request = URLRequest(url: url)
+
+            switch testCase.invocation {
+            case .postHogDataForRequest:
+                _ = try await URLSession.shared.postHogData(for: request)
+            case .postHogDataFromURL:
+                _ = try await URLSession.shared.postHogData(from: url)
+            case .postHogUploadForRequest:
+                _ = try await URLSession.shared.postHogUpload(for: request, from: Self.payloadData)
+            case .postHogUploadFileForRequest:
+                try await withTemporaryFile(contents: Self.payloadData) { fileURL in
+                    _ = try await URLSession.shared.postHogUpload(for: request, fromFile: fileURL)
+                }
+            case .postHogDownloadForRequest:
+                _ = try await URLSession.shared.postHogDownload(for: request)
+            case .postHogDownloadFromURL:
+                _ = try await URLSession.shared.postHogDownload(from: url)
             }
         }
 

--- a/PostHogTests/PostHogTracingHeadersTest.swift
+++ b/PostHogTests/PostHogTracingHeadersTest.swift
@@ -1,0 +1,397 @@
+#if os(iOS)
+    import Foundation
+    import OHHTTPStubs
+    import OHHTTPStubsSwift
+    @testable import PostHog
+    import Testing
+
+    struct ClassicTracingCase: CustomTestStringConvertible, Sendable {
+        enum Invocation: Sendable {
+            case dataTaskWithRequest
+            case dataTaskWithURL
+            case dataTaskWithCustomSession
+            case uploadTaskWithRequest
+            case downloadTaskWithRequest
+        }
+
+        let name: String
+        let invocation: Invocation
+
+        var testDescription: String { name }
+    }
+
+    struct AsyncTracingCase: CustomTestStringConvertible, Sendable {
+        enum Invocation: Sendable {
+            case dataForRequest
+            case dataFromURL
+            case uploadForRequest
+            case uploadFileForRequest
+            case downloadForRequest
+            case downloadFromURL
+            case bytesForRequest
+            case bytesFromURL
+        }
+
+        let name: String
+        let invocation: Invocation
+
+        var testDescription: String { name }
+    }
+
+    @Suite("Tracing headers", .serialized)
+    struct PostHogTracingHeadersTest {
+        private static let primaryHost = "api.example.com"
+        private static let otherHost = "other.example.com"
+        private static let subdomainHost = "sub.api.example.com"
+
+        private static let distinctIdHeader = "X-POSTHOG-DISTINCT-ID"
+        private static let sessionIdHeader = "X-POSTHOG-SESSION-ID"
+        private static let windowIdHeader = "X-POSTHOG-WINDOW-ID"
+
+        private static let payloadData = Data("payload".utf8)
+
+        private static let classicCases: [ClassicTracingCase] = [
+            .init(name: "dataTask(with: URLRequest, completionHandler:)", invocation: .dataTaskWithRequest),
+            .init(name: "dataTask(with: URL, completionHandler:)", invocation: .dataTaskWithURL),
+            .init(name: "dataTask(with: URLRequest, completionHandler:) on custom URLSession", invocation: .dataTaskWithCustomSession),
+            .init(name: "uploadTask(with:from:completionHandler:)", invocation: .uploadTaskWithRequest),
+            .init(name: "downloadTask(with:completionHandler:)", invocation: .downloadTaskWithRequest),
+        ]
+
+        private static let asyncCases: [AsyncTracingCase] = [
+            .init(name: "data(for:)", invocation: .dataForRequest),
+            .init(name: "data(from:)", invocation: .dataFromURL),
+            .init(name: "upload(for:from:)", invocation: .uploadForRequest),
+            .init(name: "upload(for:fromFile:)", invocation: .uploadFileForRequest),
+            .init(name: "download(for:)", invocation: .downloadForRequest),
+            .init(name: "download(from:)", invocation: .downloadFromURL),
+            .init(name: "bytes(for:)", invocation: .bytesForRequest),
+            .init(name: "bytes(from:)", invocation: .bytesFromURL),
+        ]
+
+        @Test("adds distinct and session tracing headers to listed hosts for classic URLSession APIs", arguments: classicCases)
+        func addsHeadersToListedHostsForClassicURLSessionAPIs(_ testCase: ClassicTracingCase) async throws {
+            try await withTracingSut(addTracingHeaders: [Self.primaryHost]) { sut in
+                let capture = CapturedRequest()
+                stubRequest(host: Self.primaryHost, capture: capture)
+
+                try await invokeClassicTracingCase(testCase)
+
+                let capturedRequest = try #require(capture.request)
+                let sessionId = try #require(sut.getSessionId())
+                assertTracingHeaders(capturedRequest, sut: sut, expectedSessionId: sessionId)
+            }
+        }
+
+        @Test("normalizes configured hostnames while keeping exact host matching")
+        func normalizesConfiguredHostnamesWhileKeepingExactHostMatching() async throws {
+            try await withTracingSut(addTracingHeaders: ["  API.EXAMPLE.COM  "]) { sut in
+                let matchingCapture = CapturedRequest()
+                stubRequest(host: Self.primaryHost, capture: matchingCapture)
+
+                try await performDataTask(with: try makeURL(host: Self.primaryHost))
+
+                let matchingRequest = try #require(matchingCapture.request)
+                #expect(matchingRequest.value(forHTTPHeaderField: Self.distinctIdHeader) == sut.getDistinctId())
+
+                HTTPStubs.removeAllStubs()
+
+                let nonMatchingCapture = CapturedRequest()
+                stubRequest(host: Self.subdomainHost, capture: nonMatchingCapture)
+
+                try await performDataTask(with: try makeURL(host: Self.subdomainHost))
+
+                let nonMatchingRequest = try #require(nonMatchingCapture.request)
+                assertNoTracingHeaders(nonMatchingRequest)
+            }
+        }
+
+        @Test("adds distinct and session tracing headers to listed hosts for async await URLSession APIs", arguments: asyncCases)
+        func addsHeadersToListedHostsForAsyncAwaitURLSessionAPIs(_ testCase: AsyncTracingCase) async throws {
+            guard #available(iOS 15.0, *) else {
+                return
+            }
+
+            try await withTracingSut(addTracingHeaders: [Self.primaryHost]) { sut in
+                let capture = CapturedRequest()
+                stubRequest(host: Self.primaryHost, capture: capture)
+
+                try await invokeAsyncTracingCase(testCase)
+
+                let capturedRequest = try #require(capture.request)
+                let sessionId = try #require(sut.getSessionId())
+                assertTracingHeaders(capturedRequest, sut: sut, expectedSessionId: sessionId)
+            }
+        }
+
+        @Test("applies request modifiers only once for URL overloads")
+        func appliesRequestModifiersOnlyOnceForURLOverloads() async throws {
+            HTTPStubs.removeAllStubs()
+
+            let modifierInvocationCount = Counter()
+            let registrationId = try URLSessionInstrumentation.shared.register(requestModifier: { request in
+                let invocationCount = modifierInvocationCount.incrementAndGet()
+                var request = request
+                request.setValue(String(invocationCount), forHTTPHeaderField: "X-POSTHOG-MODIFIER-COUNT")
+                return request
+            })
+            defer {
+                URLSessionInstrumentation.shared.unregister(registrationId)
+                HTTPStubs.removeAllStubs()
+            }
+
+            let capture = CapturedRequest()
+            stubRequest(host: Self.primaryHost, capture: capture)
+
+            try await performDataTask(with: makeURL(host: Self.primaryHost))
+
+            let capturedRequest = try #require(capture.request)
+
+            #expect(modifierInvocationCount.value == 1)
+            #expect(capturedRequest.value(forHTTPHeaderField: "X-POSTHOG-MODIFIER-COUNT") == "1")
+        }
+
+        @Test("does not add tracing headers to unlisted hosts for URL data tasks")
+        func doesNotAddHeadersToUnlistedHostsForURLDataTasks() async throws {
+            try await withTracingSut(addTracingHeaders: [Self.primaryHost]) { _ in
+                let capture = CapturedRequest()
+                stubRequest(host: Self.otherHost, capture: capture)
+
+                try await performDataTask(with: try makeURL(host: Self.otherHost))
+
+                let capturedRequest = try #require(capture.request)
+                assertNoTracingHeaders(capturedRequest)
+            }
+        }
+
+        @Test("keeps distinct id header but omits session tracing headers when the session has ended")
+        func omitsSessionHeadersWhenSessionHasEnded() async throws {
+            try await withTracingSut(addTracingHeaders: [Self.primaryHost]) { sut in
+                sut.endSession()
+
+                let capture = CapturedRequest()
+                stubRequest(host: Self.primaryHost, capture: capture)
+
+                try await performDataTask(with: try makeURL(host: Self.primaryHost))
+
+                let capturedRequest = try #require(capture.request)
+                assertTracingHeaders(capturedRequest, sut: sut, expectedSessionId: nil)
+            }
+        }
+
+        private func withTracingSut<T>(
+            addTracingHeaders: [String],
+            _ body: (PostHogSDK) async throws -> T
+        ) async throws -> T {
+            PostHogTracingHeadersIntegration.clearInstalls()
+            HTTPStubs.removeAllStubs()
+
+            let sut = makeSut(addTracingHeaders: addTracingHeaders)
+            defer {
+                sut.close()
+                HTTPStubs.removeAllStubs()
+                PostHogTracingHeadersIntegration.clearInstalls()
+            }
+
+            return try await body(sut)
+        }
+
+        private func invokeClassicTracingCase(_ testCase: ClassicTracingCase) async throws {
+            let url = try makeURL(host: Self.primaryHost)
+            let request = URLRequest(url: url)
+
+            switch testCase.invocation {
+            case .dataTaskWithRequest:
+                try await performDataTask(with: request)
+            case .dataTaskWithURL:
+                try await performDataTask(with: url)
+            case .dataTaskWithCustomSession:
+                let session = URLSession(configuration: .ephemeral)
+                defer { session.invalidateAndCancel() }
+                try await performDataTask(with: request, using: session)
+            case .uploadTaskWithRequest:
+                try await performUploadTask(with: request, body: Self.payloadData)
+            case .downloadTaskWithRequest:
+                try await performDownloadTask(with: request)
+            }
+        }
+
+        @available(iOS 15.0, *)
+        private func invokeAsyncTracingCase(_ testCase: AsyncTracingCase) async throws {
+            let url = try makeURL(host: Self.primaryHost)
+            let request = URLRequest(url: url)
+
+            switch testCase.invocation {
+            case .dataForRequest:
+                _ = try await URLSession.shared.data(for: request)
+            case .dataFromURL:
+                _ = try await URLSession.shared.data(from: url)
+            case .uploadForRequest:
+                _ = try await URLSession.shared.upload(for: request, from: Self.payloadData)
+            case .uploadFileForRequest:
+                try await withTemporaryFile(contents: Self.payloadData) { fileURL in
+                    _ = try await URLSession.shared.upload(for: request, fromFile: fileURL)
+                }
+            case .downloadForRequest:
+                _ = try await URLSession.shared.download(for: request)
+            case .downloadFromURL:
+                _ = try await URLSession.shared.download(from: url)
+            case .bytesForRequest:
+                let (bytes, _) = try await URLSession.shared.bytes(for: request)
+                try await consumeFirstByte(from: bytes)
+            case .bytesFromURL:
+                let (bytes, _) = try await URLSession.shared.bytes(from: url)
+                try await consumeFirstByte(from: bytes)
+            }
+        }
+
+        @available(iOS 15.0, *)
+        private func consumeFirstByte(from bytes: URLSession.AsyncBytes) async throws {
+            var iterator = bytes.makeAsyncIterator()
+            _ = try await iterator.next()
+        }
+
+        private func assertTracingHeaders(_ request: URLRequest, sut: PostHogSDK, expectedSessionId: String?) {
+            #expect(request.value(forHTTPHeaderField: Self.distinctIdHeader) == sut.getDistinctId())
+            #expect(request.value(forHTTPHeaderField: Self.sessionIdHeader) == expectedSessionId)
+            #expect(request.value(forHTTPHeaderField: Self.windowIdHeader) == nil)
+        }
+
+        private func assertNoTracingHeaders(_ request: URLRequest) {
+            #expect(request.value(forHTTPHeaderField: Self.distinctIdHeader) == nil)
+            #expect(request.value(forHTTPHeaderField: Self.sessionIdHeader) == nil)
+            #expect(request.value(forHTTPHeaderField: Self.windowIdHeader) == nil)
+        }
+
+        private func makeURL(host: String) throws -> URL {
+            try #require(URL(string: "https://\(host)/test"))
+        }
+
+        private func makeSut(addTracingHeaders: [String]) -> PostHogSDK {
+            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            config.addTracingHeaders = addTracingHeaders
+            config.captureApplicationLifecycleEvents = false
+            config.captureScreenViews = false
+            config.disableReachabilityForTesting = true
+            config.disableQueueTimerForTesting = true
+            config.disableFlushOnBackgroundForTesting = true
+            config.disableRemoteConfigForTesting = true
+
+            let storage = PostHogStorage(config)
+            storage.reset()
+
+            return PostHogSDK.with(config)
+        }
+
+        private func stubRequest(host: String, capture: CapturedRequest) {
+            stub(condition: isHost(host)) { request in
+                capture.set(request)
+                return HTTPStubsResponse(
+                    data: Data("ok".utf8),
+                    statusCode: 200,
+                    headers: ["Content-Type": "text/plain"]
+                )
+            }
+        }
+
+        private func performDataTask(with request: URLRequest, using session: URLSession = .shared) async throws {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                let task = session.dataTask(with: request) { _, _, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume(returning: ())
+                    }
+                }
+                task.resume()
+            }
+        }
+
+        private func performDataTask(with url: URL, using session: URLSession = .shared) async throws {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                let task = session.dataTask(with: url) { _, _, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume(returning: ())
+                    }
+                }
+                task.resume()
+            }
+        }
+
+        private func performUploadTask(with request: URLRequest, body: Data, using session: URLSession = .shared) async throws {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                let task = session.uploadTask(with: request, from: body) { _, _, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume(returning: ())
+                    }
+                }
+                task.resume()
+            }
+        }
+
+        private func performDownloadTask(with request: URLRequest, using session: URLSession = .shared) async throws {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                let task = session.downloadTask(with: request) { _, _, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume(returning: ())
+                    }
+                }
+                task.resume()
+            }
+        }
+
+        private func withTemporaryFile<T>(
+            contents: Data,
+            _ body: (URL) async throws -> T
+        ) async throws -> T {
+            let fileURL = try makeTemporaryFile(contents: contents)
+            defer { try? FileManager.default.removeItem(at: fileURL) }
+            return try await body(fileURL)
+        }
+
+        private func makeTemporaryFile(contents: Data) throws -> URL {
+            let fileURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension("bin")
+            try contents.write(to: fileURL)
+            return fileURL
+        }
+    }
+
+    private final class CapturedRequest {
+        private let lock = NSLock()
+        private var _request: URLRequest?
+
+        var request: URLRequest? {
+            lock.withLock { _request }
+        }
+
+        func set(_ request: URLRequest) {
+            lock.withLock {
+                _request = request
+            }
+        }
+    }
+
+    private final class Counter {
+        private let lock = NSLock()
+        private var _value = 0
+
+        var value: Int {
+            lock.withLock { _value }
+        }
+
+        func incrementAndGet() -> Int {
+            lock.withLock {
+                _value += 1
+                return _value
+            }
+        }
+    }
+#endif


### PR DESCRIPTION
## :bulb: Motivation and Context

Add support for `addTracingHeaders` on iOS so apps can automatically attach PostHog tracing headers to selected outbound `URLSession` requests.

This is aimed at teams using `URLSession` directly across both classic completion-handler APIs and async/await APIs who want consistent outbound tracing headers on iOS.

## :green_heart: How did you test it?

- Added `PostHogTracingHeadersTest` coverage for:
  - classic `URLSession` data/upload/download task APIs
  - async/await `URLSession` data/upload/download/bytes APIs
  - custom `URLSession` configurations
  - exact-host matching and hostname normalization
  - unlisted-host omission
  - ended-session omission of session headers
  - single-application of request modifiers for URL overloads
- Ran:
  - `make test filter=PostHogConfigTest`
  - `xcrun xcodebuild test -scheme PostHog -destination 'id=043AFB16-0063-4585-9666-03FEC5FF694E' -only-testing:PostHogTests/PostHogTracingHeadersTest`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
