### PR TITLE
Rename apiKey to projectToken with aliases

### DIFF
--- a/.changeset/gentle-tigers-hunt.md
+++ b/.changeset/gentle-tigers-hunt.md
@@ -1,0 +1,5 @@
+---
+"PostHog": minor
+---
+
+Rename apiKey to projectToken with backward-compatible aliases

--- a/.changeset/gentle-tigers-hunt.md
+++ b/.changeset/gentle-tigers-hunt.md
@@ -1,5 +1,5 @@
 ---
-"PostHog": minor
+"posthog-ios": minor
 ---
 
 Rename apiKey to projectToken with backward-compatible aliases

--- a/PostHog/Models/PostHogEvent.swift
+++ b/PostHog/Models/PostHogEvent.swift
@@ -57,6 +57,7 @@ import Foundation
         let uuid = ((json["uuid"] as? String) ?? (json["message_id"] as? String)) ?? UUID.v7().uuidString
         let uuidObj = UUID(uuidString: uuid) ?? UUID.v7()
 
+        // Wire field name remains api_key, but it carries the PostHog project token.
         let projectKey = json["api_key"] as? String
 
         return PostHogEvent(
@@ -78,8 +79,9 @@ import Foundation
             "uuid": uuid.uuidString,
         ]
 
-        if let apiKey {
-            json["api_key"] = apiKey
+        if let projectToken = apiKey {
+            // Wire field name remains api_key, but it carries the PostHog project token.
+            json["api_key"] = projectToken
         }
 
         return json

--- a/PostHog/Models/PostHogEvent.swift
+++ b/PostHog/Models/PostHogEvent.swift
@@ -13,7 +13,9 @@ import Foundation
     @objc public var properties: [String: Any]
     @objc public var timestamp: Date
     @objc public private(set) var uuid: UUID
-    // Only used for Replay
+    // Only used for Replay.
+    // Publicly this remains named apiKey for BeforeSendBlock compatibility,
+    // but it carries the PostHog project token and is serialized as api_key on the wire.
     var apiKey: String?
 
     init(event: String, distinctId: String, properties: [String: Any]? = nil, timestamp: Date = Date(), uuid: UUID = UUID.v7(), apiKey: String? = nil) {
@@ -55,7 +57,7 @@ import Foundation
         let uuid = ((json["uuid"] as? String) ?? (json["message_id"] as? String)) ?? UUID.v7().uuidString
         let uuidObj = UUID(uuidString: uuid) ?? UUID.v7()
 
-        let apiKey = json["api_key"] as? String
+        let projectKey = json["api_key"] as? String
 
         return PostHogEvent(
             event: event,
@@ -63,7 +65,7 @@ import Foundation
             properties: properties,
             timestamp: timestampDate,
             uuid: uuidObj,
-            apiKey: apiKey
+            apiKey: projectKey
         )
     }
 

--- a/PostHog/PostHogApi.swift
+++ b/PostHog/PostHogApi.swift
@@ -71,7 +71,7 @@ class PostHogApi {
             return nil
         }
 
-        let url = baseUrl.appendingPathComponent("/array/\(config.apiKey)/config")
+        let url = baseUrl.appendingPathComponent("/array/\(config.projectToken)/config")
 
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
@@ -94,7 +94,7 @@ class PostHogApi {
         let request = getURLRequest(url)
 
         let toSend: [String: Any] = [
-            "api_key": self.config.apiKey,
+            "api_key": self.config.projectToken,
             "batch": events.map { $0.toJSON() },
             "sent_at": toISO8601String(Date()),
         ]
@@ -139,7 +139,7 @@ class PostHogApi {
         }
 
         for event in events {
-            event.apiKey = self.config.apiKey
+            event.apiKey = self.config.projectToken
         }
 
         let config = sessionConfig()
@@ -210,7 +210,7 @@ class PostHogApi {
         let request = getURLRequest(url)
 
         var toSend: [String: Any] = [
-            "api_key": self.config.apiKey,
+            "api_key": self.config.projectToken,
             "distinct_id": distinctId,
             "groups": groups,
             "timezone": TimeZone.current.identifier,

--- a/PostHog/PostHogApi.swift
+++ b/PostHog/PostHogApi.swift
@@ -94,6 +94,7 @@ class PostHogApi {
         let request = getURLRequest(url)
 
         let toSend: [String: Any] = [
+            // Wire field name remains api_key, but it carries the PostHog project token.
             "api_key": self.config.projectToken,
             "batch": events.map { $0.toJSON() },
             "sent_at": toISO8601String(Date()),
@@ -210,6 +211,7 @@ class PostHogApi {
         let request = getURLRequest(url)
 
         var toSend: [String: Any] = [
+            // Wire field name remains api_key, but it carries the PostHog project token.
             "api_key": self.config.projectToken,
             "distinct_id": distinctId,
             "groups": groups,

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -37,7 +37,18 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
     }
 
     @objc public let host: URL
-    @objc public let apiKey: String
+
+    /// Your PostHog project token.
+    ///
+    /// You can find it at:
+    /// https://us.posthog.com/settings/project-details#variables
+    ///
+    /// This field was formerly named <c>apiKey</c>.
+    @objc public let projectToken: String
+
+    /// Obsolete alias for <c>projectToken</c>.
+    @available(*, deprecated, message: "Use projectToken instead. This will be removed in the next major version.")
+    @objc public var apiKey: String { projectToken }
     @objc public var flushAt: Int = Defaults.flushAt
     @objc public var maxQueueSize: Int = Defaults.maxQueueSize
     @objc public var maxBatchSize: Int = Defaults.maxBatchSize
@@ -217,31 +228,50 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
     // internal
     public var storageManager: PostHogStorageManager?
 
-    private static func normalizeApiKey(_ apiKey: String) -> String {
-        let normalizedApiKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
-        if normalizedApiKey.isEmpty {
-            hedgeLog("apiKey is empty after trimming whitespace; check your project API key")
+    private static func normalizeProjectToken(_ projectToken: String) -> String {
+        let normalizedProjectToken = projectToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalizedProjectToken.isEmpty {
+            hedgeLog("Either projectToken or apiKey must be provided.")
         }
-        return normalizedApiKey
+        return normalizedProjectToken
     }
 
-    @objc(apiKey:)
+    @objc(projectToken:)
     public init(
-        apiKey: String
+        projectToken: String
     ) {
-        self.apiKey = Self.normalizeApiKey(apiKey)
+        self.projectToken = Self.normalizeProjectToken(projectToken)
         host = URL(string: PostHogConfig.defaultHost)!
     }
 
-    @objc(apiKey:host:)
+    @objc(projectToken:host:)
     public init(
-        apiKey: String,
+        projectToken: String,
         host: String = defaultHost
     ) {
         let normalizedHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        self.apiKey = Self.normalizeApiKey(apiKey)
+        self.projectToken = Self.normalizeProjectToken(projectToken)
         self.host = URL(string: normalizedHost.isEmpty ? PostHogConfig.defaultHost : normalizedHost) ?? URL(string: PostHogConfig.defaultHost)!
+    }
+
+    @available(*, deprecated, message: "Use init(projectToken:) instead. This will be removed in the next major version.")
+    @objc(apiKey:)
+    public convenience init(
+        apiKey: String
+    ) {
+        hedgeLog("apiKey is deprecated and will be removed in the next major version. Use projectToken instead.")
+        self.init(projectToken: apiKey)
+    }
+
+    @available(*, deprecated, message: "Use init(projectToken:host:) instead. This will be removed in the next major version.")
+    @objc(apiKey:host:)
+    public convenience init(
+        apiKey: String,
+        host: String = defaultHost
+    ) {
+        hedgeLog("apiKey is deprecated and will be removed in the next major version. Use projectToken instead.")
+        self.init(projectToken: apiKey, host: host)
     }
 
     /// Returns an array of integrations to be installed based on current configuration

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -48,7 +48,10 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
 
     /// Obsolete alias for <c>projectToken</c>.
     @available(*, deprecated, message: "Use projectToken instead. This will be removed in the next major version.")
-    @objc public var apiKey: String { projectToken }
+    @objc public var apiKey: String {
+        hedgeLog("apiKey is deprecated and will be removed in the next major version. Use projectToken instead.")
+        return projectToken
+    }
     @objc public var flushAt: Int = Defaults.flushAt
     @objc public var maxQueueSize: Int = Defaults.maxQueueSize
     @objc public var maxBatchSize: Int = Defaults.maxBatchSize

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -61,9 +61,9 @@ let maxRetryDelay = 30.0
 
     // nonisolated(unsafe) is introduced in Swift 5.10
     #if swift(>=5.10)
-        @objc public nonisolated(unsafe) static let shared: PostHogSDK = .init(PostHogConfig(apiKey: ""))
+        @objc public nonisolated(unsafe) static let shared: PostHogSDK = .init(PostHogConfig(projectToken: ""))
     #else
-        @objc public static let shared: PostHogSDK = .init(PostHogConfig(apiKey: ""))
+        @objc public static let shared: PostHogSDK = .init(PostHogConfig(projectToken: ""))
     #endif
 
     deinit {
@@ -91,10 +91,10 @@ let maxRetryDelay = 30.0
                 return
             }
 
-            if PostHogSDK.apiKeys.contains(config.apiKey) {
-                hedgeLog("API Key: \(config.apiKey) already has a PostHog instance.")
+            if PostHogSDK.apiKeys.contains(config.projectToken) {
+                hedgeLog("Project Token: \(config.projectToken) already has a PostHog instance.")
             } else {
-                PostHogSDK.apiKeys.insert(config.apiKey)
+                PostHogSDK.apiKeys.insert(config.projectToken)
             }
 
             enabled = true
@@ -1767,7 +1767,7 @@ let maxRetryDelay = 30.0
 
         setupLock.withLock {
             enabled = false
-            PostHogSDK.apiKeys.remove(config.apiKey)
+            PostHogSDK.apiKeys.remove(config.projectToken)
 
             queue?.stop()
             replayQueue?.stop()
@@ -1776,7 +1776,7 @@ let maxRetryDelay = 30.0
             replayQueue = nil
             config.storageManager?.reset(keepAnonymousId: config.reuseAnonymousId)
             config.storageManager = nil
-            config = PostHogConfig(apiKey: "")
+            config = PostHogConfig(projectToken: "")
             remoteConfig = nil
             storage = nil
             #if !os(watchOS)

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -1855,11 +1855,10 @@ let maxRetryDelay = 30.0
                 return hedgeLog("Could not start recording. Session replay feature flag is disabled.")
             }
 
-            let sessionId = resumeCurrent
+            guard (resumeCurrent
                 ? sessionManager.getSessionId()
-                : sessionManager.getNextSessionId()
-
-            guard let sessionId else {
+                : sessionManager.getNextSessionId()) != nil
+            else {
                 return hedgeLog("Could not start recording. Missing session id.")
             }
 

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -47,7 +47,7 @@ let maxRetryDelay = 30.0
     private var flagCallReported: [String: [Any?]] = .init()
     private(set) var remoteConfig: PostHogRemoteConfig?
     private var context: PostHogContext?
-    private static var apiKeys = Set<String>()
+    private static var projectTokens = Set<String>()
     private var installedIntegrations: [PostHogIntegration] = []
     let sessionManager = PostHogSessionManager()
     let onEventCaptured = PostHogMulticastCallback<PostHogEvent>()
@@ -91,10 +91,10 @@ let maxRetryDelay = 30.0
                 return
             }
 
-            if PostHogSDK.apiKeys.contains(config.projectToken) {
+            if PostHogSDK.projectTokens.contains(config.projectToken) {
                 hedgeLog("Project token: \(config.projectToken) already has a PostHog instance.")
             } else {
-                PostHogSDK.apiKeys.insert(config.projectToken)
+                PostHogSDK.projectTokens.insert(config.projectToken)
             }
 
             enabled = true
@@ -1767,7 +1767,7 @@ let maxRetryDelay = 30.0
 
         setupLock.withLock {
             enabled = false
-            PostHogSDK.apiKeys.remove(config.projectToken)
+            PostHogSDK.projectTokens.remove(config.projectToken)
 
             queue?.stop()
             replayQueue?.stop()

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -92,7 +92,7 @@ let maxRetryDelay = 30.0
             }
 
             if PostHogSDK.apiKeys.contains(config.projectToken) {
-                hedgeLog("Project Token: \(config.projectToken) already has a PostHog instance.")
+                hedgeLog("Project token: \(config.projectToken) already has a PostHog instance.")
             } else {
                 PostHogSDK.apiKeys.insert(config.projectToken)
             }

--- a/PostHog/PostHogStorage.swift
+++ b/PostHog/PostHogStorage.swift
@@ -382,7 +382,7 @@ class PostHogStorage {
 
     private static func getAppFolderUrl(from configuration: PostHogConfig) -> URL {
         let apiDir = getBaseAppFolderUrl(from: configuration)
-            .appendingPathComponent(configuration.apiKey)
+            .appendingPathComponent(configuration.projectToken)
 
         createDirectoryAtURLIfNeeded(url: apiDir)
 

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -1235,7 +1235,7 @@
         }
 
         func replayQueueDidBufferSnapshot(_ replayQueue: PostHogReplayQueue) {
-            guard let postHog else { return }
+            guard postHog != nil else { return }
 
             let minimumDuration: TimeInterval? = bufferingLock.withLock { cachedMinimumDuration }
             guard let minimumDuration, minimumDuration > 0 else {

--- a/PostHogExample/AppDelegate.swift
+++ b/PostHogExample/AppDelegate.swift
@@ -12,7 +12,7 @@ import UIKit
 class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         let config = PostHogConfig(
-            apiKey: "phc_WKfvDfedaJEDCoUmt9pVa3OWtbbUP1W2ctxwXkt3A3n"
+            projectToken: "phc_WKfvDfedaJEDCoUmt9pVa3OWtbbUP1W2ctxwXkt3A3n"
         )
         // the ScreenViews for SwiftUI does not work, the names are not useful
         config.captureScreenViews = false

--- a/PostHogExample/ContentView.swift
+++ b/PostHogExample/ContentView.swift
@@ -49,7 +49,7 @@ class FeatureFlagsModel: ObservableObject {
     @objc func reloaded() {
         boolValue = PostHogSDK.shared.isFeatureEnabled("4535-funnel-bar-viz")
         stringValue = PostHogSDK.shared.getFeatureFlag("multivariant") as? String
-        payloadValue = PostHogSDK.shared.getFeatureFlagPayload("multivariant") as? [String: String]
+        payloadValue = PostHogSDK.shared.getFeatureFlagResult("multivariant")?.payload as? [String: String]
     }
 
     func reload() {
@@ -131,19 +131,19 @@ struct ContentView: View {
 
     private func asyncLevel1() async throws {
         // Simulate some async work
-        await Task.sleep(10_000_000) // 0.01 seconds
+        try await Task.sleep(nanoseconds: 10_000_000) // 0.01 seconds
         try await asyncLevel2()
     }
 
     private func asyncLevel2() async throws {
         // Simulate more async work
-        await Task.sleep(20_000_000) // 0.02 seconds
+        try await Task.sleep(nanoseconds: 20_000_000) // 0.02 seconds
         try await asyncLevel3()
     }
 
     private func asyncLevel3() async throws {
         // Simulate final async work before error
-        await Task.sleep(30_000_000) // 0.03 seconds
+        try await Task.sleep(nanoseconds: 30_000_000) // 0.03 seconds
 
         // Throw an error from deep in the async chain
         throw AsyncTestError.deepAsyncError(

--- a/PostHogExample/PHGExceptionHandler.m
+++ b/PostHogExample/PHGExceptionHandler.m
@@ -43,7 +43,10 @@
 + (void)triggerSampleInvalidArgumentException {
     // This will throw an NSInvalidArgumentException
     NSMutableArray *mutableArray = [[NSMutableArray alloc] init];
-    [mutableArray insertObject:nil atIndex:0]; // Inserting nil object
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+    [mutableArray insertObject:nil atIndex:0]; // Inserting nil object intentionally
+#pragma clang diagnostic pop
 }
 
 + (void)triggerSampleGenericException {

--- a/PostHogExampleAutocapture/PostHogExampleAutocapture/AppDelegate.swift
+++ b/PostHogExampleAutocapture/PostHogExampleAutocapture/AppDelegate.swift
@@ -12,7 +12,7 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         let config = PostHogConfig(
-            apiKey: "phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D"
+            projectToken: "phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D"
         )
         config.debug = true
 

--- a/PostHogExampleExternalSDK/ExternalSDK.swift
+++ b/PostHogExampleExternalSDK/ExternalSDK.swift
@@ -13,7 +13,7 @@ public final class MyExternalSDK {
 
     private init() {
         let config = PostHogConfig(
-            apiKey: "phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D"
+            projectToken: "phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D"
         )
 
         config.captureScreenViews = true

--- a/PostHogExampleMacOS/AppDelegate.swift
+++ b/PostHogExampleMacOS/AppDelegate.swift
@@ -4,7 +4,7 @@ import PostHog
 class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_: Notification) {
         let config = PostHogConfig(
-            apiKey: "phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D"
+            projectToken: "phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D"
         )
         config.debug = true
 

--- a/PostHogExampleStoryboard/AppDelegate.swift
+++ b/PostHogExampleStoryboard/AppDelegate.swift
@@ -13,7 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         let config = PostHogConfig(
-            apiKey: "phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D"
+            projectToken: "phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D"
         )
         // the ScreenViews for SwiftUI does not work, the names are not useful
         config.captureScreenViews = false

--- a/PostHogExampleTvOS/AppDelegate.swift
+++ b/PostHogExampleTvOS/AppDelegate.swift
@@ -7,7 +7,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         let config = PostHogConfig(
-            apiKey: "phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D"
+            projectToken: "phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D"
         )
         config.debug = true
 

--- a/PostHogExampleVisionOS/PostHogExampleVisionOS/AppDelegate.swift
+++ b/PostHogExampleVisionOS/PostHogExampleVisionOS/AppDelegate.swift
@@ -13,7 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         let config = PostHogConfig(
-            apiKey: "phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D"
+            projectToken: "phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D"
         )
         config.debug = true
 

--- a/PostHogExampleWatchOS/PostHogExampleWatchOS Watch App/PostHogExampleWatchOSApp.swift
+++ b/PostHogExampleWatchOS/PostHogExampleWatchOS Watch App/PostHogExampleWatchOSApp.swift
@@ -13,7 +13,7 @@ struct PostHogExampleWatchOSApp: App {
     init() {
         // TODO: init on app delegate instead
         let config = PostHogConfig(
-            apiKey: "phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D"
+            projectToken: "phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D"
         )
 
         PostHogSDK.shared.setup(config)

--- a/PostHogExampleWithPods/PostHogExampleWithPods/AppDelegate.swift
+++ b/PostHogExampleWithPods/PostHogExampleWithPods/AppDelegate.swift
@@ -19,7 +19,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
                                   object: nil)
 
         let config = PostHogConfig(
-            apiKey: "phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D"
+            projectToken: "phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D"
         )
 
         PostHogSDK.shared.setup(config)

--- a/PostHogExampleWithSPM/PostHogExampleWithSPM/AppDelegate.swift
+++ b/PostHogExampleWithSPM/PostHogExampleWithSPM/AppDelegate.swift
@@ -18,7 +18,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
                                   object: nil)
 
         let config = PostHogConfig(
-            apiKey: "phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D"
+            projectToken: "phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D"
         )
 
         PostHogSDK.shared.setup(config)

--- a/PostHogObjCExample/AppDelegate.m
+++ b/PostHogObjCExample/AppDelegate.m
@@ -27,7 +27,7 @@
             name:PostHogSDK.didStartNotification
             object:nil];
 
-    PostHogConfig *config = [[PostHogConfig alloc] initWithProjectToken:@"_6SG-F7I1vCuZ-HdJL3VZQqjBlaSb1_20hDPwqMNnGI"];
+    PostHogConfig *config = [[PostHogConfig alloc] projectToken:@"_6SG-F7I1vCuZ-HdJL3VZQqjBlaSb1_20hDPwqMNnGI"];
     config.preloadFeatureFlags = YES;
     config.sessionReplayConfig.captureLogs = YES;
     config.sessionReplayConfig.captureLogsConfig.minLogLevel = PostHogLogLevelWarn;

--- a/PostHogObjCExample/AppDelegate.m
+++ b/PostHogObjCExample/AppDelegate.m
@@ -27,7 +27,7 @@
             name:PostHogSDK.didStartNotification
             object:nil];
 
-    PostHogConfig *config = [[PostHogConfig alloc] apiKey:@"_6SG-F7I1vCuZ-HdJL3VZQqjBlaSb1_20hDPwqMNnGI"];
+    PostHogConfig *config = [[PostHogConfig alloc] initWithProjectToken:@"_6SG-F7I1vCuZ-HdJL3VZQqjBlaSb1_20hDPwqMNnGI"];
     config.preloadFeatureFlags = YES;
     config.sessionReplayConfig.captureLogs = YES;
     config.sessionReplayConfig.captureLogsConfig.minLogLevel = PostHogLogLevelWarn;

--- a/PostHogTests/PostHogApiTest.swift
+++ b/PostHogTests/PostHogApiTest.swift
@@ -66,7 +66,7 @@ enum PostHogApiTests {
         }
 
         func getSut(host: String) -> PostHogApi {
-            PostHogApi(PostHogConfig(projectToken: "123", host: host))
+            PostHogApi(PostHogConfig(projectToken: "test_project_token", host: host))
         }
     }
 

--- a/PostHogTests/PostHogApiTest.swift
+++ b/PostHogTests/PostHogApiTest.swift
@@ -66,7 +66,7 @@ enum PostHogApiTests {
         }
 
         func getSut(host: String) -> PostHogApi {
-            PostHogApi(PostHogConfig(apiKey: "123", host: host))
+            PostHogApi(PostHogConfig(projectToken: "123", host: host))
         }
     }
 

--- a/PostHogTests/PostHogAppLifeCycleIntegrationTest.swift
+++ b/PostHogTests/PostHogAppLifeCycleIntegrationTest.swift
@@ -35,7 +35,7 @@ final class PostHogAppLifeCycleIntegrationTest {
         captureApplicationLifecycleEvents: Bool = true,
         disableFlushOnBackgroundForTesting: Bool = true
     ) -> PostHogSDK {
-        let config = PostHogConfig(apiKey: "app_lifecycle", host: "http://localhost:9000")
+        let config = PostHogConfig(projectToken: "app_lifecycle", host: "http://localhost:9000")
         config.captureApplicationLifecycleEvents = captureApplicationLifecycleEvents
         config.flushAt = flushAt
         config.maxBatchSize = flushAt

--- a/PostHogTests/PostHogAppLifeCycleIntegrationTest.swift
+++ b/PostHogTests/PostHogAppLifeCycleIntegrationTest.swift
@@ -35,7 +35,7 @@ final class PostHogAppLifeCycleIntegrationTest {
         captureApplicationLifecycleEvents: Bool = true,
         disableFlushOnBackgroundForTesting: Bool = true
     ) -> PostHogSDK {
-        let config = PostHogConfig(projectToken: "app_lifecycle", host: "http://localhost:9000")
+        let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost:9000")
         config.captureApplicationLifecycleEvents = captureApplicationLifecycleEvents
         config.flushAt = flushAt
         config.maxBatchSize = flushAt

--- a/PostHogTests/PostHogAutocaptureIntegrationSpec.swift
+++ b/PostHogTests/PostHogAutocaptureIntegrationSpec.swift
@@ -18,7 +18,7 @@ import Quick
             var posthog: PostHogSDK!
 
             beforeEach {
-                let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+                let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
                 config.captureElementInteractions = true
                 config.flushIntervalSeconds = 0.2
                 config.maxBatchSize = 1

--- a/PostHogTests/PostHogAutocaptureIntegrationSpec.swift
+++ b/PostHogTests/PostHogAutocaptureIntegrationSpec.swift
@@ -18,7 +18,7 @@ import Quick
             var posthog: PostHogSDK!
 
             beforeEach {
-                let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+                let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
                 config.captureElementInteractions = true
                 config.flushIntervalSeconds = 0.2
                 config.maxBatchSize = 1

--- a/PostHogTests/PostHogConfigTest.swift
+++ b/PostHogTests/PostHogConfigTest.swift
@@ -13,7 +13,7 @@ import Quick
 class PostHogConfigTest: QuickSpec {
     override func spec() {
         it("init config with default values") {
-            let config = PostHogConfig(projectToken: testAPIKey)
+            let config = PostHogConfig(projectToken: testProjectToken)
 
             expect(config.host) == URL(string: PostHogConfig.defaultHost)
             expect(config.flushAt) == 20
@@ -30,31 +30,31 @@ class PostHogConfigTest: QuickSpec {
         }
 
         it("init takes project token") {
-            let config = PostHogConfig(projectToken: testAPIKey)
+            let config = PostHogConfig(projectToken: testProjectToken)
 
-            expect(config.projectToken) == testAPIKey
-            expect(config.apiKey) == testAPIKey
+            expect(config.projectToken) == testProjectToken
+            expect(config.apiKey) == testProjectToken
         }
 
         it("trims whitespace-sensitive config values") {
             let config = PostHogConfig(
-                projectToken: " \n\(testAPIKey)\t ",
+                projectToken: " \n\(testProjectToken)\t ",
                 host: " \nhttps://eu.i.posthog.com/\t "
             )
 
-            expect(config.projectToken) == testAPIKey
-            expect(config.apiKey) == testAPIKey
+            expect(config.projectToken) == testProjectToken
+            expect(config.apiKey) == testProjectToken
             expect(config.host) == URL(string: "https://eu.i.posthog.com/")
         }
 
         it("defaults a blank host after trimming whitespace") {
-            let config = PostHogConfig(projectToken: testAPIKey, host: " \n\t ")
+            let config = PostHogConfig(projectToken: testProjectToken, host: " \n\t ")
 
             expect(config.host) == URL(string: PostHogConfig.defaultHost)
         }
 
         it("init takes host") {
-            let config = PostHogConfig(projectToken: testAPIKey, host: "localhost:9000")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "localhost:9000")
 
             expect(config.host) == URL(string: "localhost:9000")!
         }
@@ -62,14 +62,14 @@ class PostHogConfigTest: QuickSpec {
         #if os(iOS)
             context("when initialized with default values for captureElementInteractions") {
                 it("should enable autocapture by default") {
-                    let sut = PostHogConfig(projectToken: testAPIKey)
+                    let sut = PostHogConfig(projectToken: testProjectToken)
                     expect(sut.captureElementInteractions).to(beFalse())
                 }
             }
 
             context("when customized") {
                 it("should allow disabling autocapture") {
-                    let config = PostHogConfig(projectToken: testAPIKey)
+                    let config = PostHogConfig(projectToken: testProjectToken)
                     config.captureElementInteractions = false
                     expect(config.captureElementInteractions).to(beFalse())
                 }

--- a/PostHogTests/PostHogConfigTest.swift
+++ b/PostHogTests/PostHogConfigTest.swift
@@ -13,7 +13,7 @@ import Quick
 class PostHogConfigTest: QuickSpec {
     override func spec() {
         it("init config with default values") {
-            let config = PostHogConfig(apiKey: testAPIKey)
+            let config = PostHogConfig(projectToken: testAPIKey)
 
             expect(config.host) == URL(string: PostHogConfig.defaultHost)
             expect(config.flushAt) == 20
@@ -29,30 +29,32 @@ class PostHogConfigTest: QuickSpec {
             expect(config.optOut) == false
         }
 
-        it("init takes api key") {
-            let config = PostHogConfig(apiKey: testAPIKey)
+        it("init takes project token") {
+            let config = PostHogConfig(projectToken: testAPIKey)
 
+            expect(config.projectToken) == testAPIKey
             expect(config.apiKey) == testAPIKey
         }
 
         it("trims whitespace-sensitive config values") {
             let config = PostHogConfig(
-                apiKey: " \n\(testAPIKey)\t ",
+                projectToken: " \n\(testAPIKey)\t ",
                 host: " \nhttps://eu.i.posthog.com/\t "
             )
 
+            expect(config.projectToken) == testAPIKey
             expect(config.apiKey) == testAPIKey
             expect(config.host) == URL(string: "https://eu.i.posthog.com/")
         }
 
         it("defaults a blank host after trimming whitespace") {
-            let config = PostHogConfig(apiKey: testAPIKey, host: " \n\t ")
+            let config = PostHogConfig(projectToken: testAPIKey, host: " \n\t ")
 
             expect(config.host) == URL(string: PostHogConfig.defaultHost)
         }
 
         it("init takes host") {
-            let config = PostHogConfig(apiKey: testAPIKey, host: "localhost:9000")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "localhost:9000")
 
             expect(config.host) == URL(string: "localhost:9000")!
         }
@@ -60,14 +62,14 @@ class PostHogConfigTest: QuickSpec {
         #if os(iOS)
             context("when initialized with default values for captureElementInteractions") {
                 it("should enable autocapture by default") {
-                    let sut = PostHogConfig(apiKey: testAPIKey)
+                    let sut = PostHogConfig(projectToken: testAPIKey)
                     expect(sut.captureElementInteractions).to(beFalse())
                 }
             }
 
             context("when customized") {
                 it("should allow disabling autocapture") {
-                    let config = PostHogConfig(apiKey: testAPIKey)
+                    let config = PostHogConfig(projectToken: testAPIKey)
                     config.captureElementInteractions = false
                     expect(config.captureElementInteractions).to(beFalse())
                 }

--- a/PostHogTests/PostHogConfigTest.swift
+++ b/PostHogTests/PostHogConfigTest.swift
@@ -36,6 +36,33 @@ class PostHogConfigTest: QuickSpec {
             expect(config.apiKey) == testProjectToken
         }
 
+        it("deprecated init(apiKey:) maps to project token") {
+            let config = PostHogConfig(apiKey: testProjectToken)
+
+            expect(config.projectToken) == testProjectToken
+            expect(config.apiKey) == testProjectToken
+            expect(config.host) == URL(string: PostHogConfig.defaultHost)
+        }
+
+        it("deprecated init(apiKey:host:) maps to project token and host") {
+            let config = PostHogConfig(apiKey: testProjectToken, host: "localhost:9000")
+
+            expect(config.projectToken) == testProjectToken
+            expect(config.apiKey) == testProjectToken
+            expect(config.host) == URL(string: "localhost:9000")!
+        }
+
+        it("deprecated init(apiKey:host:) trims whitespace-sensitive values") {
+            let config = PostHogConfig(
+                apiKey: " \n\(testProjectToken)\t ",
+                host: " \nhttps://eu.i.posthog.com/\t "
+            )
+
+            expect(config.projectToken) == testProjectToken
+            expect(config.apiKey) == testProjectToken
+            expect(config.host) == URL(string: "https://eu.i.posthog.com/")
+        }
+
         it("trims whitespace-sensitive config values") {
             let config = PostHogConfig(
                 projectToken: " \n\(testProjectToken)\t ",

--- a/PostHogTests/PostHogDeepLinkIntegrationTests.swift
+++ b/PostHogTests/PostHogDeepLinkIntegrationTests.swift
@@ -90,7 +90,7 @@ final class PostHogDeepLinkEventTests {
     }
 
     private func getSut(flushAt: Int = 1) -> PostHogSDK {
-        let config = PostHogConfig(projectToken: "deep_link_test", host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost:9001")
         config.flushAt = flushAt
         config.maxBatchSize = flushAt
         config.captureApplicationLifecycleEvents = false
@@ -194,7 +194,7 @@ final class PostHogDeepLinkEventTests {
         sut.captureDeepLink(url: url)
 
         // Capture should be ignored, re-enable and capture something else
-        let config = PostHogConfig(projectToken: "deep_link_test_2", host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost:9001")
         config.flushAt = 1
         config.captureApplicationLifecycleEvents = false
         config.disableReachabilityForTesting = true

--- a/PostHogTests/PostHogDeepLinkIntegrationTests.swift
+++ b/PostHogTests/PostHogDeepLinkIntegrationTests.swift
@@ -90,7 +90,7 @@ final class PostHogDeepLinkEventTests {
     }
 
     private func getSut(flushAt: Int = 1) -> PostHogSDK {
-        let config = PostHogConfig(apiKey: "deep_link_test", host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: "deep_link_test", host: "http://localhost:9001")
         config.flushAt = flushAt
         config.maxBatchSize = flushAt
         config.captureApplicationLifecycleEvents = false
@@ -194,7 +194,7 @@ final class PostHogDeepLinkEventTests {
         sut.captureDeepLink(url: url)
 
         // Capture should be ignored, re-enable and capture something else
-        let config = PostHogConfig(apiKey: "deep_link_test_2", host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: "deep_link_test_2", host: "http://localhost:9001")
         config.flushAt = 1
         config.captureApplicationLifecycleEvents = false
         config.disableReachabilityForTesting = true

--- a/PostHogTests/PostHogDeviceBucketingTests.swift
+++ b/PostHogTests/PostHogDeviceBucketingTests.swift
@@ -20,7 +20,7 @@ class PostHogDeviceBucketingTests {
         reuseAnonymousId: Bool = false,
         flushAt: Int = 1
     ) -> PostHogSDK {
-        let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
         config.captureApplicationLifecycleEvents = false
         config.reuseAnonymousId = reuseAnonymousId
         config.flushAt = flushAt
@@ -148,7 +148,7 @@ class PostHogDeviceBucketingTests {
         let originalDeviceId = sut.getDeviceId()
         sut.close()
 
-        // Re-init with same storage (same API key hits the same storage path)
+        // Re-init with same storage (same project token hits the same storage path)
         sut = getSut()
         #expect(sut.getDeviceId() == originalDeviceId)
     }

--- a/PostHogTests/PostHogDeviceBucketingTests.swift
+++ b/PostHogTests/PostHogDeviceBucketingTests.swift
@@ -20,7 +20,7 @@ class PostHogDeviceBucketingTests {
         reuseAnonymousId: Bool = false,
         flushAt: Int = 1
     ) -> PostHogSDK {
-        let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
         config.captureApplicationLifecycleEvents = false
         config.reuseAnonymousId = reuseAnonymousId
         config.flushAt = flushAt

--- a/PostHogTests/PostHogDeviceBucketingTests.swift
+++ b/PostHogTests/PostHogDeviceBucketingTests.swift
@@ -17,10 +17,11 @@ class PostHogDeviceBucketingTests {
     var cleanupJobs: [() -> Void]
 
     func getSut(
+        projectToken: String = UUID().uuidString,
         reuseAnonymousId: Bool = false,
         flushAt: Int = 1
     ) -> PostHogSDK {
-        let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: projectToken, host: "http://localhost:9001")
         config.captureApplicationLifecycleEvents = false
         config.reuseAnonymousId = reuseAnonymousId
         config.flushAt = flushAt
@@ -144,12 +145,13 @@ class PostHogDeviceBucketingTests {
 
     @Test("persists device_id across SDK restarts")
     func persistsDeviceIdAcrossSdkRestarts() {
-        var sut = getSut()
+        let projectToken = UUID().uuidString
+        var sut = getSut(projectToken: projectToken)
         let originalDeviceId = sut.getDeviceId()
         sut.close()
 
         // Re-init with same storage (same project token hits the same storage path)
-        sut = getSut()
+        sut = getSut(projectToken: projectToken)
         #expect(sut.getDeviceId() == originalDeviceId)
     }
 }

--- a/PostHogTests/PostHogEnrichedAnalyticsTest.swift
+++ b/PostHogTests/PostHogEnrichedAnalyticsTest.swift
@@ -26,7 +26,7 @@ class PostHogEnrichedAnalyticsTest {
     }
 
     func getSut(optOut: Bool = false) -> PostHogSDK {
-        let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
         config.flushAt = 1
         config.captureApplicationLifecycleEvents = false
         config.disableReachabilityForTesting = true

--- a/PostHogTests/PostHogEnrichedAnalyticsTest.swift
+++ b/PostHogTests/PostHogEnrichedAnalyticsTest.swift
@@ -26,7 +26,7 @@ class PostHogEnrichedAnalyticsTest {
     }
 
     func getSut(optOut: Bool = false) -> PostHogSDK {
-        let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
         config.flushAt = 1
         config.captureApplicationLifecycleEvents = false
         config.disableReachabilityForTesting = true

--- a/PostHogTests/PostHogFeatureFlagsTest.swift
+++ b/PostHogTests/PostHogFeatureFlagsTest.swift
@@ -19,7 +19,7 @@ private struct TestPayload: Decodable, Equatable {
 enum PostHogFeatureFlagsTest {
     class BaseTestClass {
         let config: PostHogConfig = {
-            let c = PostHogConfig(projectToken: UUID().uuidString, host: "http://localhost:9001")
+            let c = PostHogConfig(projectToken: "test_project_token", host: "http://localhost:9001")
             c.preloadFeatureFlags = false
             c.disableReachabilityForTesting = true
             c.disableQueueTimerForTesting = true

--- a/PostHogTests/PostHogFeatureFlagsTest.swift
+++ b/PostHogTests/PostHogFeatureFlagsTest.swift
@@ -19,7 +19,7 @@ private struct TestPayload: Decodable, Equatable {
 enum PostHogFeatureFlagsTest {
     class BaseTestClass {
         let config: PostHogConfig = {
-            let c = PostHogConfig(apiKey: UUID().uuidString, host: "http://localhost:9001")
+            let c = PostHogConfig(projectToken: UUID().uuidString, host: "http://localhost:9001")
             c.preloadFeatureFlags = false
             c.disableReachabilityForTesting = true
             c.disableQueueTimerForTesting = true

--- a/PostHogTests/PostHogFeatureFlagsV3Test.swift
+++ b/PostHogTests/PostHogFeatureFlagsV3Test.swift
@@ -12,7 +12,7 @@ import XCTest
 @Suite("Test Feature Flags V3", .serialized)
 enum PostHogFeatureFlagsV3Test {
     class BaseTestClass {
-        let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
         var server: MockPostHogServer!
 
         init() {

--- a/PostHogTests/PostHogFeatureFlagsV3Test.swift
+++ b/PostHogTests/PostHogFeatureFlagsV3Test.swift
@@ -12,7 +12,7 @@ import XCTest
 @Suite("Test Feature Flags V3", .serialized)
 enum PostHogFeatureFlagsV3Test {
     class BaseTestClass {
-        let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
         var server: MockPostHogServer!
 
         init() {

--- a/PostHogTests/PostHogIdentityTests.swift
+++ b/PostHogTests/PostHogIdentityTests.swift
@@ -19,7 +19,7 @@ class PostHogIdentityTests {
         reuseAnonymousId: Bool = false,
         flushAt: Int = 1
     ) -> PostHogSDK {
-        let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
         config.captureApplicationLifecycleEvents = false
         config.reuseAnonymousId = reuseAnonymousId
         config.flushAt = flushAt

--- a/PostHogTests/PostHogIdentityTests.swift
+++ b/PostHogTests/PostHogIdentityTests.swift
@@ -19,7 +19,7 @@ class PostHogIdentityTests {
         reuseAnonymousId: Bool = false,
         flushAt: Int = 1
     ) -> PostHogSDK {
-        let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
         config.captureApplicationLifecycleEvents = false
         config.reuseAnonymousId = reuseAnonymousId
         config.flushAt = flushAt

--- a/PostHogTests/PostHogIntegrationInstallationTest.swift
+++ b/PostHogTests/PostHogIntegrationInstallationTest.swift
@@ -22,13 +22,13 @@ class PostHogIntegrationInstallationTest {
     }
 
     private func getSut(
-        apiKey: String,
+        projectToken: String,
         sessionReplay: Bool = false,
         captureApplicationLifecycleEvents: Bool = false,
         captureScreenViews: Bool = false,
         captureElementInteractions: Bool = false
     ) -> PostHogSDK {
-        let config = PostHogConfig(projectToken: apiKey)
+        let config = PostHogConfig(projectToken: projectToken)
         config.captureApplicationLifecycleEvents = captureApplicationLifecycleEvents
 
         #if os(iOS)
@@ -51,8 +51,8 @@ class PostHogIntegrationInstallationTest {
     #if os(iOS)
         @Test("replay integration installed only once, on first instance")
         func replayIntegrationInstalledOnce() {
-            let first = getSut(apiKey: "123", sessionReplay: true)
-            let second = getSut(apiKey: "345", sessionReplay: true)
+            let first = getSut(projectToken: "test_project_token", sessionReplay: true)
+            let second = getSut(projectToken: "test_project_token", sessionReplay: true)
 
             #expect(first.getReplayIntegration() != nil)
             #expect(second.getReplayIntegration() == nil)
@@ -65,8 +65,8 @@ class PostHogIntegrationInstallationTest {
     #if os(iOS) || targetEnvironment(macCatalyst)
         @Test("autocapture integration installed only once, on first instance")
         func autocaptureIntegrationInstalledOnce() async {
-            let first = getSut(apiKey: "123", captureElementInteractions: true)
-            let second = getSut(apiKey: "345", captureElementInteractions: true)
+            let first = getSut(projectToken: "test_project_token", captureElementInteractions: true)
+            let second = getSut(projectToken: "test_project_token", captureElementInteractions: true)
 
             #expect(first.getAutocaptureIntegration() != nil)
             #expect(second.getAutocaptureIntegration() == nil)
@@ -78,8 +78,8 @@ class PostHogIntegrationInstallationTest {
 
     @Test("app life cycle integration installed only once, on first instance")
     func appLifeCycleIntegrationInstalledOnce() async {
-        let first = getSut(apiKey: "123", captureApplicationLifecycleEvents: true)
-        let second = getSut(apiKey: "345", captureApplicationLifecycleEvents: true)
+        let first = getSut(projectToken: "test_project_token", captureApplicationLifecycleEvents: true)
+        let second = getSut(projectToken: "test_project_token", captureApplicationLifecycleEvents: true)
 
         #expect(first.getAppLifeCycleIntegration() != nil)
         #expect(second.getAppLifeCycleIntegration() == nil)
@@ -90,8 +90,8 @@ class PostHogIntegrationInstallationTest {
 
     @Test("screen view integration installed only once, on first instance")
     func screenViewIntegrationInstalledOnce() async {
-        let first = getSut(apiKey: "123", captureScreenViews: true)
-        let second = getSut(apiKey: "345", captureScreenViews: true)
+        let first = getSut(projectToken: "test_project_token", captureScreenViews: true)
+        let second = getSut(projectToken: "test_project_token", captureScreenViews: true)
 
         #expect(first.getScreenViewIntegration() != nil)
         #expect(second.getScreenViewIntegration() == nil)

--- a/PostHogTests/PostHogIntegrationInstallationTest.swift
+++ b/PostHogTests/PostHogIntegrationInstallationTest.swift
@@ -28,7 +28,7 @@ class PostHogIntegrationInstallationTest {
         captureScreenViews: Bool = false,
         captureElementInteractions: Bool = false
     ) -> PostHogSDK {
-        let config = PostHogConfig(apiKey: apiKey)
+        let config = PostHogConfig(projectToken: apiKey)
         config.captureApplicationLifecycleEvents = captureApplicationLifecycleEvents
 
         #if os(iOS)

--- a/PostHogTests/PostHogPropertiesSerializationTest.swift
+++ b/PostHogTests/PostHogPropertiesSerializationTest.swift
@@ -101,7 +101,7 @@ struct PostHogPropertiesSerializationTests {
         }
 
         func getSut(flushAt: Int = 1) -> PostHogSDK {
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             config.flushAt = flushAt
             config.disableReachabilityForTesting = true
             config.disableQueueTimerForTesting = true

--- a/PostHogTests/PostHogPropertiesSerializationTest.swift
+++ b/PostHogTests/PostHogPropertiesSerializationTest.swift
@@ -101,7 +101,7 @@ struct PostHogPropertiesSerializationTests {
         }
 
         func getSut(flushAt: Int = 1) -> PostHogSDK {
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             config.flushAt = flushAt
             config.disableReachabilityForTesting = true
             config.disableQueueTimerForTesting = true

--- a/PostHogTests/PostHogQueueTest.swift
+++ b/PostHogTests/PostHogQueueTest.swift
@@ -13,7 +13,7 @@ import XCTest
 
 class PostHogQueueTest: QuickSpec {
     func getSut(flushAt: Int = 1, maxQueueSize: Int = 1000) -> PostHogQueue {
-        let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
         config.flushAt = flushAt
         config.maxQueueSize = maxQueueSize
         config.sendFeatureFlagEvent = false

--- a/PostHogTests/PostHogQueueTest.swift
+++ b/PostHogTests/PostHogQueueTest.swift
@@ -13,7 +13,7 @@ import XCTest
 
 class PostHogQueueTest: QuickSpec {
     func getSut(flushAt: Int = 1, maxQueueSize: Int = 1000) -> PostHogQueue {
-        let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
         config.flushAt = flushAt
         config.maxQueueSize = maxQueueSize
         config.sendFeatureFlagEvent = false

--- a/PostHogTests/PostHogRageClickIntegrationTest.swift
+++ b/PostHogTests/PostHogRageClickIntegrationTest.swift
@@ -16,7 +16,7 @@
             captureElementInteractions: Bool = true,
             captureRageClicks: Bool = true
         ) -> (MockPostHogServer, PostHogSDK, PostHogRageClickIntegration?) {
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             config.captureElementInteractions = captureElementInteractions
             config.rageClickConfig.enabled = captureRageClicks
             config.rageClickConfig.minimumTapCount = 3

--- a/PostHogTests/PostHogRageClickIntegrationTest.swift
+++ b/PostHogTests/PostHogRageClickIntegrationTest.swift
@@ -16,7 +16,7 @@
             captureElementInteractions: Bool = true,
             captureRageClicks: Bool = true
         ) -> (MockPostHogServer, PostHogSDK, PostHogRageClickIntegration?) {
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             config.captureElementInteractions = captureElementInteractions
             config.rageClickConfig.enabled = captureRageClicks
             config.rageClickConfig.minimumTapCount = 3

--- a/PostHogTests/PostHogRemoteConfigTest.swift
+++ b/PostHogTests/PostHogRemoteConfigTest.swift
@@ -13,7 +13,7 @@ import XCTest
 enum PostHogRemoteConfigTest {
     class BaseTestClass {
         let config: PostHogConfig = {
-            let c = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let c = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             c.disableRemoteConfigForTesting = true
             return c
         }()
@@ -61,7 +61,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("remote config fetches feature flags if missing")
         func remoteConfigLoadsFeatureFlagsIfNotPreviouslyLoaded() async {
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             config.preloadFeatureFlags = true
             config.storageManager = PostHogStorageManager(config)
             let sut = getSut(config: config)
@@ -89,7 +89,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("remote config does not fetch feature flags if preloadFeatureFlags is disabled")
         func remoteConfigDoesNotFetchFeatureFlagsIfPreloadFeatureFlagsIsDisabled() async throws {
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
             let sut = getSut(config: config)
@@ -127,7 +127,7 @@ enum PostHogRemoteConfigTest {
             // return flipped cached flag
             server.featureFlags = ["some-flag": false]
 
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             config.preloadFeatureFlags = true
             config.storageManager = PostHogStorageManager(config)
 
@@ -159,7 +159,7 @@ enum PostHogRemoteConfigTest {
             server.hasFeatureFlags = false
             server.featureFlags = [:]
 
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
 
@@ -198,7 +198,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("should not clear flags if remote config call fails")
         func shouldNotClearFlagsIfRemoteConfigCallFails() async {
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             config.preloadFeatureFlags = true
 
             let storage = PostHogStorage(config)
@@ -234,7 +234,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("should not clear flags if hasFeatureFlags key is missing")
         func shouldNotClearFlagsIfHasFeatureFlagsKeyIsMissing() async {
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             config.preloadFeatureFlags = true
 
             let storage = PostHogStorage(config)
@@ -273,7 +273,7 @@ enum PostHogRemoteConfigTest {
     class TestFeatureFlagLoadingRaceCondition: BaseTestClass {
         @Test("guard prevents concurrent requests and queues pending")
         func guardPreventsConcurrentRequestsAndQueuesPending() async {
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
             let sut = getSut(config: config)
@@ -306,7 +306,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("pending request uses correct identity after identify")
         func pendingRequestUsesCorrectIdentity() async {
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
             let sut = getSut(config: config)
@@ -342,7 +342,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("pending request replaces earlier pending with latest")
         func pendingRequestReplacesEarlierPending() async {
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
             let sut = getSut(config: config)
@@ -384,7 +384,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("callbacks fire for both initial and pending requests")
         func callbacksFireForBothRequests() async {
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
             let sut = getSut(config: config)
@@ -416,7 +416,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("no pending queue when no concurrent load")
         func noPendingQueueWhenNoConcurrentLoad() async {
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
             let sut = getSut(config: config)
@@ -437,7 +437,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("reloadRemoteConfig concurrent calls do not crash")
         func reloadRemoteConfigConcurrentCallsDoNotCrash() async {
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             let sut = getSut(config: config)
 
@@ -706,7 +706,7 @@ enum PostHogRemoteConfigTest {
 
             @Test("does not call featureFlagCalledCallback when sendFeatureFlagEvent is disabled")
             func doesNotCallFeatureFlagCalledCallbackWhenSendFeatureFlagEventDisabled() async {
-                let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+                let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
                 config.sendFeatureFlagEvent = false
                 let storage = PostHogStorage(config)
                 defer { storage.reset() }
@@ -794,7 +794,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("enables autocapture exceptions from remote config dict")
         func enablesAutocaptureExceptionsFromRemoteConfigDict() async {
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
 
@@ -824,7 +824,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("disables autocapture exceptions from remote config dict")
         func disablesAutocaptureExceptionsFromRemoteConfigDict() async {
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
 
@@ -853,7 +853,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("disables autocapture exceptions when errorTracking is boolean false")
         func disablesAutocaptureExceptionsWhenErrorTrackingIsBooleanFalse() async {
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
 
@@ -889,7 +889,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("disables autocapture exceptions when errorTracking key is missing")
         func disablesAutocaptureExceptionsWhenErrorTrackingKeyIsMissing() async {
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
 

--- a/PostHogTests/PostHogRemoteConfigTest.swift
+++ b/PostHogTests/PostHogRemoteConfigTest.swift
@@ -13,7 +13,7 @@ import XCTest
 enum PostHogRemoteConfigTest {
     class BaseTestClass {
         let config: PostHogConfig = {
-            let c = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let c = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             c.disableRemoteConfigForTesting = true
             return c
         }()
@@ -61,7 +61,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("remote config fetches feature flags if missing")
         func remoteConfigLoadsFeatureFlagsIfNotPreviouslyLoaded() async {
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             config.preloadFeatureFlags = true
             config.storageManager = PostHogStorageManager(config)
             let sut = getSut(config: config)
@@ -89,7 +89,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("remote config does not fetch feature flags if preloadFeatureFlags is disabled")
         func remoteConfigDoesNotFetchFeatureFlagsIfPreloadFeatureFlagsIsDisabled() async throws {
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
             let sut = getSut(config: config)
@@ -127,7 +127,7 @@ enum PostHogRemoteConfigTest {
             // return flipped cached flag
             server.featureFlags = ["some-flag": false]
 
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             config.preloadFeatureFlags = true
             config.storageManager = PostHogStorageManager(config)
 
@@ -159,7 +159,7 @@ enum PostHogRemoteConfigTest {
             server.hasFeatureFlags = false
             server.featureFlags = [:]
 
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
 
@@ -198,7 +198,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("should not clear flags if remote config call fails")
         func shouldNotClearFlagsIfRemoteConfigCallFails() async {
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             config.preloadFeatureFlags = true
 
             let storage = PostHogStorage(config)
@@ -234,7 +234,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("should not clear flags if hasFeatureFlags key is missing")
         func shouldNotClearFlagsIfHasFeatureFlagsKeyIsMissing() async {
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             config.preloadFeatureFlags = true
 
             let storage = PostHogStorage(config)
@@ -273,7 +273,7 @@ enum PostHogRemoteConfigTest {
     class TestFeatureFlagLoadingRaceCondition: BaseTestClass {
         @Test("guard prevents concurrent requests and queues pending")
         func guardPreventsConcurrentRequestsAndQueuesPending() async {
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
             let sut = getSut(config: config)
@@ -306,7 +306,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("pending request uses correct identity after identify")
         func pendingRequestUsesCorrectIdentity() async {
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
             let sut = getSut(config: config)
@@ -342,7 +342,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("pending request replaces earlier pending with latest")
         func pendingRequestReplacesEarlierPending() async {
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
             let sut = getSut(config: config)
@@ -384,7 +384,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("callbacks fire for both initial and pending requests")
         func callbacksFireForBothRequests() async {
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
             let sut = getSut(config: config)
@@ -416,7 +416,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("no pending queue when no concurrent load")
         func noPendingQueueWhenNoConcurrentLoad() async {
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
             let sut = getSut(config: config)
@@ -437,7 +437,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("reloadRemoteConfig concurrent calls do not crash")
         func reloadRemoteConfigConcurrentCallsDoNotCrash() async {
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             let sut = getSut(config: config)
 
@@ -706,7 +706,7 @@ enum PostHogRemoteConfigTest {
 
             @Test("does not call featureFlagCalledCallback when sendFeatureFlagEvent is disabled")
             func doesNotCallFeatureFlagCalledCallbackWhenSendFeatureFlagEventDisabled() async {
-                let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+                let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
                 config.sendFeatureFlagEvent = false
                 let storage = PostHogStorage(config)
                 defer { storage.reset() }
@@ -794,7 +794,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("enables autocapture exceptions from remote config dict")
         func enablesAutocaptureExceptionsFromRemoteConfigDict() async {
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
 
@@ -824,7 +824,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("disables autocapture exceptions from remote config dict")
         func disablesAutocaptureExceptionsFromRemoteConfigDict() async {
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
 
@@ -853,7 +853,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("disables autocapture exceptions when errorTracking is boolean false")
         func disablesAutocaptureExceptionsWhenErrorTrackingIsBooleanFalse() async {
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
 
@@ -889,7 +889,7 @@ enum PostHogRemoteConfigTest {
 
         @Test("disables autocapture exceptions when errorTracking key is missing")
         func disablesAutocaptureExceptionsWhenErrorTrackingKeyIsMissing() async {
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
 

--- a/PostHogTests/PostHogReplayQueueTest.swift
+++ b/PostHogTests/PostHogReplayQueueTest.swift
@@ -29,7 +29,7 @@ class PostHogReplayQueueTests {
     private func createReplayQueue() -> PostHogReplayQueue {
         // Use unique API key per test to ensure isolated storage
         let uniqueKey = UUID().uuidString
-        let config = PostHogConfig(apiKey: uniqueKey, host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: uniqueKey, host: "http://localhost:9001")
         let storage = PostHogStorage(config)
         let api = PostHogApi(config)
         let queue = PostHogReplayQueue(config, storage, api, nil)
@@ -142,7 +142,7 @@ class PostHogReplayQueueTests {
         server.start(snapshotCount: 1)
         defer { server.stop() }
 
-        let config = PostHogConfig(apiKey: UUID().uuidString, host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: UUID().uuidString, host: "http://localhost:9001")
         let storage = PostHogStorage(config)
         storage.reset()
         let api = PostHogApi(config)

--- a/PostHogTests/PostHogReplayQueueTest.swift
+++ b/PostHogTests/PostHogReplayQueueTest.swift
@@ -27,7 +27,7 @@ class PostHogReplayQueueTests {
     }
 
     private func createReplayQueue() -> PostHogReplayQueue {
-        // Use unique API key per test to ensure isolated storage
+        // Use unique project token per test to ensure isolated storage
         let uniqueKey = UUID().uuidString
         let config = PostHogConfig(projectToken: uniqueKey, host: "http://localhost:9001")
         let storage = PostHogStorage(config)
@@ -142,7 +142,7 @@ class PostHogReplayQueueTests {
         server.start(snapshotCount: 1)
         defer { server.stop() }
 
-        let config = PostHogConfig(projectToken: UUID().uuidString, host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost:9001")
         let storage = PostHogStorage(config)
         storage.reset()
         let api = PostHogApi(config)

--- a/PostHogTests/PostHogSDKPersonProfilesTest.swift
+++ b/PostHogTests/PostHogSDKPersonProfilesTest.swift
@@ -14,7 +14,7 @@ class PostHogSDKPersonProfilesTest: QuickSpec {
     func getSut(flushAt: Int = 1,
                 personProfiles: PostHogPersonProfiles = .identifiedOnly) -> PostHogSDK
     {
-        let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
         config.flushAt = flushAt
         config.preloadFeatureFlags = false
         config.sendFeatureFlagEvent = false

--- a/PostHogTests/PostHogSDKPersonProfilesTest.swift
+++ b/PostHogTests/PostHogSDKPersonProfilesTest.swift
@@ -14,7 +14,7 @@ class PostHogSDKPersonProfilesTest: QuickSpec {
     func getSut(flushAt: Int = 1,
                 personProfiles: PostHogPersonProfiles = .identifiedOnly) -> PostHogSDK
     {
-        let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
         config.flushAt = flushAt
         config.preloadFeatureFlags = false
         config.sendFeatureFlagEvent = false

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -21,7 +21,7 @@ class PostHogSDKTest: QuickSpec {
                 setDefaultPersonProperties: Bool = true,
                 beforeSend: [BeforeSendBlock]? = nil) -> PostHogSDK
     {
-        let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
         config.flushAt = flushAt
         config.preloadFeatureFlags = preloadFeatureFlags
         config.sendFeatureFlagEvent = sendFeatureFlagEvent
@@ -999,7 +999,7 @@ class PostHogSDKTest: QuickSpec {
         #if os(iOS)
             context("autocapture") {
                 it("isAutocaptureActive() should be false if disabled by config") {
-                    let config = PostHogConfig(projectToken: testAPIKey)
+                    let config = PostHogConfig(projectToken: testProjectToken)
                     config.captureElementInteractions = false
                     let sut = PostHogSDK.with(config)
 
@@ -1007,7 +1007,7 @@ class PostHogSDKTest: QuickSpec {
                 }
 
                 it("isAutocaptureActive() should be false if SDK is not enabled") {
-                    let config = PostHogConfig(projectToken: testAPIKey)
+                    let config = PostHogConfig(projectToken: testProjectToken)
                     config.captureElementInteractions = true
                     let sut = PostHogSDK.with(config)
                     sut.close()

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -21,7 +21,7 @@ class PostHogSDKTest: QuickSpec {
                 setDefaultPersonProperties: Bool = true,
                 beforeSend: [BeforeSendBlock]? = nil) -> PostHogSDK
     {
-        let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
         config.flushAt = flushAt
         config.preloadFeatureFlags = preloadFeatureFlags
         config.sendFeatureFlagEvent = sendFeatureFlagEvent
@@ -999,7 +999,7 @@ class PostHogSDKTest: QuickSpec {
         #if os(iOS)
             context("autocapture") {
                 it("isAutocaptureActive() should be false if disabled by config") {
-                    let config = PostHogConfig(apiKey: testAPIKey)
+                    let config = PostHogConfig(projectToken: testAPIKey)
                     config.captureElementInteractions = false
                     let sut = PostHogSDK.with(config)
 
@@ -1007,7 +1007,7 @@ class PostHogSDKTest: QuickSpec {
                 }
 
                 it("isAutocaptureActive() should be false if SDK is not enabled") {
-                    let config = PostHogConfig(apiKey: testAPIKey)
+                    let config = PostHogConfig(projectToken: testAPIKey)
                     config.captureElementInteractions = true
                     let sut = PostHogSDK.with(config)
                     sut.close()

--- a/PostHogTests/PostHogSamplingTest.swift
+++ b/PostHogTests/PostHogSamplingTest.swift
@@ -106,7 +106,7 @@ class PostHogSamplingTests {
 
     @Suite("parseSampleRate Tests", .serialized)
     class ParseSampleRateTests {
-        let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
         var server: MockPostHogServer!
 
         init() {
@@ -223,7 +223,7 @@ class PostHogSamplingTests {
 
         @Test("parses sample rate from remote config response")
         func parsesSampleRateFromRemoteConfig() async {
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             config.remoteConfig = true
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
@@ -250,7 +250,7 @@ class PostHogSamplingTests {
 
         @Test("remote config without sample rate leaves it nil")
         func remoteConfigWithoutSampleRate() async {
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             config.remoteConfig = true
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)

--- a/PostHogTests/PostHogSamplingTest.swift
+++ b/PostHogTests/PostHogSamplingTest.swift
@@ -106,7 +106,7 @@ class PostHogSamplingTests {
 
     @Suite("parseSampleRate Tests", .serialized)
     class ParseSampleRateTests {
-        let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+        let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
         var server: MockPostHogServer!
 
         init() {
@@ -223,7 +223,7 @@ class PostHogSamplingTests {
 
         @Test("parses sample rate from remote config response")
         func parsesSampleRateFromRemoteConfig() async {
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             config.remoteConfig = true
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)
@@ -250,7 +250,7 @@ class PostHogSamplingTests {
 
         @Test("remote config without sample rate leaves it nil")
         func remoteConfigWithoutSampleRate() async {
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             config.remoteConfig = true
             config.preloadFeatureFlags = false
             config.storageManager = PostHogStorageManager(config)

--- a/PostHogTests/PostHogScreenViewIntegrationTest.swift
+++ b/PostHogTests/PostHogScreenViewIntegrationTest.swift
@@ -28,7 +28,7 @@ final class ScreenViewIntegrationTest {
     }
 
     private func getSut(captureScreenViews: Bool = true) -> PostHogSDK {
-        let config = PostHogConfig(projectToken: "screen_test", host: "https://localhost:9090")
+        let config = PostHogConfig(projectToken: "test_project_token", host: "https://localhost:9090")
         config.captureScreenViews = captureScreenViews
         config.captureApplicationLifecycleEvents = false
         config.flushAt = 1

--- a/PostHogTests/PostHogScreenViewIntegrationTest.swift
+++ b/PostHogTests/PostHogScreenViewIntegrationTest.swift
@@ -28,7 +28,7 @@ final class ScreenViewIntegrationTest {
     }
 
     private func getSut(captureScreenViews: Bool = true) -> PostHogSDK {
-        let config = PostHogConfig(apiKey: "screen_test", host: "https://localhost:9090")
+        let config = PostHogConfig(projectToken: "screen_test", host: "https://localhost:9090")
         config.captureScreenViews = captureScreenViews
         config.captureApplicationLifecycleEvents = false
         config.flushAt = 1

--- a/PostHogTests/PostHogSessionManagerTest.swift
+++ b/PostHogTests/PostHogSessionManagerTest.swift
@@ -21,7 +21,7 @@ enum PostHogSessionManagerTest {
         }
 
         func getSut() -> PostHogSDK {
-            let config = PostHogConfig(projectToken: "test-key")
+            let config = PostHogConfig(projectToken: "test_project_token")
             return PostHogSDK.with(config)
         }
 
@@ -187,7 +187,7 @@ enum PostHogSessionManagerTest {
             propertiesSanitizer: PostHogPropertiesSanitizer? = nil,
             personProfiles: PostHogPersonProfiles = .identifiedOnly
         ) -> PostHogSDK {
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             config.flushAt = flushAt
             config.preloadFeatureFlags = preloadFeatureFlags
             config.sendFeatureFlagEvent = sendFeatureFlagEvent
@@ -394,7 +394,7 @@ enum PostHogSessionManagerTest {
             postHogSdkName = "posthog-react-native"
             mockAppLifecycle = MockApplicationLifecyclePublisher()
             DI.main.appLifecyclePublisher = mockAppLifecycle
-            let config = PostHogConfig(projectToken: "test-key")
+            let config = PostHogConfig(projectToken: "test_project_token")
             posthog = PostHogSDK.with(config)
         }
 

--- a/PostHogTests/PostHogSessionManagerTest.swift
+++ b/PostHogTests/PostHogSessionManagerTest.swift
@@ -21,7 +21,7 @@ enum PostHogSessionManagerTest {
         }
 
         func getSut() -> PostHogSDK {
-            let config = PostHogConfig(apiKey: "test-key")
+            let config = PostHogConfig(projectToken: "test-key")
             return PostHogSDK.with(config)
         }
 
@@ -187,7 +187,7 @@ enum PostHogSessionManagerTest {
             propertiesSanitizer: PostHogPropertiesSanitizer? = nil,
             personProfiles: PostHogPersonProfiles = .identifiedOnly
         ) -> PostHogSDK {
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             config.flushAt = flushAt
             config.preloadFeatureFlags = preloadFeatureFlags
             config.sendFeatureFlagEvent = sendFeatureFlagEvent
@@ -394,7 +394,7 @@ enum PostHogSessionManagerTest {
             postHogSdkName = "posthog-react-native"
             mockAppLifecycle = MockApplicationLifecyclePublisher()
             DI.main.appLifecyclePublisher = mockAppLifecycle
-            let config = PostHogConfig(apiKey: "test-key")
+            let config = PostHogConfig(projectToken: "test-key")
             posthog = PostHogSDK.with(config)
         }
 

--- a/PostHogTests/PostHogSessionReplayEventTriggersTest.swift
+++ b/PostHogTests/PostHogSessionReplayEventTriggersTest.swift
@@ -20,7 +20,7 @@
         private func getSut(
             eventTriggers: [String]? = nil
         ) -> PostHogSDK {
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             config.sessionReplay = true
             config.disableReachabilityForTesting = true
             config.disableQueueTimerForTesting = true

--- a/PostHogTests/PostHogSessionReplayEventTriggersTest.swift
+++ b/PostHogTests/PostHogSessionReplayEventTriggersTest.swift
@@ -5,7 +5,7 @@
 
     @Suite("Session Replay Event Triggers", .serialized)
     class PostHogSessionReplayEventTriggersTests {
-        let testAPIKey = "test_api_key"
+        let testProjectToken = "test_project_token"
         let server: MockPostHogServer
 
         init() {
@@ -20,7 +20,7 @@
         private func getSut(
             eventTriggers: [String]? = nil
         ) -> PostHogSDK {
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             config.sessionReplay = true
             config.disableReachabilityForTesting = true
             config.disableQueueTimerForTesting = true

--- a/PostHogTests/PostHogSessionReplayTest.swift
+++ b/PostHogTests/PostHogSessionReplayTest.swift
@@ -4,7 +4,7 @@
 
     @Suite("Session Replay tests", .serialized)
     class PostHogSessionReplayTests {
-        let testAPIKey = "test_api_key"
+        let testProjectToken = "test_project_token"
         let server: MockPostHogServer
 
         init() {
@@ -19,7 +19,7 @@
         private func getSut(
             sessionReplay: Bool
         ) -> PostHogSDK {
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
             config.sessionReplay = sessionReplay
             config.disableReachabilityForTesting = true
             config.disableQueueTimerForTesting = true

--- a/PostHogTests/PostHogSessionReplayTest.swift
+++ b/PostHogTests/PostHogSessionReplayTest.swift
@@ -19,7 +19,7 @@
         private func getSut(
             sessionReplay: Bool
         ) -> PostHogSDK {
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9001")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9001")
             config.sessionReplay = sessionReplay
             config.disableReachabilityForTesting = true
             config.disableQueueTimerForTesting = true

--- a/PostHogTests/PostHogStorageManagerTest.swift
+++ b/PostHogTests/PostHogStorageManagerTest.swift
@@ -12,7 +12,7 @@ import Quick
 
 class PostHogStorageManagerTest: QuickSpec {
     func getSut(_ config: PostHogConfig? = nil) -> PostHogStorageManager {
-        let theConfig = config ?? PostHogConfig(apiKey: "123")
+        let theConfig = config ?? PostHogConfig(projectToken: "123")
         let storage = PostHogStorage(theConfig)
         storage.reset()
         return PostHogStorageManager(theConfig)
@@ -49,7 +49,7 @@ class PostHogStorageManagerTest: QuickSpec {
         }
 
         it("Can accept anon id customization via config") {
-            let config = PostHogConfig(apiKey: "123")
+            let config = PostHogConfig(projectToken: "123")
             let fixedUuid = UUID.v7()
             config.getAnonymousId = { _ in fixedUuid }
             let sut = self.getSut(config)
@@ -63,7 +63,7 @@ class PostHogStorageManagerTest: QuickSpec {
             let anonymousIdToSet = UUID.v7()
             let distinctIdToSet = UUID.v7().uuidString
 
-            let config = PostHogConfig(apiKey: "123")
+            let config = PostHogConfig(projectToken: "123")
             config.getAnonymousId = { _ in anonymousIdToSet }
 
             let sut = self.getSut(config)

--- a/PostHogTests/PostHogStorageManagerTest.swift
+++ b/PostHogTests/PostHogStorageManagerTest.swift
@@ -12,7 +12,7 @@ import Quick
 
 class PostHogStorageManagerTest: QuickSpec {
     func getSut(_ config: PostHogConfig? = nil) -> PostHogStorageManager {
-        let theConfig = config ?? PostHogConfig(projectToken: "123")
+        let theConfig = config ?? PostHogConfig(projectToken: "test_project_token")
         let storage = PostHogStorage(theConfig)
         storage.reset()
         return PostHogStorageManager(theConfig)
@@ -49,7 +49,7 @@ class PostHogStorageManagerTest: QuickSpec {
         }
 
         it("Can accept anon id customization via config") {
-            let config = PostHogConfig(projectToken: "123")
+            let config = PostHogConfig(projectToken: "test_project_token")
             let fixedUuid = UUID.v7()
             config.getAnonymousId = { _ in fixedUuid }
             let sut = self.getSut(config)
@@ -63,7 +63,7 @@ class PostHogStorageManagerTest: QuickSpec {
             let anonymousIdToSet = UUID.v7()
             let distinctIdToSet = UUID.v7().uuidString
 
-            let config = PostHogConfig(projectToken: "123")
+            let config = PostHogConfig(projectToken: "test_project_token")
             config.getAnonymousId = { _ in anonymousIdToSet }
 
             let sut = self.getSut(config)

--- a/PostHogTests/PostHogStorageMergeTest.swift
+++ b/PostHogTests/PostHogStorageMergeTest.swift
@@ -11,7 +11,7 @@ import Testing
 
 @Suite("PostHogStorage app group merge tests", .serialized)
 class PostHogStorageMergeTest {
-    let testApiKey = "test_merge_api_key"
+    let testProjectToken = "test_project_token"
     var baseUrl: URL!
     var fileManager: FileManager!
 
@@ -36,7 +36,7 @@ class PostHogStorageMergeTest {
 
         try? fileManager.removeItem(at: legacyUrl)
         try? fileManager.removeItem(at: appGroupUrl)
-        try? fileManager.removeItem(at: baseUrl.appendingPathComponent(testApiKey))
+        try? fileManager.removeItem(at: baseUrl.appendingPathComponent(testProjectToken))
     }
 
     private func calculateFileHash(_ url: URL) throws -> String {
@@ -67,16 +67,16 @@ class PostHogStorageMergeTest {
         return try calculateFileHash(fileUrl)
     }
 
-    private func createLegacyFile(bundleId: String, apiKey: String, fileName: String, content: Data) throws -> String {
+    private func createLegacyFile(bundleId: String, projectToken: String, fileName: String, content: Data) throws -> String {
         let bundleDir = baseUrl.appendingPathComponent(bundleId)
-        let apiKeyDir = bundleDir.appendingPathComponent(apiKey)
-        return try createFile(at: apiKeyDir, fileName: fileName, content: content)
+        let projectTokenDir = bundleDir.appendingPathComponent(projectToken)
+        return try createFile(at: projectTokenDir, fileName: fileName, content: content)
     }
 
-    private func createAppGroupFile(appGroupId: String, apiKey: String, fileName: String, content: Data) throws -> String {
+    private func createAppGroupFile(appGroupId: String, projectToken: String, fileName: String, content: Data) throws -> String {
         let appGroupDir = baseUrl.appendingPathComponent(appGroupId)
-        let apiKeyDir = appGroupDir.appendingPathComponent(apiKey)
-        return try createFile(at: apiKeyDir, fileName: fileName, content: content)
+        let projectTokenDir = appGroupDir.appendingPathComponent(projectToken)
+        return try createFile(at: projectTokenDir, fileName: fileName, content: content)
     }
 
     @Test("test app group container merge detection")
@@ -88,7 +88,7 @@ class PostHogStorageMergeTest {
         let fileContent = "test_content".data(using: .utf8)!
         _ = try createLegacyFile(
             bundleId: testBundleIdentifier,
-            apiKey: testApiKey,
+            projectToken: testProjectToken,
             fileName: "test_file.txt",
             content: fileContent
         )
@@ -96,7 +96,7 @@ class PostHogStorageMergeTest {
         // Verify legacy file exists
         let legacyFileUrl = baseUrl
             .appendingPathComponent(testBundleIdentifier)
-            .appendingPathComponent(testApiKey)
+            .appendingPathComponent(testProjectToken)
             .appendingPathComponent("test_file.txt")
         #expect(fileManager.fileExists(atPath: legacyFileUrl.path))
 
@@ -112,7 +112,7 @@ class PostHogStorageMergeTest {
         let fileContent = "test_user_123".data(using: .utf8)!
         _ = try createLegacyFile(
             bundleId: testBundleIdentifier,
-            apiKey: testApiKey,
+            projectToken: testProjectToken,
             fileName: PostHogStorage.StorageKey.distinctId.rawValue,
             content: fileContent
         )
@@ -125,22 +125,22 @@ class PostHogStorageMergeTest {
 
         // Verify file was migrated
         let migratedFileUrl = destinationUrl
-            .appendingPathComponent(testApiKey)
+            .appendingPathComponent(testProjectToken)
             .appendingPathComponent(PostHogStorage.StorageKey.distinctId.rawValue)
         #expect(fileManager.fileExists(atPath: migratedFileUrl.path))
 
         // Verify legacy file was removed
         let legacyFileUrl = baseUrl
             .appendingPathComponent(testBundleIdentifier)
-            .appendingPathComponent(testApiKey)
+            .appendingPathComponent(testProjectToken)
             .appendingPathComponent(PostHogStorage.StorageKey.distinctId.rawValue)
         #expect(!fileManager.fileExists(atPath: legacyFileUrl.path))
     }
 
     @Test("test file migration with existing files")
     func fileMigrationWithExistingFiles() throws {
-        let sourceDir = baseUrl.appendingPathComponent(testBundleIdentifier).appendingPathComponent(testApiKey)
-        let destDir = baseUrl.appendingPathComponent(testAppGroupIdentifier).appendingPathComponent(testApiKey)
+        let sourceDir = baseUrl.appendingPathComponent(testBundleIdentifier).appendingPathComponent(testProjectToken)
+        let destDir = baseUrl.appendingPathComponent(testAppGroupIdentifier).appendingPathComponent(testProjectToken)
 
         // Create test files in source
         let file1Content = "file1_content".data(using: .utf8)!
@@ -174,8 +174,8 @@ class PostHogStorageMergeTest {
 
     @Test("test nested directory migration")
     func nestedDirectoryMigration() throws {
-        let sourceDir = baseUrl.appendingPathComponent(testBundleIdentifier).appendingPathComponent(testApiKey)
-        let destDir = baseUrl.appendingPathComponent(testAppGroupIdentifier).appendingPathComponent(testApiKey)
+        let sourceDir = baseUrl.appendingPathComponent(testBundleIdentifier).appendingPathComponent(testProjectToken)
+        let destDir = baseUrl.appendingPathComponent(testAppGroupIdentifier).appendingPathComponent(testProjectToken)
 
         // Create nested structure
         let queueDir = sourceDir.appendingPathComponent(PostHogStorage.StorageKey.queue.rawValue)
@@ -211,8 +211,8 @@ class PostHogStorageMergeTest {
 
     @Test("test anonymous ID preservation")
     func anonymousIdPreservation() throws {
-        let sourceDir = baseUrl.appendingPathComponent(testBundleIdentifier).appendingPathComponent(testApiKey)
-        let destDir = baseUrl.appendingPathComponent(testAppGroupIdentifier).appendingPathComponent(testApiKey)
+        let sourceDir = baseUrl.appendingPathComponent(testBundleIdentifier).appendingPathComponent(testProjectToken)
+        let destDir = baseUrl.appendingPathComponent(testAppGroupIdentifier).appendingPathComponent(testProjectToken)
 
         // Create anonymous ID in destination (should be preserved)
         let existingAnonymousId = "existing_anonymous_123".data(using: .utf8)!

--- a/PostHogTests/PostHogStorageMigrationTest.swift
+++ b/PostHogTests/PostHogStorageMigrationTest.swift
@@ -82,7 +82,7 @@ class PostHogStorageMigrationTest {
         }
 
         // Initialize storage which should trigger migration
-        _ = PostHogStorage(PostHogConfig(apiKey: testApiKey))
+        _ = PostHogStorage(PostHogConfig(projectToken: testApiKey))
 
         // Verify legacy file was removed
         #expect(!fileManager.fileExists(atPath: legacyFileUrl.path))
@@ -114,7 +114,7 @@ class PostHogStorageMigrationTest {
         }
 
         // Initialize storage which should trigger migration
-        _ = PostHogStorage(PostHogConfig(apiKey: testApiKey))
+        _ = PostHogStorage(PostHogConfig(projectToken: testApiKey))
 
         // Verify events were migrated correctly
         let newQueueUrl = newBaseUrl.appendingPathComponent(key.rawValue)
@@ -301,7 +301,7 @@ class PostHogStorageMigrationTest {
         _ = try createLegacyFile("my.application.data", content: myAppData)
 
         // Initialize storage which should trigger migration
-        _ = PostHogStorage(PostHogConfig(apiKey: testApiKey))
+        _ = PostHogStorage(PostHogConfig(projectToken: testApiKey))
 
         // Verify storage file was migrated
         let newFileUrl = newBaseUrl.appendingPathComponent(PostHogStorage.StorageKey.distinctId.rawValue)

--- a/PostHogTests/PostHogStorageMigrationTest.swift
+++ b/PostHogTests/PostHogStorageMigrationTest.swift
@@ -11,7 +11,7 @@ import Testing
 
 @Suite("PostHogStorage migration tests", .serialized)
 class PostHogStorageMigrationTest {
-    let testApiKey = "test_migration_key"
+    let testProjectToken = "test_project_token"
     var legacyUrl: URL!
     var newBaseUrl: URL!
     var fileManager: FileManager!
@@ -19,7 +19,7 @@ class PostHogStorageMigrationTest {
     init() {
         // Set up base URLs
         legacyUrl = applicationSupportDirectoryURL()
-        newBaseUrl = legacyUrl.appendingPathComponent(testApiKey)
+        newBaseUrl = legacyUrl.appendingPathComponent(testProjectToken)
 
         // Clean up any existing test directories
         fileManager = FileManager.default
@@ -82,7 +82,7 @@ class PostHogStorageMigrationTest {
         }
 
         // Initialize storage which should trigger migration
-        _ = PostHogStorage(PostHogConfig(projectToken: testApiKey))
+        _ = PostHogStorage(PostHogConfig(projectToken: testProjectToken))
 
         // Verify legacy file was removed
         #expect(!fileManager.fileExists(atPath: legacyFileUrl.path))
@@ -114,7 +114,7 @@ class PostHogStorageMigrationTest {
         }
 
         // Initialize storage which should trigger migration
-        _ = PostHogStorage(PostHogConfig(projectToken: testApiKey))
+        _ = PostHogStorage(PostHogConfig(projectToken: testProjectToken))
 
         // Verify events were migrated correctly
         let newQueueUrl = newBaseUrl.appendingPathComponent(key.rawValue)
@@ -256,7 +256,7 @@ class PostHogStorageMigrationTest {
                 ],
                 timestamp: Date(timeIntervalSince1970: 1707221234000),
                 uuid: UUID(),
-                apiKey: "test_api_key_1"
+                apiKey: "test_project_token"
             ),
             PostHogEvent(
                 event: "$snapshot",
@@ -285,7 +285,7 @@ class PostHogStorageMigrationTest {
                 ],
                 timestamp: Date(timeIntervalSince1970: 1707221235),
                 uuid: UUID(),
-                apiKey: "test_api_key_1"
+                apiKey: "test_project_token"
             ),
         ]
 
@@ -301,7 +301,7 @@ class PostHogStorageMigrationTest {
         _ = try createLegacyFile("my.application.data", content: myAppData)
 
         // Initialize storage which should trigger migration
-        _ = PostHogStorage(PostHogConfig(projectToken: testApiKey))
+        _ = PostHogStorage(PostHogConfig(projectToken: testProjectToken))
 
         // Verify storage file was migrated
         let newFileUrl = newBaseUrl.appendingPathComponent(PostHogStorage.StorageKey.distinctId.rawValue)
@@ -318,6 +318,6 @@ class PostHogStorageMigrationTest {
         let legacyDirContents = try fileManager.contentsOfDirectory(atPath: legacyUrl.path).sorted()
         #expect(legacyDirContents.count == 2)
         #expect(legacyDirContents[0] == "my.application.data")
-        #expect(legacyDirContents[1] == "test_migration_key")
+        #expect(legacyDirContents[1] == "test_project_token")
     }
 }

--- a/PostHogTests/PostHogStorageTest.swift
+++ b/PostHogTests/PostHogStorageTest.swift
@@ -11,7 +11,7 @@ import Testing
 
 @Suite("PostHogStorage Tests", .serialized)
 class PostHogStorageTest {
-    func getSut(config: PostHogConfig = PostHogConfig(apiKey: "123")) -> PostHogStorage {
+    func getSut(config: PostHogConfig = PostHogConfig(projectToken: "123")) -> PostHogStorage {
         PostHogStorage(config)
     }
 
@@ -25,7 +25,7 @@ class PostHogStorageTest {
 
     @Test("returns the app group container dir URL")
     func returnsTheAppGroupContainerDirURL() {
-        let config = PostHogConfig(apiKey: "123")
+        let config = PostHogConfig(projectToken: "123")
         config.appGroupIdentifier = testAppGroupIdentifier
         let url = appGroupContainerUrl(config: config)!
 
@@ -128,7 +128,7 @@ class PostHogStorageTest {
 
     @Test("writes to disk in an api key folder under application support directory")
     func writesToDiskInAnApiKeyFolderUnderApplicationSupportDirectory() {
-        let config = PostHogConfig(apiKey: "test_key")
+        let config = PostHogConfig(projectToken: "test_key")
         let sut = PostHogStorage(config)
         let url = sut.appFolderUrl
 
@@ -150,7 +150,7 @@ class PostHogStorageTest {
 
     @Test("writes to disk in an api key folder under a group container directory")
     func writesToDiskInAnApiKeyFolderUnderGroupContainerDirectory() {
-        let config = PostHogConfig(apiKey: "test_key")
+        let config = PostHogConfig(projectToken: "test_key")
         config.appGroupIdentifier = testAppGroupIdentifier
         let sut = PostHogStorage(config)
         let url = sut.appFolderUrl
@@ -176,7 +176,7 @@ class PostHogStorageTest {
 
     @Test("falls back to application support directory when app group identifier is not provided")
     func fallsBackToApplicationSupportDirectoryWhenAppGroupIdentifierIsNotProvided() {
-        let config = PostHogConfig(apiKey: "123")
+        let config = PostHogConfig(projectToken: "123")
         config.appGroupIdentifier = nil
         let sut = PostHogStorage(config)
         let url = sut.appFolderUrl

--- a/PostHogTests/PostHogStorageTest.swift
+++ b/PostHogTests/PostHogStorageTest.swift
@@ -11,7 +11,7 @@ import Testing
 
 @Suite("PostHogStorage Tests", .serialized)
 class PostHogStorageTest {
-    func getSut(config: PostHogConfig = PostHogConfig(projectToken: "123")) -> PostHogStorage {
+    func getSut(config: PostHogConfig = PostHogConfig(projectToken: "test_project_token")) -> PostHogStorage {
         PostHogStorage(config)
     }
 
@@ -25,7 +25,7 @@ class PostHogStorageTest {
 
     @Test("returns the app group container dir URL")
     func returnsTheAppGroupContainerDirURL() {
-        let config = PostHogConfig(projectToken: "123")
+        let config = PostHogConfig(projectToken: "test_project_token")
         config.appGroupIdentifier = testAppGroupIdentifier
         let url = appGroupContainerUrl(config: config)!
 
@@ -126,15 +126,15 @@ class PostHogStorageTest {
         sut.reset()
     }
 
-    @Test("writes to disk in an api key folder under application support directory")
+    @Test("writes to disk in an project token folder under application support directory")
     func writesToDiskInAnApiKeyFolderUnderApplicationSupportDirectory() {
-        let config = PostHogConfig(projectToken: "test_key")
+        let config = PostHogConfig(projectToken: "test_project_token")
         let sut = PostHogStorage(config)
         let url = sut.appFolderUrl
 
         sut.setString(forKey: .distinctId, contents: "distinct_id_value")
 
-        let expectedSuffix = ["Library", "Application Support", testBundleIdentifier, "test_key"]
+        let expectedSuffix = ["Library", "Application Support", testBundleIdentifier, "test_project_token"]
         let actualSuffix = Array(url.pathComponents.suffix(expectedSuffix.count))
         #expect(expectedSuffix == actualSuffix)
 
@@ -148,16 +148,16 @@ class PostHogStorageTest {
         sut.reset()
     }
 
-    @Test("writes to disk in an api key folder under a group container directory")
+    @Test("writes to disk in an project token folder under a group container directory")
     func writesToDiskInAnApiKeyFolderUnderGroupContainerDirectory() {
-        let config = PostHogConfig(projectToken: "test_key")
+        let config = PostHogConfig(projectToken: "test_project_token")
         config.appGroupIdentifier = testAppGroupIdentifier
         let sut = PostHogStorage(config)
         let url = sut.appFolderUrl
 
         sut.setString(forKey: .distinctId, contents: "distinct_id_value")
 
-        let expectedSuffix = ["Library", "Application Support", testAppGroupIdentifier, "test_key"]
+        let expectedSuffix = ["Library", "Application Support", testAppGroupIdentifier, "test_project_token"]
         let actualSuffix = Array(url.pathComponents.suffix(expectedSuffix.count))
         #expect(expectedSuffix == actualSuffix)
 
@@ -176,12 +176,12 @@ class PostHogStorageTest {
 
     @Test("falls back to application support directory when app group identifier is not provided")
     func fallsBackToApplicationSupportDirectoryWhenAppGroupIdentifierIsNotProvided() {
-        let config = PostHogConfig(projectToken: "123")
+        let config = PostHogConfig(projectToken: "test_project_token")
         config.appGroupIdentifier = nil
         let sut = PostHogStorage(config)
         let url = sut.appFolderUrl
 
-        let expectedSuffix = ["Library", "Application Support", testBundleIdentifier, "123"]
+        let expectedSuffix = ["Library", "Application Support", testBundleIdentifier, "test_project_token"]
         let actualSuffix = Array(url.pathComponents.suffix(expectedSuffix.count))
         #expect(expectedSuffix == actualSuffix)
 

--- a/PostHogTests/PostHogStorageTest.swift
+++ b/PostHogTests/PostHogStorageTest.swift
@@ -126,8 +126,8 @@ class PostHogStorageTest {
         sut.reset()
     }
 
-    @Test("writes to disk in an project token folder under application support directory")
-    func writesToDiskInAnApiKeyFolderUnderApplicationSupportDirectory() {
+    @Test("writes to disk in a project token folder under application support directory")
+    func writesToDiskInAProjectTokenFolderUnderApplicationSupportDirectory() {
         let config = PostHogConfig(projectToken: "test_project_token")
         let sut = PostHogStorage(config)
         let url = sut.appFolderUrl
@@ -148,8 +148,8 @@ class PostHogStorageTest {
         sut.reset()
     }
 
-    @Test("writes to disk in an project token folder under a group container directory")
-    func writesToDiskInAnApiKeyFolderUnderGroupContainerDirectory() {
+    @Test("writes to disk in a project token folder under a group container directory")
+    func writesToDiskInAProjectTokenFolderUnderGroupContainerDirectory() {
         let config = PostHogConfig(projectToken: "test_project_token")
         config.appGroupIdentifier = testAppGroupIdentifier
         let sut = PostHogStorage(config)

--- a/PostHogTests/PostHogSurveyEventsTest.swift
+++ b/PostHogTests/PostHogSurveyEventsTest.swift
@@ -89,7 +89,7 @@ class PostHogSurveyEventsTest {
     }
 
     func getSut() -> PostHogSDK {
-        let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9090")
+        let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9090")
         config._surveys = true
         config.flushAt = 1
         config.disableReachabilityForTesting = true

--- a/PostHogTests/PostHogSurveyEventsTest.swift
+++ b/PostHogTests/PostHogSurveyEventsTest.swift
@@ -89,7 +89,7 @@ class PostHogSurveyEventsTest {
     }
 
     func getSut() -> PostHogSDK {
-        let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9090")
+        let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9090")
         config._surveys = true
         config.flushAt = 1
         config.disableReachabilityForTesting = true

--- a/PostHogTests/PostHogSurveysTest.swift
+++ b/PostHogTests/PostHogSurveysTest.swift
@@ -527,7 +527,7 @@ enum PostHogSurveysTest {
             server = MockPostHogServer()
             server.start()
 
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9090")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9090")
             config._surveys = true
             config.flushAt = 1
             config.disableReachabilityForTesting = true
@@ -576,7 +576,7 @@ enum PostHogSurveysTest {
             server = MockPostHogServer()
             server.start()
 
-            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9090")
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9090")
             config._surveys = true
             config.flushAt = 1
             config.disableReachabilityForTesting = true
@@ -758,7 +758,7 @@ enum PostHogSurveysTest {
         let postHog: PostHogSDK
 
         init() {
-            let config = PostHogConfig(projectToken: "test", host: "http://localhost:9090")
+            let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost:9090")
             config._surveys = true
             config.disableFlushOnBackgroundForTesting = true
             postHog = PostHogSDK.with(config)
@@ -1158,7 +1158,7 @@ enum PostHogSurveysTest {
         let storage: PostHogStorage
 
         init() {
-            let config = PostHogConfig(projectToken: "test", host: "http://localhost:9090")
+            let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost:9090")
             config._surveys = true
             config.disableFlushOnBackgroundForTesting = true
             postHog = PostHogSDK.with(config)

--- a/PostHogTests/PostHogSurveysTest.swift
+++ b/PostHogTests/PostHogSurveysTest.swift
@@ -527,7 +527,7 @@ enum PostHogSurveysTest {
             server = MockPostHogServer()
             server.start()
 
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9090")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9090")
             config._surveys = true
             config.flushAt = 1
             config.disableReachabilityForTesting = true
@@ -576,7 +576,7 @@ enum PostHogSurveysTest {
             server = MockPostHogServer()
             server.start()
 
-            let config = PostHogConfig(apiKey: testAPIKey, host: "http://localhost:9090")
+            let config = PostHogConfig(projectToken: testAPIKey, host: "http://localhost:9090")
             config._surveys = true
             config.flushAt = 1
             config.disableReachabilityForTesting = true
@@ -758,7 +758,7 @@ enum PostHogSurveysTest {
         let postHog: PostHogSDK
 
         init() {
-            let config = PostHogConfig(apiKey: "test", host: "http://localhost:9090")
+            let config = PostHogConfig(projectToken: "test", host: "http://localhost:9090")
             config._surveys = true
             config.disableFlushOnBackgroundForTesting = true
             postHog = PostHogSDK.with(config)
@@ -1158,7 +1158,7 @@ enum PostHogSurveysTest {
         let storage: PostHogStorage
 
         init() {
-            let config = PostHogConfig(apiKey: "test", host: "http://localhost:9090")
+            let config = PostHogConfig(projectToken: "test", host: "http://localhost:9090")
             config._surveys = true
             config.disableFlushOnBackgroundForTesting = true
             postHog = PostHogSDK.with(config)

--- a/PostHogTests/Resources/fixture_remote_config.json
+++ b/PostHogTests/Resources/fixture_remote_config.json
@@ -1,5 +1,5 @@
 {
-    "token": "test_api_key",
+    "token": "test_project_token",
     "supportedCompression": [
         "gzip",
         "gzip-js"

--- a/PostHogTests/TestUtils/MockPostHogServer.swift
+++ b/PostHogTests/TestUtils/MockPostHogServer.swift
@@ -369,7 +369,7 @@ class MockPostHogServer {
             let configData =
                 """
                 {
-                    "token": "test_api_key",
+                    "token": "test_project_token",
                     "supportedCompression": [
                         "gzip",
                         "gzip-js"

--- a/PostHogTests/TestUtils/TestPostHog.swift
+++ b/PostHogTests/TestUtils/TestPostHog.swift
@@ -103,4 +103,4 @@ let testAppGroupIdentifier = "group.com.posthog.test"
 
 final class BundleLocator {}
 
-let testAPIKey = "test_api_key"
+let testProjectToken = "test_project_token"

--- a/USAGE.md
+++ b/USAGE.md
@@ -21,20 +21,20 @@ dependencies: [
 ```swift
 import PostHog
 
-let config = PostHogConfig(apiKey: apiKey)
+let config = PostHogConfig(projectToken: projectToken)
 PostHogSDK.shared.setup(config)
 ```
 
 Set a custom `host` (Self-Hosted)
 
 ```swift
-let config = PostHogConfig(apiKey: apiKey, host: host)
+let config = PostHogConfig(projectToken: projectToken, host: host)
 ```
 
 Change the default configuration
 
 ```swift
-let config = PostHogConfig(apiKey: apiKey)
+let config = PostHogConfig(projectToken: projectToken)
 config.captureScreenViews = false
 config.captureApplicationLifecycleEvents = false
 config.debug = true
@@ -45,7 +45,7 @@ If you don't want to use the global/singleton instance, you can create your own 
 and hold it
 
 ```swift
-let config = PostHogConfig(apiKey: apiKey)
+let config = PostHogConfig(projectToken: projectToken)
 let postHog = PostHogSDK.with(config)
 
 PostHogSDK.shared.capture("user_signed_up")
@@ -55,7 +55,7 @@ Enable or Disable the SDK to capture events
 
 ```swift
 // During SDK setup
-let config = PostHogConfig(apiKey: apiKey)
+let config = PostHogConfig(projectToken: projectToken)
 // the SDK is enabled by default
 config.optOut = true
 PostHogSDK.shared.setup(config)
@@ -72,7 +72,7 @@ if (PostHogSDK.shared.isOptOut()) {
 Capture a screen view event
 
 ```swift
-let config = PostHogConfig(apiKey: apiKey)
+let config = PostHogConfig(projectToken: projectToken)
 // it's enabled by default
 config.captureScreenViews = true
 PostHogSDK.shared.setup(config)
@@ -232,7 +232,7 @@ Requires the iOS SDK version >= [3.6.1](https://github.com/PostHog/posthog-ios/r
 Enable the SDK to capture Session Recording.
 
 ```swift
-let config = PostHogConfig(apiKey: apiKey)
+let config = PostHogConfig(projectToken: projectToken)
 // sessionReplay is disabled by default
 config.sessionReplay = true
 // sessionReplayConfig is optional, they are enabled by default

--- a/sdk_compliance_adapter/Package.resolved
+++ b/sdk_compliance_adapter/Package.resolved
@@ -37,6 +37,15 @@
       }
     },
     {
+      "identity" : "plcrashreporter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/microsoft/plcrashreporter.git",
+      "state" : {
+        "revision" : "0254f941c646b1ed17b243654723d0f071e990d0",
+        "version" : "1.12.2"
+      }
+    },
+    {
       "identity" : "routing-kit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/routing-kit.git",

--- a/sdk_compliance_adapter/Sources/RequestInterceptor.swift
+++ b/sdk_compliance_adapter/Sources/RequestInterceptor.swift
@@ -119,7 +119,7 @@ class RequestInterceptor: URLProtocol {
                 }
 
                 if let json = try JSONSerialization.jsonObject(with: decompressed) as? [String: Any] {
-                    // Server SDK format: {"api_key": "...", "batch": [...]}
+                    // Server SDK format: {"api_key": "...", "batch": [...]} where api_key carries the project token.
                     if let batch = json["batch"] as? [[String: Any]] {
                         events = batch
                         print("[INTERCEPTOR] Found batch with \(events.count) events")

--- a/sdk_compliance_adapter/Sources/main.swift
+++ b/sdk_compliance_adapter/Sources/main.swift
@@ -62,7 +62,7 @@ app.post("init") { req async throws -> Response in
     state.reset()
 
     // Create PostHog configuration
-    let config = PostHogConfig(apiKey: initReq.apiKey, host: host)
+    let config = PostHogConfig(projectToken: initReq.apiKey, host: host)
 
     // Configure for fast flushing in tests
     config.flushAt = initReq.flushAt ?? 1

--- a/sdk_compliance_adapter/Sources/main.swift
+++ b/sdk_compliance_adapter/Sources/main.swift
@@ -44,6 +44,7 @@ app.post("init") { req async throws -> Response in
         let flushIntervalMs: Int?
 
         enum CodingKeys: String, CodingKey {
+            // Wire field name remains api_key, but it carries the PostHog project token.
             case apiKey = "api_key"
             case host
             case flushAt = "flush_at"


### PR DESCRIPTION
## :bulb: Motivation and Context

The iOS SDK still uses `apiKey` as the public name for the project credential. This draft updates the public surface to prefer `projectToken`, while keeping `apiKey` working as a backwards-compatible alias.

It also improves the runtime messaging around the old name by:
- warning when `apiKey` is used
- making empty-value logs clearer with an explicit either/or message

## :green_heart: How did you test it?

- Updated `PostHogConfigTest` to cover the new `projectToken` surface and the deprecated `apiKey` alias.
- This is a draft PR for early review; I have not run the full iOS test suite yet.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
