### PR TITLE
chore: trigger releases from main changesets

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,5 @@
 ## If releasing new changes
 
 - [ ] Ran `pnpm changeset` to generate a changeset file
-- [ ] Added the `release` label to the PR
 
 <!-- For more details check RELEASING.md -->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,10 @@ permissions:
   contents: read
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [main]
+    paths:
+      - '.changeset/**'
   workflow_dispatch:
 
 # Concurrency control: only one release process can run at a time
@@ -18,12 +19,6 @@ jobs:
   check-changesets:
     name: Check for changesets
     runs-on: ubuntu-latest
-    # Run when PR with 'release' label is merged to main, or when manually triggered
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request'
-       && github.event.pull_request.merged == true
-       && contains(github.event.pull_request.labels.*.name, 'release'))
     outputs:
       has-changesets: ${{ steps.check.outputs.has-changesets }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [main]
     paths:
-      - '.changeset/**'
+      - '.changeset/*.md'
   workflow_dispatch:
 
 # Concurrency control: only one release process can run at a time
@@ -121,7 +121,7 @@ jobs:
             echo "No changes to commit"
             echo "committed=false" >> "$GITHUB_OUTPUT"
           else
-            git commit -m "chore: release v$NEW_VERSION [version bump]"
+            git commit -m "chore: release v$NEW_VERSION [version bump] [skip ci]"
             git push origin main
             echo "committed=true" >> "$GITHUB_OUTPUT"
           fi

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,7 +18,7 @@ This prompts you to select the version bump (`patch`, `minor`, or `major`) and w
 
 After review, merge the PR to `main`. No GitHub release label is required.
 
-A push to `main` that includes `.changeset/**` changes automatically starts the release workflow. The workflow then:
+A push to `main` that includes `.changeset/*.md` changes automatically starts the release workflow. The workflow then:
 
 1. Checks for pending changesets
 2. Notifies the client libraries team in Slack for approval

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,202 +6,40 @@ This repository uses [Changesets](https://github.com/changesets/changesets) for 
 
 ### 1. Add a Changeset
 
-When making changes that should be released, add a changeset:
+When making a change that should be released, add a changeset:
 
 ```bash
 pnpm changeset
 ```
 
-This will prompt you to:
-- Select the type of version bump (patch, minor, major)
-- Write a summary of the changes
+This prompts you to select the version bump (`patch`, `minor`, or `major`) and write a short release summary. Commit the generated file in `.changeset/` with your pull request.
 
-The changeset file will be created in the `.changeset/` directory.
+### 2. Merge the Pull Request
 
-### 2. Create a Pull Request
+After review, merge the PR to `main`. No GitHub release label is required.
 
-Create a PR with your changes and the changeset file(s). Add the `release` label to the PR.
+A push to `main` that includes `.changeset/**` changes automatically starts the release workflow. The workflow then:
 
-### 3. Merge the PR
-
-When the PR is merged to `main`, the release workflow will automatically:
-
-1. Check for changesets
-2. Notify the client libraries team in Slack for approval
-3. Wait for approval from a maintainer (via GitHub environment protection)
-4. Once approved:
-   - Apply changesets and bump the version (in `package.json`, `PostHogVersion.swift`, and `PostHog.podspec`)
-   - Update the `CHANGELOG.md`
-   - Commit the version bump to `main`
-   - Create a git tag and GitHub release
-   - Publish the pod to CocoaPods
-   - SPM uses the tag name to determine the version, directly from the repo
+1. Checks for pending changesets
+2. Notifies the client libraries team in Slack for approval
+3. Waits for approval from a maintainer via the GitHub `Release` environment
+4. The workflow applies Changesets, syncs Swift version files, tags the release, and creates a GitHub Release.
+5. Notifies Slack when the release completes or fails
 
 ### Manual Trigger
 
-You can also manually trigger the release workflow from the [Actions tab](https://github.com/PostHog/posthog-ios/actions/workflows/release.yml) by clicking "Run workflow".
+You can also manually trigger the release workflow from the Actions tab with `workflow_dispatch`. Manual runs still require pending changesets.
 
 ## Version Bumping
 
-Changesets handles version bumping automatically based on the changesets you create:
+Changesets determines the next version from the committed changeset files:
 
-- **patch**: Bug fixes, documentation updates, internal changes (e.g., `3.41.1` → `3.41.2`)
-- **minor**: New features, non-breaking changes (e.g., `3.41.1` → `3.42.0`)
-- **major**: Breaking changes (e.g., `3.41.1` → `4.0.0`)
-
-## Pre-release Versions
-
-For pre-release versions (alpha, beta, RC), you can manually enter pre-release mode:
-
-```bash
-pnpm changeset pre enter alpha  # or beta, rc
-pnpm changeset version
-```
-
-To exit pre-release mode:
-
-```bash
-pnpm changeset pre exit
-```
+- **patch**: bug fixes, documentation updates, and internal changes
+- **minor**: backwards-compatible features
+- **major**: breaking changes
 
 ## Troubleshooting
 
 ### No changesets found
 
-If the release workflow fails with "No changesets found", ensure your PR includes at least one changeset file in the `.changeset/` directory.
-
-### Release not triggered
-
-Make sure the PR has the `release` label applied before merging.
-
-### Manual CocoaPods publish (emergency only)
-
-In case of automation failure, you can manually publish:
-
-```bash
-make releaseCocoaPods
-```
-
-You'll need to be authenticated with CocoaPods trunk and have push access to the `PostHog` pod.
-
-# CocoaPods Management
-
-The PostHog iOS SDK is published to CocoaPods automatically via GitHub Actions when a release is created. This section covers the management of CocoaPods permissions and tokens.
-
-### Check Your Current Session
-
-```bash
-# Check if you're logged in and your permissions
-pod trunk me
-```
-
-Expected output should show:
-
-```text
-- Name:     Your Name
-- Email:    your.email@posthog.com
-- Since:    Date
-- Pods:
-  - PostHog
-- Sessions:
-  - Session details...
-```
-
-### Check Pod Ownership
-
-```bash
-# Check who owns the PostHog pod
-pod trunk info PostHog
-```
-
-This will show:
-
-- Current version
-- All owners with push permissions
-
-### Adding a co-owner
-
-1. **With an existing owner**:
-
-   ```bash
-   # Run this as an existing owner
-   pod trunk add-owner PostHog dev.email@posthog.com
-   ```
-
-2. **Verify**:
-   ```bash
-   # Check that the new owner was added
-   pod trunk info PostHog
-   ```
-
-### Removing a co-owner
-
-1. **With an existing owner**:
-
-   ```bash
-   # Run this as an existing owner
-   pod trunk remove-owner PostHog dev.email@posthog.com
-   ```
-
-2. **Verify**:
-   ```bash
-   # Check that the new owner was removed
-   pod trunk info PostHog
-   ```
-
-### Rotating COCOAPODS_TRUNK_TOKEN
-
-The `COCOAPODS_TRUNK_TOKEN` is used in GitHub Actions for automated releases. Here's how to rotate it:
-
-The token is stored as a GitHub secret and used in `.github/workflows/release.yml`:
-
-```yaml
-env:
-  COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-```
-
-#### Step 1: Create a new session
-
-1. **Login to CocoaPods Trunk**
-   As the account that will own the token, create a new session with:
-   ```bash
-   pod trunk register your.email@posthog.com 'Your Name'
-   # Verify email if needed
-   ```
-
-2. **Extract the token**:
-   The token is stored in `~/.netrc` file:
-   ```bash
-   # View your .netrc file
-   grep -A2 'trunk.cocoapods.org' ~/.netrc
-   # or look for the line with `trunk.cocoapods.org` in ~/.netrc
-   cat ~/.netrc
-   ```
-
-#### Step 2: Update GitHub Secret
-
-1. **Go to GitHub repository settings**:
-   - Request temp access if needed
-   - Navigate to `https://github.com/organizations/PostHog/settings/secrets/actions`
-   - Or: Org → Settings → Secrets and variables → Actions
-
-2. **Update the secret**:
-   - Find `COCOAPODS_TRUNK_TOKEN` in the list
-   - Update the secret
-
-#### Step 3: Revoking Old Sessions
-
-1. **Revoke old sessions**:
-   ```bash
-   # Clear current sessions (from the user that owned the previous token)
-   pod trunk me clean-sessions
-   ```
-
-#### Step 4: Update workflow docs
-
-Update `./.github/workflows/release.yml` with a comment on the new token owner.
-
-```yaml
-env:
-  COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }} # Using @username token
-```
+If the release workflow reports that no changesets were found, make sure your PR includes at least one releasable `.changeset/*.md` file.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,40 +6,202 @@ This repository uses [Changesets](https://github.com/changesets/changesets) for 
 
 ### 1. Add a Changeset
 
-When making a change that should be released, add a changeset:
+When making changes that should be released, add a changeset:
 
 ```bash
 pnpm changeset
 ```
 
-This prompts you to select the version bump (`patch`, `minor`, or `major`) and write a short release summary. Commit the generated file in `.changeset/` with your pull request.
+This will prompt you to:
+- Select the type of version bump (patch, minor, major)
+- Write a summary of the changes
 
-### 2. Merge the Pull Request
+The changeset file will be created in the `.changeset/` directory.
 
-After review, merge the PR to `main`. No GitHub release label is required.
+### 2. Create a Pull Request
 
-A push to `main` that includes `.changeset/*.md` changes automatically starts the release workflow. The workflow then:
+Create a PR with your changes and the changeset file(s). No release label is required.
 
-1. Checks for pending changesets
-2. Notifies the client libraries team in Slack for approval
-3. Waits for approval from a maintainer via the GitHub `Release` environment
-4. The workflow applies Changesets, syncs Swift version files, tags the release, and creates a GitHub Release.
-5. Notifies Slack when the release completes or fails
+### 3. Merge the PR
+
+When the PR is merged to `main`, the release workflow will automatically:
+
+1. Check for changesets
+2. Notify the client libraries team in Slack for approval
+3. Wait for approval from a maintainer (via GitHub environment protection)
+4. Once approved:
+   - Apply changesets and bump the version (in `package.json`, `PostHogVersion.swift`, and `PostHog.podspec`)
+   - Update the `CHANGELOG.md`
+   - Commit the version bump to `main`
+   - Create a git tag and GitHub release
+   - Publish the pod to CocoaPods
+   - SPM uses the tag name to determine the version, directly from the repo
 
 ### Manual Trigger
 
-You can also manually trigger the release workflow from the Actions tab with `workflow_dispatch`. Manual runs still require pending changesets.
+You can also manually trigger the release workflow from the [Actions tab](https://github.com/PostHog/posthog-ios/actions/workflows/release.yml) by clicking "Run workflow".
 
 ## Version Bumping
 
-Changesets determines the next version from the committed changeset files:
+Changesets handles version bumping automatically based on the changesets you create:
 
-- **patch**: bug fixes, documentation updates, and internal changes
-- **minor**: backwards-compatible features
-- **major**: breaking changes
+- **patch**: Bug fixes, documentation updates, internal changes (e.g., `3.41.1` → `3.41.2`)
+- **minor**: New features, non-breaking changes (e.g., `3.41.1` → `3.42.0`)
+- **major**: Breaking changes (e.g., `3.41.1` → `4.0.0`)
+
+## Pre-release Versions
+
+For pre-release versions (alpha, beta, RC), you can manually enter pre-release mode:
+
+```bash
+pnpm changeset pre enter alpha  # or beta, rc
+pnpm changeset version
+```
+
+To exit pre-release mode:
+
+```bash
+pnpm changeset pre exit
+```
 
 ## Troubleshooting
 
 ### No changesets found
 
-If the release workflow reports that no changesets were found, make sure your PR includes at least one releasable `.changeset/*.md` file.
+If the release workflow fails with "No changesets found", ensure your PR includes at least one changeset file in the `.changeset/` directory.
+
+### Release not triggered
+
+Make sure the PR includes a changeset file and was merged to `main`, or trigger the workflow manually from the Actions tab.
+
+### Manual CocoaPods publish (emergency only)
+
+In case of automation failure, you can manually publish:
+
+```bash
+make releaseCocoaPods
+```
+
+You'll need to be authenticated with CocoaPods trunk and have push access to the `PostHog` pod.
+
+# CocoaPods Management
+
+The PostHog iOS SDK is published to CocoaPods automatically via GitHub Actions when a release is created. This section covers the management of CocoaPods permissions and tokens.
+
+### Check Your Current Session
+
+```bash
+# Check if you're logged in and your permissions
+pod trunk me
+```
+
+Expected output should show:
+
+```text
+- Name:     Your Name
+- Email:    your.email@posthog.com
+- Since:    Date
+- Pods:
+  - PostHog
+- Sessions:
+  - Session details...
+```
+
+### Check Pod Ownership
+
+```bash
+# Check who owns the PostHog pod
+pod trunk info PostHog
+```
+
+This will show:
+
+- Current version
+- All owners with push permissions
+
+### Adding a co-owner
+
+1. **With an existing owner**:
+
+   ```bash
+   # Run this as an existing owner
+   pod trunk add-owner PostHog dev.email@posthog.com
+   ```
+
+2. **Verify**:
+   ```bash
+   # Check that the new owner was added
+   pod trunk info PostHog
+   ```
+
+### Removing a co-owner
+
+1. **With an existing owner**:
+
+   ```bash
+   # Run this as an existing owner
+   pod trunk remove-owner PostHog dev.email@posthog.com
+   ```
+
+2. **Verify**:
+   ```bash
+   # Check that the new owner was removed
+   pod trunk info PostHog
+   ```
+
+### Rotating COCOAPODS_TRUNK_TOKEN
+
+The `COCOAPODS_TRUNK_TOKEN` is used in GitHub Actions for automated releases. Here's how to rotate it:
+
+The token is stored as a GitHub secret and used in `.github/workflows/release.yml`:
+
+```yaml
+env:
+  COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+```
+
+#### Step 1: Create a new session
+
+1. **Login to CocoaPods Trunk**
+   As the account that will own the token, create a new session with:
+   ```bash
+   pod trunk register your.email@posthog.com 'Your Name'
+   # Verify email if needed
+   ```
+
+2. **Extract the token**:
+   The token is stored in `~/.netrc` file:
+   ```bash
+   # View your .netrc file
+   grep -A2 'trunk.cocoapods.org' ~/.netrc
+   # or look for the line with `trunk.cocoapods.org` in ~/.netrc
+   cat ~/.netrc
+   ```
+
+#### Step 2: Update GitHub Secret
+
+1. **Go to GitHub repository settings**:
+   - Request temp access if needed
+   - Navigate to `https://github.com/organizations/PostHog/settings/secrets/actions`
+   - Or: Org → Settings → Secrets and variables → Actions
+
+2. **Update the secret**:
+   - Find `COCOAPODS_TRUNK_TOKEN` in the list
+   - Update the secret
+
+#### Step 3: Revoking Old Sessions
+
+1. **Revoke old sessions**:
+   ```bash
+   # Clear current sessions (from the user that owned the previous token)
+   pod trunk me clean-sessions
+   ```
+
+#### Step 4: Update workflow docs
+
+Update `./.github/workflows/release.yml` with a comment on the new token owner.
+
+```yaml
+env:
+  COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }} # Using @username token
+```


### PR DESCRIPTION
## :bulb: Motivation and Context
Standardize SDK releases so they are triggered by pushes to `main` containing release changesets, rather than by PR labels or `pull_request.closed` events.

## Changes
- Updated the release workflow to run on `push` to `main` for `.changeset/*.md`, while keeping manual `workflow_dispatch`
- Removed the release-label check from the release flow
- Added `[skip ci]` to release version-bump commits and narrowed release path filters to changeset markdown files to avoid re-triggering release workflows on consumed changeset deletions
- Updated only the release-label parts of the release docs and PR checklist

## :green_heart: How did you test it?
- Parsed the updated release workflow YAML locally
- Verified the release workflow no longer references `pull_request` or PR labels
- Verified the PR template no longer asks for a release label

## :pencil: Checklist
- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file (not needed for this release-process-only change)
