### PR TITLE
fix: parse build number consistently across lifecycle events

### DIFF
--- a/.changeset/parse-build-number-consistently.md
+++ b/.changeset/parse-build-number-consistently.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+fix: parse `build` as Int when possible on `Application Opened` events, matching `Application Installed` / `Application Updated`. Extracts the shared `CFBundleVersion` parsing into a reusable helper so all four `build` / `$app_build` / `previous_build` call sites stay consistent.

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -76,6 +76,8 @@
 		6999918F2AFE1B39000DCB78 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6999918E2AFE1B39000DCB78 /* Preview Assets.xcassets */; };
 		6999919A2AFE1BAB000DCB78 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 699991992AFE1BAB000DCB78 /* AppDelegate.swift */; };
 		699C5FE62C20178E007DB818 /* UUIDUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 699C5FE52C20178E007DB818 /* UUIDUtils.swift */; };
+		D53D57A93B4EA103E8E99819 /* BundleUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826D9ED566BF6FEFBA430555 /* BundleUtils.swift */; };
+		46A911BC1659B0FEFA8D1E43 /* BundleUtilsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E781EB127B3DC1290199836 /* BundleUtilsTest.swift */; };
 		699C5FEF2C20242A007DB818 /* UUIDTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 699C5FEE2C20242A007DB818 /* UUIDTest.swift */; };
 		69B7F60C2CF7703400A48BCC /* UIImage+Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B7F6062CF7702D00A48BCC /* UIImage+Util.swift */; };
 		69BA38D72B888E8500AA69D6 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 69BA38D62B888E8500AA69D6 /* PrivacyInfo.xcprivacy */; };
@@ -649,6 +651,8 @@
 		699991902AFE1B39000DCB78 /* PostHogExampleMacOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PostHogExampleMacOS.entitlements; sourceTree = "<group>"; };
 		699991992AFE1BAB000DCB78 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		699C5FE52C20178E007DB818 /* UUIDUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UUIDUtils.swift; sourceTree = "<group>"; };
+		826D9ED566BF6FEFBA430555 /* BundleUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleUtils.swift; sourceTree = "<group>"; };
+		9E781EB127B3DC1290199836 /* BundleUtilsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleUtilsTest.swift; sourceTree = "<group>"; };
 		699C5FEE2C20242A007DB818 /* UUIDTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UUIDTest.swift; sourceTree = "<group>"; };
 		69B7F6062CF7702D00A48BCC /* UIImage+Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Util.swift"; sourceTree = "<group>"; };
 		69BA38D62B888E8500AA69D6 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
@@ -1097,6 +1101,7 @@
 				690FF0B42AEBBD3C00A0B06B /* DictUtils.swift */,
 				690FF0AE2AEB9C1400A0B06B /* DateUtils.swift */,
 				699C5FE52C20178E007DB818 /* UUIDUtils.swift */,
+				826D9ED566BF6FEFBA430555 /* BundleUtils.swift */,
 				690B2DF22C205B5600AE3B45 /* TimeBasedEpochGenerator.swift */,
 				DAF95F502D072F04001E82BB /* UIImage+WebP.swift */,
 				DA10448F2D0B1D4300C4ACF3 /* AssociatedKeys.swift */,
@@ -1192,6 +1197,7 @@
 				DA4FFBB42DAD5AF9006BAEEA /* PostHogIdentityTests.swift */,
 				DA0F98A12D940E7D009AB6F5 /* ApplicationViewLayoutPublisherTest.swift */,
 				DAD39DF52D561787002A1A69 /* UtilsTest.swift */,
+				9E781EB127B3DC1290199836 /* BundleUtilsTest.swift */,
 				DAF95F5B2D077BCC001E82BB /* Resources */,
 				3A62646829C9E37A007E8C07 /* TestUtils */,
 				DA53DE7D2D3E66A300C38DCA /* PostHogRemoteConfigTest.swift */,
@@ -2443,6 +2449,7 @@
 				69261D132AD5685B00232EC7 /* PostHogRemoteConfig.swift in Sources */,
 				DA9AE8F42D89AFD7002F1B44 /* BottomSection.swift in Sources */,
 				699C5FE62C20178E007DB818 /* UUIDUtils.swift in Sources */,
+				D53D57A93B4EA103E8E99819 /* BundleUtils.swift in Sources */,
 				690B2DF32C205B5600AE3B45 /* TimeBasedEpochGenerator.swift in Sources */,
 				69261D1D2AD967CD00232EC7 /* PostHogFileBackedQueue.swift in Sources */,
 				3AE3FB432992985A00AFFC18 /* Reachability.swift in Sources */,
@@ -2492,6 +2499,7 @@
 				690FF0E92AEFD3BD00A0B06B /* PostHogQueueTest.swift in Sources */,
 				3AE3FB4B2993A68500AFFC18 /* PostHogStorageTest.swift in Sources */,
 				DAD39DF62D56178D002A1A69 /* UtilsTest.swift in Sources */,
+				46A911BC1659B0FEFA8D1E43 /* BundleUtilsTest.swift in Sources */,
 				DA27AEC92F56B3F3002A59CE /* PostHogSamplingTest.swift in Sources */,
 				3A580B4329E489D000C5C6F3 /* URLSession+body.swift in Sources */,
 				DA1D29602D10C810003A31DA /* PostHogSessionManagerTest.swift in Sources */,

--- a/PostHog/AppLifeCycle/PostHogAppLifeCycleIntegration.swift
+++ b/PostHog/AppLifeCycle/PostHogAppLifeCycleIntegration.swift
@@ -90,7 +90,6 @@ final class PostHogAppLifeCycleIntegration: PostHogIntegration {
         didEnterBackgroundToken = nil
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
     private func captureAppInstallOrUpdated() {
         // Check if Application Installed or Application Updated was already checked in the lifecycle of this app
         // This can be called multiple times in case of optOut, multiple instances or start/stop integration
@@ -130,13 +129,8 @@ final class PostHogAppLifeCycleIntegration: PostHogIntegration {
             if previousVersion != nil {
                 props["previous_version"] = previousVersion
             }
-            // Try to parse as Int first, then fallback to String
             if let previousVersionCode {
-                if let prevBuildInt = Int(previousVersionCode) {
-                    props["previous_build"] = prevBuildInt
-                } else {
-                    props["previous_build"] = previousVersionCode
-                }
+                props["previous_build"] = parseBundleVersion(previousVersionCode)
             }
         }
 
@@ -148,12 +142,7 @@ final class PostHogAppLifeCycleIntegration: PostHogIntegration {
         }
 
         if let versionCode {
-            // Try to parse as Int first, then fallback to String
-            if let buildInt = Int(versionCode) {
-                props["build"] = buildInt
-            } else {
-                props["build"] = versionCode
-            }
+            props["build"] = parseBundleVersion(versionCode)
             userDefaults.setValue(versionCode, forKey: "PHGBuildKeyV2")
             syncDefaults = true
         }
@@ -192,8 +181,8 @@ final class PostHogAppLifeCycleIntegration: PostHogIntegration {
             if versionName != nil {
                 props["version"] = versionName
             }
-            if versionCode != nil {
-                props["build"] = versionCode
+            if let versionCode {
+                props["build"] = parseBundleVersion(versionCode)
             }
 
             isFreshAppLaunch = false

--- a/PostHog/PostHogContext.swift
+++ b/PostHog/PostHogContext.swift
@@ -38,11 +38,7 @@ class PostHogContext {
             properties["$app_version"] = appVersion
         }
         if let appBuild = infoDictionary?["CFBundleVersion"] as? String {
-            if let appBuildInt = Int(appBuild) {
-                properties["$app_build"] = appBuildInt
-            } else {
-                properties["$app_build"] = appBuild
-            }
+            properties["$app_build"] = parseBundleVersion(appBuild)
         }
         properties["$is_testflight"] = PostHogContext.isTestFlight
         properties["$is_sideloaded"] = PostHogContext.isSideloaded

--- a/PostHog/Utils/BundleUtils.swift
+++ b/PostHog/Utils/BundleUtils.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Parses a `CFBundleVersion` string as an `Int` when possible, falling back to the
+/// raw `String`. Apple allows both numeric (`"42"`) and dotted (`"1.2.3"`) build
+/// numbers, so a parse failure is expected and not an error.
+func parseBundleVersion(_ value: String) -> Any {
+    Int(value) ?? value
+}

--- a/PostHogTests/BundleUtilsTest.swift
+++ b/PostHogTests/BundleUtilsTest.swift
@@ -1,0 +1,34 @@
+import Foundation
+@testable import PostHog
+import Testing
+
+@Suite("BundleUtilsTest")
+struct BundleUtilsTest {
+    @Suite("parseBundleVersion")
+    struct ParseBundleVersionTests {
+        @Test("returns Int when the value is purely numeric")
+        func returnsIntForNumericValue() {
+            #expect(parseBundleVersion("42") as? Int == 42)
+        }
+
+        @Test("returns String when the value contains dots (e.g. semver-style builds)")
+        func returnsStringForDottedValue() {
+            #expect(parseBundleVersion("1.2.3") as? String == "1.2.3")
+        }
+
+        @Test("returns String when the value contains non-numeric characters")
+        func returnsStringForAlphanumericValue() {
+            #expect(parseBundleVersion("42-beta") as? String == "42-beta")
+        }
+
+        @Test("returns String for an empty value")
+        func returnsStringForEmptyValue() {
+            #expect(parseBundleVersion("") as? String == "")
+        }
+
+        @Test("returns Int for zero")
+        func returnsIntForZero() {
+            #expect(parseBundleVersion("0") as? Int == 0)
+        }
+    }
+}

--- a/PostHogTests/PostHogAppLifeCycleIntegrationTest.swift
+++ b/PostHogTests/PostHogAppLifeCycleIntegrationTest.swift
@@ -113,7 +113,7 @@ final class PostHogAppLifeCycleIntegrationTest {
 
             print("running tests")
             #expect(events.first?.properties["$app_version"] != nil)
-            #expect(events.first?.properties["build"] != nil)
+            #expect(events.first?.properties["$app_build"] != nil)
             #expect(events.first?.properties["build"] != nil)
 
             #expect(UserDefaults.standard.string(forKey: "PHGVersionKey") != nil)
@@ -147,8 +147,9 @@ final class PostHogAppLifeCycleIntegrationTest {
 
             print("running tests")
             #expect(events.first?.properties["$app_version"] != nil)
+            #expect(events.first?.properties["$app_build"] != nil)
             #expect(events.first?.properties["build"] != nil)
-            #expect(events.first?.properties["build"] != nil)
+            #expect(events.first?.properties["previous_build"] != nil)
 
             #expect(UserDefaults.standard.string(forKey: "PHGVersionKey") != nil)
             #expect(UserDefaults.standard.string(forKey: "PHGBuildKeyV2") != nil)
@@ -181,7 +182,7 @@ final class PostHogAppLifeCycleIntegrationTest {
 
             print("running tests")
             #expect(events.first?.properties["$app_version"] != nil)
-            #expect(events.first?.properties["build"] != nil)
+            #expect(events.first?.properties["$app_build"] != nil)
             #expect(events.first?.properties["build"] != nil)
 
             #expect(UserDefaults.standard.string(forKey: "PHGVersionKey") != nil)
@@ -256,6 +257,7 @@ final class PostHogAppLifeCycleIntegrationTest {
         #if targetEnvironment(simulator)
             #expect(events[1].properties["version"] != nil)
             #expect(events[1].properties["build"] != nil)
+            #expect(events[1].properties["$app_build"] != nil)
         #endif
 
         sut.close()
@@ -334,6 +336,7 @@ final class PostHogAppLifeCycleIntegrationTest {
         #if targetEnvironment(simulator)
             #expect(events[1].properties["version"] != nil)
             #expect(events[1].properties["build"] != nil)
+            #expect(events[1].properties["$app_build"] != nil)
         #endif
 
         sut.close()


### PR DESCRIPTION
## :bulb: Motivation and Context

Follow-up to #423 as discussed with @marandaneto ([comment](https://github.com/PostHog/posthog-ios/pull/423#issuecomment-4313115250)).

`Application Opened` was sending `build` as a raw `String`, while `Application Installed` / `Updated` parsed it as `Int` when possible. Same build number, different types on different events.

Extracts the shared parsing into `parseBundleVersion(_:)` (`Utils/BundleUtils.swift`) so all four call sites — `$app_build`, `previous_build`, and both `build` sites — use one helper.

## :green_heart: How did you test it?

- Added `BundleUtilsTest.swift` (Swift Testing: numeric, dotted, alphanumeric, empty, zero).
- Extended `PostHogAppLifeCycleIntegrationTest` to assert `$app_build` on `Application Installed` / `Updated` / `Opened`, and `previous_build` on `Updated`.
- `make test` passes (457 tests), `make lint` clean (0 serious).
- iOS + macOS built locally; other platforms left to CI.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the `release` label to the PR