### PR TITLE
fix: improve session replay screenshot performance

### DIFF
--- a/.changeset/tasty-hands-like.md
+++ b/.changeset/tasty-hands-like.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+fix: improve session replay screenshot performance

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -238,6 +238,7 @@
 		DA71854D2D07E11200396388 /* input_1.png in Resources */ = {isa = PBXBuildFile; fileRef = DA7185422D07E11200396388 /* input_1.png */; };
 		DA74644F2DC8D58100C7D394 /* PostHogConsoleLogInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA74644E2DC8D58100C7D394 /* PostHogConsoleLogInterceptor.swift */; };
 		DA86D0E32E02D78C00CF3065 /* PostHogSurveysDefaultDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA86D0E22E02D78C00CF3065 /* PostHogSurveysDefaultDelegate.swift */; };
+		DA879D7A2F9CC8AD0036A854 /* PostHogGraphicsImageRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA879D792F9CC8AD0036A854 /* PostHogGraphicsImageRenderer.swift */; };
 		DA8C9B982EC633FA00C6EADB /* PostHogErrorTrackingConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8C9B962EC633FA00C6EADB /* PostHogErrorTrackingConfig.swift */; };
 		DA929C082D0B3A1D0018369C /* PostHog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AC745B5296D6FE60025C109 /* PostHog.framework */; };
 		DA929C092D0B3A1D0018369C /* PostHog.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3AC745B5296D6FE60025C109 /* PostHog.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -353,6 +354,7 @@
 		DAA022472D78203D00197660 /* fixture_survey_url_match_type_not_regex.json in Resources */ = {isa = PBXBuildFile; fileRef = DAA022462D78203D00197660 /* fixture_survey_url_match_type_not_regex.json */; };
 		DAA022492D78205100197660 /* fixture_survey_url_match_type_is_not.json in Resources */ = {isa = PBXBuildFile; fileRef = DAA022482D78205100197660 /* fixture_survey_url_match_type_is_not.json */; };
 		DAA0224B2D782D6F00197660 /* fixture_survey_url_match_type_exact.json in Resources */ = {isa = PBXBuildFile; fileRef = DAA0224A2D782D6F00197660 /* fixture_survey_url_match_type_exact.json */; };
+		DAA1B2C32F8C100000112233 /* PostHogRageClickIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA1B2C22F8C100000112233 /* PostHogRageClickIntegration.swift */; };
 		DAA5ED972D4043A500D437E0 /* PostHogSurveysTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA5ED962D4043A500D437E0 /* PostHogSurveysTest.swift */; };
 		DAA5EE212D43605000D437E0 /* fixture_survey_branching_response_based_linkert.json in Resources */ = {isa = PBXBuildFile; fileRef = DAA5EE1A2D43605000D437E0 /* fixture_survey_branching_response_based_linkert.json */; };
 		DAA5EE242D43605000D437E0 /* fixture_survey_branching_response_based_empty.json in Resources */ = {isa = PBXBuildFile; fileRef = DAA5EE192D43605000D437E0 /* fixture_survey_branching_response_based_empty.json */; };
@@ -379,9 +381,6 @@
 		DABF95052E8FEB6F0029CBBB /* PostHogSurveyEventsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DABF95042E8FEB6F0029CBBB /* PostHogSurveyEventsTest.swift */; };
 		DAC0A2BF2F2C419400BAA602 /* PostHogDebugImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3BB4DE2ED992780097A97A /* PostHogDebugImageProvider.swift */; };
 		DAC699D62CC790D9000D1D6B /* PostHogAutocaptureIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC699D52CC790D9000D1D6B /* PostHogAutocaptureIntegration.swift */; };
-		DAA1B2C32F8C100000112233 /* PostHogRageClickIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA1B2C22F8C100000112233 /* PostHogRageClickIntegration.swift */; };
-		EE47DB8C906D409AB6C2A23F /* RageClickDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E974D4AD3C438FAE6FE0C5 /* RageClickDetector.swift */; };
-		E82B0039B6834A439AD214E9 /* PostHogRageClickConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = F78338D55B15449D9EB8507B /* PostHogRageClickConfig.swift */; };
 		DAC699EC2CCA73E5000D1D6B /* ForwardingPickerViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC699EB2CCA73E5000D1D6B /* ForwardingPickerViewDelegate.swift */; };
 		DACB3ED22E0193B20061FC7D /* PostHogSurvey+Display.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACB3ED12E0193B20061FC7D /* PostHogSurvey+Display.swift */; };
 		DACC08BB2D6E3C6D00115E46 /* PostHogIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACC08B52D6E3C6800115E46 /* PostHogIntegration.swift */; };
@@ -402,6 +401,8 @@
 		DAFEC4592E03F93A0064535E /* PostHogDisplaySurveyAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFEC4582E03F93A0064535E /* PostHogDisplaySurveyAppearance.swift */; };
 		DAFF026B2D7B1A9800BD5B1D /* SurveysRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFF02652D7B1A9000BD5B1D /* SurveysRootView.swift */; };
 		DAFF026D2D7B2F9200BD5B1D /* SurveyDisplayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFF026C2D7B2F8D00BD5B1D /* SurveyDisplayController.swift */; };
+		E82B0039B6834A439AD214E9 /* PostHogRageClickConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = F78338D55B15449D9EB8507B /* PostHogRageClickConfig.swift */; };
+		EE47DB8C906D409AB6C2A23F /* RageClickDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E974D4AD3C438FAE6FE0C5 /* RageClickDetector.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -569,6 +570,7 @@
 
 /* Begin PBXFileReference section */
 		1F55581F2DFC47E8007643C0 /* PostHogStorageMergeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogStorageMergeTest.swift; sourceTree = "<group>"; };
+		26E974D4AD3C438FAE6FE0C5 /* RageClickDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RageClickDetector.swift; sourceTree = "<group>"; };
 		3A0F108229C47940002C0084 /* UIViewExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewExample.swift; sourceTree = "<group>"; };
 		3A0F108829C9BD76002C0084 /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		3A580B4229E489D000C5C6F3 /* URLSession+body.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+body.swift"; sourceTree = "<group>"; };
@@ -807,6 +809,7 @@
 		DA7185472D07E11200396388 /* output_3.webp */ = {isa = PBXFileReference; lastKnownFileType = file; path = output_3.webp; sourceTree = "<group>"; };
 		DA74644E2DC8D58100C7D394 /* PostHogConsoleLogInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogConsoleLogInterceptor.swift; sourceTree = "<group>"; };
 		DA86D0E22E02D78C00CF3065 /* PostHogSurveysDefaultDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSurveysDefaultDelegate.swift; sourceTree = "<group>"; };
+		DA879D792F9CC8AD0036A854 /* PostHogGraphicsImageRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogGraphicsImageRenderer.swift; sourceTree = "<group>"; };
 		DA8C9B962EC633FA00C6EADB /* PostHogErrorTrackingConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogErrorTrackingConfig.swift; sourceTree = "<group>"; };
 		DA8D37242CBEAC02005EBD27 /* PostHogExampleAutocapture.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = PostHogExampleAutocapture.xcodeproj; path = PostHogExampleAutocapture/PostHogExampleAutocapture.xcodeproj; sourceTree = "<group>"; };
 		DA92C6402DCE09C700C02F3E /* PostHogLogEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogLogEntry.swift; sourceTree = "<group>"; };
@@ -921,6 +924,7 @@
 		DAA022462D78203D00197660 /* fixture_survey_url_match_type_not_regex.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = fixture_survey_url_match_type_not_regex.json; sourceTree = "<group>"; };
 		DAA022482D78205100197660 /* fixture_survey_url_match_type_is_not.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = fixture_survey_url_match_type_is_not.json; sourceTree = "<group>"; };
 		DAA0224A2D782D6F00197660 /* fixture_survey_url_match_type_exact.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = fixture_survey_url_match_type_exact.json; sourceTree = "<group>"; };
+		DAA1B2C22F8C100000112233 /* PostHogRageClickIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogRageClickIntegration.swift; sourceTree = "<group>"; };
 		DAA5ED962D4043A500D437E0 /* PostHogSurveysTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSurveysTest.swift; sourceTree = "<group>"; };
 		DAA5EE132D43605000D437E0 /* fixture_survey_basic.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = fixture_survey_basic.json; sourceTree = "<group>"; };
 		DAA5EE162D43605000D437E0 /* fixture_survey_branching_end.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = fixture_survey_branching_end.json; sourceTree = "<group>"; };
@@ -945,9 +949,6 @@
 		DABDF9C22E02994000C7E498 /* PostHogDisplaySurvey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogDisplaySurvey.swift; sourceTree = "<group>"; };
 		DABF95042E8FEB6F0029CBBB /* PostHogSurveyEventsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSurveyEventsTest.swift; sourceTree = "<group>"; };
 		DAC699D52CC790D9000D1D6B /* PostHogAutocaptureIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogAutocaptureIntegration.swift; sourceTree = "<group>"; };
-		DAA1B2C22F8C100000112233 /* PostHogRageClickIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogRageClickIntegration.swift; sourceTree = "<group>"; };
-		26E974D4AD3C438FAE6FE0C5 /* RageClickDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RageClickDetector.swift; sourceTree = "<group>"; };
-		F78338D55B15449D9EB8507B /* PostHogRageClickConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogRageClickConfig.swift; sourceTree = "<group>"; };
 		DAC699EB2CCA73E5000D1D6B /* ForwardingPickerViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForwardingPickerViewDelegate.swift; sourceTree = "<group>"; };
 		DACB3ED12E0193B20061FC7D /* PostHogSurvey+Display.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostHogSurvey+Display.swift"; sourceTree = "<group>"; };
 		DACC08B52D6E3C6800115E46 /* PostHogIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogIntegration.swift; sourceTree = "<group>"; };
@@ -969,6 +970,7 @@
 		DAFEC4582E03F93A0064535E /* PostHogDisplaySurveyAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogDisplaySurveyAppearance.swift; sourceTree = "<group>"; };
 		DAFF02652D7B1A9000BD5B1D /* SurveysRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveysRootView.swift; sourceTree = "<group>"; };
 		DAFF026C2D7B2F8D00BD5B1D /* SurveyDisplayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyDisplayController.swift; sourceTree = "<group>"; };
+		F78338D55B15449D9EB8507B /* PostHogRageClickConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogRageClickConfig.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1371,6 +1373,7 @@
 				DA5175BB2F6C4E1100F0E00A /* PostHogReplayQueue.swift */,
 				DA5175B12F6C4CEA00F0E00A /* PostHogReplayBufferDelegate.swift */,
 				DA5175B22F6C4CEA00F0E00A /* PostHogReplayBufferQueue.swift */,
+				DA879D792F9CC8AD0036A854 /* PostHogGraphicsImageRenderer.swift */,
 			);
 			path = Replay;
 			sourceTree = "<group>";
@@ -2344,6 +2347,7 @@
 				DA9CE3592D3108AD00DFE652 /* cost_neon.c in Sources */,
 				DAD39DF42D560818002A1A69 /* Float+Util.swift in Sources */,
 				DA9CE35A2D3108AD00DFE652 /* enc_sse41.c in Sources */,
+				DA879D7A2F9CC8AD0036A854 /* PostHogGraphicsImageRenderer.swift in Sources */,
 				DA9CE35B2D3108AD00DFE652 /* webp_enc.c in Sources */,
 				DA9CE35C2D3108AD00DFE652 /* upsampling_neon.c in Sources */,
 				DA9CE35D2D3108AD00DFE652 /* config_enc.c in Sources */,

--- a/PostHog/Replay/PostHogGraphicsImageRenderer.swift
+++ b/PostHog/Replay/PostHogGraphicsImageRenderer.swift
@@ -1,0 +1,66 @@
+#if os(iOS)
+
+    import UIKit
+
+    /// Cached device RGB color space — avoids creating a new one per render call.
+    private let deviceRGBColorSpace = CGColorSpaceCreateDeviceRGB()
+
+    /// High-performance image renderer that bypasses `UIGraphicsImageRenderer` overhead.
+    ///
+    /// This directly allocates a `CGContext` for the target image and pushes it as the
+    /// current UIKit context, allowing existing UIKit drawing APIs such as
+    /// `drawHierarchy(in:afterScreenUpdates:)` and `UIImage.draw(at:)` to render into it.
+    final class PostHogGraphicsImageRenderer {
+        private let size: CGSize
+        private let scale: CGFloat
+
+        init(size: CGSize, scale: CGFloat) {
+            self.size = size
+            self.scale = scale
+        }
+
+        func image(actions: (CGContext) -> Void) -> UIImage? {
+            let pixelsPerRow = Int(size.width * scale)
+            let pixelsPerColumn = Int(size.height * scale)
+            let bytesPerPixel = 4
+            let bytesPerRow = bytesPerPixel * pixelsPerRow
+            let bitsPerComponent = 8
+
+            guard pixelsPerRow > 0, pixelsPerColumn > 0 else {
+                return nil
+            }
+
+            let bufferSize = pixelsPerColumn * bytesPerRow
+            guard let rawData = malloc(bufferSize) else {
+                return nil
+            }
+            defer { free(rawData) }
+
+            guard let context = CGContext(
+                data: rawData,
+                width: pixelsPerRow,
+                height: pixelsPerColumn,
+                bitsPerComponent: bitsPerComponent,
+                bytesPerRow: bytesPerRow,
+                space: deviceRGBColorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            ) else {
+                return nil
+            }
+
+            // UIKit's coordinate system is flipped relative to CoreGraphics.
+            context.translateBy(x: 0, y: size.height * scale)
+            context.scaleBy(x: scale, y: -scale)
+
+            UIGraphicsPushContext(context)
+            actions(context)
+            UIGraphicsPopContext()
+
+            guard let cgImage = context.makeImage() else {
+                return nil
+            }
+            return UIImage(cgImage: cgImage, scale: scale, orientation: .up)
+        }
+    }
+
+#endif

--- a/PostHog/Replay/RRWireframe.swift
+++ b/PostHog/Replay/RRWireframe.swift
@@ -52,9 +52,10 @@ class RRWireframe {
             }
 
             return autoreleasepool {
-                // the scale also affects the image size/resolution, from usually 100kb to 15kb each
-                UIGraphicsImageRenderer(size: image.size, format: .init(for: .init(displayScale: 1))).image { context in
-                    context.cgContext.interpolationQuality = .none
+                // Use scale=1 to preserve the existing masked screenshot payload size.
+                let renderer = PostHogGraphicsImageRenderer(size: image.size, scale: 1)
+                return renderer.image { context in
+                    context.interpolationQuality = .none
                     image.draw(at: .zero)
 
                     if let maskableWidgets = maskableWidgets {

--- a/PostHog/Replay/UIView+Util.swift
+++ b/PostHog/Replay/UIView+Util.swift
@@ -36,22 +36,17 @@
         }
 
         func toImage() -> UIImage? {
-            // Avoid Rendering Offscreen Views
-            let bounds = superview?.bounds ?? bounds
-            let size = bounds.intersection(bounds).size
+            let bounds = self.bounds
+            let size = bounds.size
 
             if !size.hasSize() {
                 return nil
             }
 
-            let rendererFormat = UIGraphicsImageRendererFormat.default()
-
-            // This can significantly improve rendering performance because the renderer won't need to
-            // process transparency.
-            rendererFormat.opaque = isOpaque
-            // Another way to improve rendering performance is to scale the renderer's content.
-            // rendererFormat.scale = 0.5
-            let renderer = UIGraphicsImageRenderer(size: size, format: rendererFormat)
+            // Use native screen scale for best drawHierarchy performance.
+            // Using a non-native scale can trigger internal rescaling overhead.
+            let nativeScale = (self as? UIWindow ?? window)?.screen.scale ?? 1
+            let renderer = PostHogGraphicsImageRenderer(size: size, scale: nativeScale)
 
             return autoreleasepool {
                 renderer.image { _ in


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #321 and possibly #571

This PR improves screenshot performance by replacing `UIGraphicsImageRenderer` with a custom and more lightweight CGContext-backed renderer.

Physical-device benchmarking and profiling on an old iPhone XR showed the UIView.toImage() path was the dominant source of UI glitches:

 - Baseline screenshot snapshots cost ~135ms on the main thread.
 - Each snapshot correlated with a >33ms frame hitch.
 - At higher snapshot rates, replay could saturate the app and drop effective frame pacing below 60fps.

### Changes
 - Adds `PostHogGraphicsImageRenderer`, a direct CoreGraphics bitmap renderer.
 - Uses it for `UIView.toImage()` screenshot capture.
 - Uses it for `RRWireframe.maskImage()` masked screenshot redraw.
 - Does not change masking traversal logic, masking decisions, serialization, or replay event structure. 

### Findings

Physical device benchmark on an iPhone XR (`iPhone11,8`), running screenshots on a complex idle view with re-layout ticks (to trigger snapshots)

Judging from the metrics collected, snapshot main-thread cost dropped by ~92%:

 | Throttle | Baseline snapshot avg | This PR snapshot avg | Delta |
 |---:|---:|---:|---:|
 | 0.50s | 134.22ms | 11.14ms | -91.7% |
 | 0.25s | 134.58ms | 10.69ms | -92.1% |
 | 0.10s | 138.92ms | 10.66ms | -92.3% |

There was also a big improvement on frame pacing and app hangs. This was also prominent when running the app, frame rate stayed at 60fps at all throttle levels (not recommended if you are reading this):

 | Throttle | Baseline frames >33ms | This PR frames >33ms |
 |---:|---:|---:|
 | 0.50s | 29 | 0 |
 | 0.25s | 57 | 0 |
 | 0.10s | 93 | 0 |
 
**Before**

https://github.com/user-attachments/assets/adc13e41-1a83-4f54-9295-c79bbfab4b65 

**After**

https://github.com/user-attachments/assets/c283d247-1b58-4eb9-9818-5326b411ae9c

### Post-release

- [ ] Bump RN posthog-ios min version
- [ ] Bump Flutter posthog-ios min version

### Note

We previously experimented with using a custom renderer to improve performance. Back then, the timing results were not that convincing and I decided not to ship a fix, which was the wrong call. This could be because: 
- I had the wrong approach on profiling the improvement and baseline
- I was not profiling/testing on the correct device 

This one is on me because we could have shipped this improvement much earlier!

## :green_heart: How did you test it?

- Profiling with Xcode Instruments and custom benchmarking
- Running on a lower-end physical device
- Verified that session recordings are scaled and masked correctly in the PostHog UI
- This 👇 
 
<img width="50%" src="https://github.com/user-attachments/assets/eb353c24-2765-483b-bfd6-707decb91adf" />

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
