### PR TITLE
fix(queue): handle HTTP 413 with adaptive batch sizing

### DIFF
--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -28,6 +28,7 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
         #endif
         static let maxBatchSize: Int = 50
         static let flushIntervalSeconds: TimeInterval = 30
+        static let maxRetries: Int = 3
     }
 
     @objc(PostHogDataMode) public enum PostHogDataMode: Int {
@@ -56,6 +57,12 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
     @objc public var maxQueueSize: Int = Defaults.maxQueueSize
     @objc public var maxBatchSize: Int = Defaults.maxBatchSize
     @objc public var flushIntervalSeconds: TimeInterval = Defaults.flushIntervalSeconds
+
+    /// Maximum number of consecutive flush attempts before the entire queue is
+    /// dropped to avoid infinite retries against a permanently-broken backend.
+    /// Increments on every retriable failure including HTTP 413 cap halving;
+    /// resets on a successful 2xx response. Default 3.
+    @objc public var maxRetries: Int = Defaults.maxRetries
     @objc public var dataMode: PostHogDataMode = .any
     @objc public var sendFeatureFlagEvent: Bool = true
     @objc public var preloadFeatureFlags: Bool = true

--- a/PostHog/PostHogQueue.swift
+++ b/PostHog/PostHogQueue.swift
@@ -12,9 +12,31 @@ import Foundation
 private let retriableStatusCodes: Set<Int> = [429, 500, 502, 503, 504]
 
 /// Clamps `value` to a minimum of 1. Used wherever we initialise / halve
-/// `currentBatchCap` / `currentFlushAt` so we never store a value below 1.
+/// the adaptive batch limits so we never store a value below 1.
 private func clamped(_ value: Int) -> Int {
     max(1, value)
+}
+
+/// Adaptive limits for the events queue. Both `cap` and `flushAt` are halved
+/// together on HTTP 413 and stay reduced for the SDK's lifetime — matching
+/// posthog-android. Stored privately rather than mutating
+/// `config.maxBatchSize` / `config.flushAt` so user-supplied config fields
+/// aren't silently changed.
+private struct BatchLimits {
+    var cap: Int
+    var flushAt: Int
+
+    static func initial(from config: PostHogConfig) -> BatchLimits {
+        BatchLimits(cap: clamped(config.maxBatchSize), flushAt: clamped(config.flushAt))
+    }
+
+    /// Halves both `cap` and `flushAt`, returning the new cap.
+    @discardableResult
+    mutating func halve() -> Int {
+        cap = clamped(cap / 2)
+        flushAt = clamped(flushAt / 2)
+        return cap
+    }
 }
 
 /**
@@ -52,15 +74,8 @@ class PostHogQueue {
     private let endpoint: PostHogApiEndpoint
     private let dispatchQueue: DispatchQueue
 
-    /// Both halved on HTTP 413; the batch is dropped once the cap reaches 1.
-    /// Once reduced, both stay reduced for the SDK's lifetime — matches
-    /// posthog-android. There is no ramp-back-up on healthy sends and no
-    /// reset on the poison drop. Stored privately rather than mutating
-    /// `config.maxBatchSize` / `config.flushAt` so user-supplied config
-    /// fields aren't silently changed.
-    private var currentBatchCap: Int
-    private var currentFlushAt: Int
-    private let batchSizeLock = NSLock()
+    private var batchLimits: BatchLimits
+    private let batchLimitsLock = NSLock()
 
     /// Internal, used for testing
     var depth: Int {
@@ -75,8 +90,7 @@ class PostHogQueue {
             self.api = api
             self.reachability = reachability
             self.endpoint = endpoint
-            currentBatchCap = clamped(config.maxBatchSize)
-            currentFlushAt = clamped(config.flushAt)
+            batchLimits = .initial(from: config)
 
             switch endpoint {
             case .batch:
@@ -92,8 +106,7 @@ class PostHogQueue {
             self.config = config
             self.api = api
             self.endpoint = endpoint
-            currentBatchCap = clamped(config.maxBatchSize)
-            currentFlushAt = clamped(config.flushAt)
+            batchLimits = .initial(from: config)
 
             switch endpoint {
             case .batch:
@@ -149,11 +162,9 @@ class PostHogQueue {
         // `config.maxRetries` consecutive failures (PostHogQueue.kt:208-212).
         // We don't have an equivalent safeguard yet — track as a follow-up.
         if statusCode == 413 {
-            let halvedCap: Int? = batchSizeLock.withLock {
-                guard currentBatchCap > 1 else { return nil }
-                currentBatchCap = clamped(currentBatchCap / 2)
-                currentFlushAt = clamped(currentFlushAt / 2)
-                return currentBatchCap
+            let halvedCap: Int? = batchLimitsLock.withLock {
+                guard batchLimits.cap > 1 else { return nil }
+                return batchLimits.halve()
             }
             if let halvedCap {
                 hedgeLog("Queue: HTTP 413, halved batch cap to \(halvedCap)")
@@ -252,7 +263,7 @@ class PostHogQueue {
             return
         }
 
-        let cap = batchSizeLock.withLock { currentBatchCap }
+        let cap = batchLimitsLock.withLock { batchLimits.cap }
         take(cap) { payload in
             if !payload.events.isEmpty {
                 self.eventHandler(payload)
@@ -264,7 +275,7 @@ class PostHogQueue {
     }
 
     func flushIfOverThreshold() {
-        let threshold = batchSizeLock.withLock { currentFlushAt }
+        let threshold = batchLimitsLock.withLock { batchLimits.flushAt }
         if fileQueue.depth >= threshold {
             flush()
         }
@@ -352,13 +363,13 @@ class PostHogQueue {
         /// Exposes the adaptive batch cap so 413 halving and poison-drop
         /// tests can assert the cap value.
         var currentBatchCapForTesting: Int {
-            batchSizeLock.withLock { currentBatchCap }
+            batchLimitsLock.withLock { batchLimits.cap }
         }
 
         /// Exposes the adaptive flush threshold so 413 tests can assert it
         /// was halved alongside the batch cap.
         var currentFlushAtForTesting: Int {
-            batchSizeLock.withLock { currentFlushAt }
+            batchLimitsLock.withLock { batchLimits.flushAt }
         }
     }
 #endif

--- a/PostHog/PostHogQueue.swift
+++ b/PostHog/PostHogQueue.swift
@@ -144,6 +144,10 @@ class PostHogQueue {
         // threshold and retry without popping. Once the cap reaches 1, drop
         // the batch — we can't shrink any further, so retrying is futile.
         // Matches posthog-android's `deleteFilesIfAPIError`.
+        //
+        // TODO: posthog-android also drops all queued events after
+        // `config.maxRetries` consecutive failures (PostHogQueue.kt:208-212).
+        // We don't have an equivalent safeguard yet — track as a follow-up.
         if statusCode == 413 {
             let halvedCap: Int? = batchSizeLock.withLock {
                 guard currentBatchCap > 1 else { return nil }

--- a/PostHog/PostHogQueue.swift
+++ b/PostHog/PostHogQueue.swift
@@ -7,6 +7,10 @@
 
 import Foundation
 
+/// HTTP status codes that trigger an exponential-backoff retry. Matches
+/// posthog-android's `RETRYABLE_STATUS_CODES` exactly.
+private let retriableStatusCodes: Set<Int> = [429, 500, 502, 503, 504]
+
 /// Clamps `value` to a minimum of 1. Used wherever we initialise / halve
 /// `currentBatchCap` / `currentFlushAt` so we never store a value below 1.
 private func clamped(_ value: Int) -> Int {
@@ -133,18 +137,13 @@ class PostHogQueue {
         // -1 means its not anything related to the API but rather network or something else, so we try again
         let statusCode = result.statusCode ?? -1
 
-        // Network error (-1), 3xx redirect, or transient server error: pause and
-        // retry the same batch. The 5xx subset is intentionally narrow to match
-        // posthog-android's RETRYABLE_STATUS_CODES.
-        let retriable = statusCode == -1
+        // Network error (-1), 3xx redirect, or transient server error: pause
+        // and retry the same batch.
+        let isRetriable = statusCode == -1
             || (300 ... 399 ~= statusCode)
-            || statusCode == 429
-            || statusCode == 500
-            || statusCode == 502
-            || statusCode == 503
-            || statusCode == 504
+            || retriableStatusCodes.contains(statusCode)
 
-        if retriable {
+        if isRetriable {
             retryCount += 1
             let delay = min(retryCount * retryDelay, maxRetryDelay)
             pauseFor(seconds: delay)

--- a/PostHog/PostHogQueue.swift
+++ b/PostHog/PostHogQueue.swift
@@ -7,6 +7,12 @@
 
 import Foundation
 
+/// Clamps `value` to a minimum of 1. Used wherever we initialise / halve
+/// `currentBatchCap` / `currentFlushAt` so we never store a value below 1.
+private func clamped(_ value: Int) -> Int {
+    max(1, value)
+}
+
 /**
  # Queue
 
@@ -77,8 +83,8 @@ class PostHogQueue {
             self.api = api
             self.reachability = reachability
             self.endpoint = endpoint
-            currentBatchCap = max(1, config.maxBatchSize)
-            currentFlushAt = max(1, config.flushAt)
+            currentBatchCap = clamped(config.maxBatchSize)
+            currentFlushAt = clamped(config.flushAt)
 
             switch endpoint {
             case .batch:
@@ -94,8 +100,8 @@ class PostHogQueue {
             self.config = config
             self.api = api
             self.endpoint = endpoint
-            currentBatchCap = max(1, config.maxBatchSize)
-            currentFlushAt = max(1, config.flushAt)
+            currentBatchCap = clamped(config.maxBatchSize)
+            currentFlushAt = clamped(config.flushAt)
 
             switch endpoint {
             case .batch:
@@ -154,8 +160,8 @@ class PostHogQueue {
         if statusCode == 413 {
             let halvedCap: Int? = batchSizeLock.withLock {
                 guard currentBatchCap > 1 else { return nil }
-                currentBatchCap = max(1, currentBatchCap / 2)
-                currentFlushAt = max(1, currentFlushAt / 2)
+                currentBatchCap = clamped(currentBatchCap / 2)
+                currentFlushAt = clamped(currentFlushAt / 2)
                 return currentBatchCap
             }
             if let halvedCap {

--- a/PostHog/PostHogQueue.swift
+++ b/PostHog/PostHogQueue.swift
@@ -67,18 +67,6 @@ class PostHogQueue {
         fileQueue.depth
     }
 
-    /// Internal, used for testing — exposes the adaptive batch cap so 413
-    /// halving and poison-drop tests can assert the cap value.
-    var currentBatchCapForTesting: Int {
-        batchSizeLock.withLock { currentBatchCap }
-    }
-
-    /// Internal, used for testing — exposes the adaptive flush threshold so
-    /// 413 tests can assert it was halved alongside the batch cap.
-    var currentFlushAtForTesting: Int {
-        batchSizeLock.withLock { currentFlushAt }
-    }
-
     let fileQueue: PostHogFileBackedQueue
 
     #if !os(watchOS)
@@ -354,3 +342,19 @@ class PostHogQueue {
         return true
     }
 }
+
+#if TESTING
+    extension PostHogQueue {
+        /// Exposes the adaptive batch cap so 413 halving and poison-drop
+        /// tests can assert the cap value.
+        var currentBatchCapForTesting: Int {
+            batchSizeLock.withLock { currentBatchCap }
+        }
+
+        /// Exposes the adaptive flush threshold so 413 tests can assert it
+        /// was halved alongside the batch cap.
+        var currentFlushAtForTesting: Int {
+            batchSizeLock.withLock { currentFlushAt }
+        }
+    }
+#endif

--- a/PostHog/PostHogQueue.swift
+++ b/PostHog/PostHogQueue.swift
@@ -150,6 +150,11 @@ class PostHogQueue {
 
         if isRetriable {
             retryCount += 1
+            if retryCountExceededMax() {
+                dropAllQueuedEvents(reason: "max retries (\(config.maxRetries)) exceeded")
+                payload.completion(true)
+                return
+            }
             let delay = min(retryCount * retryDelay, maxRetryDelay)
             pauseFor(seconds: delay)
             hedgeLog("Pausing queue consumption for \(delay) seconds due to \(retryCount) API failure(s).")
@@ -161,11 +166,13 @@ class PostHogQueue {
         // threshold and retry without popping. Once the cap reaches 1, drop
         // the batch — we can't shrink any further, so retrying is futile.
         // Matches posthog-android's `deleteFilesIfAPIError`.
-        //
-        // TODO: posthog-android also drops all queued events after
-        // `config.maxRetries` consecutive failures (PostHogQueue.kt:208-212).
-        // We don't have an equivalent safeguard yet — track as a follow-up.
         if statusCode == 413 {
+            retryCount += 1
+            if retryCountExceededMax() {
+                dropAllQueuedEvents(reason: "max retries (\(config.maxRetries)) exceeded after repeated HTTP 413")
+                payload.completion(true)
+                return
+            }
             let actualBatchSize = payload.events.count
             let halvedCap: Int? = batchLimitsLock.withLock {
                 guard batchLimits.cap > 1 else { return nil }
@@ -173,7 +180,6 @@ class PostHogQueue {
             }
             if let halvedCap {
                 hedgeLog("Queue: HTTP 413, halved batch cap to \(halvedCap)")
-                retryCount = 0
                 payload.completion(false)
                 return
             }
@@ -188,6 +194,26 @@ class PostHogQueue {
         // posthog-android and posthog-js-lite.
         retryCount = 0
         payload.completion(true)
+    }
+
+    /// True when `retryCount` has exceeded `config.maxRetries` after just
+    /// being incremented for the current attempt. Comparison is `>` (not `>=`)
+    /// so the configured value is the count of *retries* allowed before the
+    /// drop fires — with the default of 3 you get attempts 1–3 retried,
+    /// attempt 4 drops. Matches posthog-android.
+    private func retryCountExceededMax() -> Bool {
+        Int(retryCount) > config.maxRetries
+    }
+
+    /// Drops every queued event from disk and resets the retry / pause state.
+    /// Called when `retryCount` exceeds `config.maxRetries` to avoid
+    /// retrying forever against a permanently-broken backend. Matches
+    /// posthog-android's `dropAllEvents`.
+    private func dropAllQueuedEvents(reason: String) {
+        hedgeLog("Queue: dropping all queued events — \(reason)")
+        fileQueue.clear()
+        retryCount = 0
+        pausedUntil = nil
     }
 
     func start(disableReachabilityForTesting: Bool,

--- a/PostHog/PostHogQueue.swift
+++ b/PostHog/PostHogQueue.swift
@@ -42,9 +42,31 @@ class PostHogQueue {
     private let endpoint: PostHogApiEndpoint
     private let dispatchQueue: DispatchQueue
 
+    /// Both halved on HTTP 413; the batch is dropped once the cap reaches 1.
+    /// Once reduced, both stay reduced for the SDK's lifetime — matches
+    /// posthog-android. There is no ramp-back-up on healthy sends and no
+    /// reset on the poison drop. Stored privately rather than mutating
+    /// `config.maxBatchSize` / `config.flushAt` so user-supplied config
+    /// fields aren't silently changed.
+    private var currentBatchCap: Int
+    private var currentFlushAt: Int
+    private let batchSizeLock = NSLock()
+
     /// Internal, used for testing
     var depth: Int {
         fileQueue.depth
+    }
+
+    /// Internal, used for testing — exposes the adaptive batch cap so 413
+    /// halving and poison-drop tests can assert the cap value.
+    var currentBatchCapForTesting: Int {
+        batchSizeLock.withLock { currentBatchCap }
+    }
+
+    /// Internal, used for testing — exposes the adaptive flush threshold so
+    /// 413 tests can assert it was halved alongside the batch cap.
+    var currentFlushAtForTesting: Int {
+        batchSizeLock.withLock { currentFlushAt }
     }
 
     let fileQueue: PostHogFileBackedQueue
@@ -55,6 +77,8 @@ class PostHogQueue {
             self.api = api
             self.reachability = reachability
             self.endpoint = endpoint
+            currentBatchCap = max(1, config.maxBatchSize)
+            currentFlushAt = max(1, config.flushAt)
 
             switch endpoint {
             case .batch:
@@ -70,6 +94,8 @@ class PostHogQueue {
             self.config = config
             self.api = api
             self.endpoint = endpoint
+            currentBatchCap = max(1, config.maxBatchSize)
+            currentFlushAt = max(1, config.flushAt)
 
             switch endpoint {
             case .batch:
@@ -101,24 +127,54 @@ class PostHogQueue {
         // -1 means its not anything related to the API but rather network or something else, so we try again
         let statusCode = result.statusCode ?? -1
 
-        var shouldRetry = false
-        if 300 ... 399 ~= statusCode || statusCode == -1 {
-            shouldRetry = true
-        }
+        // Network error (-1), 3xx redirect, or transient server error: pause and
+        // retry the same batch. The 5xx subset is intentionally narrow to match
+        // posthog-android's RETRYABLE_STATUS_CODES.
+        let retriable = statusCode == -1
+            || (300 ... 399 ~= statusCode)
+            || statusCode == 429
+            || statusCode == 500
+            || statusCode == 502
+            || statusCode == 503
+            || statusCode == 504
 
-        // TODO: https://github.com/PostHog/posthog-android/pull/130
-        // fix: reduce batch size if API returns 413
-
-        if shouldRetry {
+        if retriable {
             retryCount += 1
             let delay = min(retryCount * retryDelay, maxRetryDelay)
             pauseFor(seconds: delay)
             hedgeLog("Pausing queue consumption for \(delay) seconds due to \(retryCount) API failure(s).")
-        } else {
-            retryCount = 0
+            payload.completion(false)
+            return
         }
 
-        payload.completion(!shouldRetry)
+        // 413 Payload Too Large: halve both the batch cap and the flush
+        // threshold and retry without popping. Once the cap reaches 1, drop
+        // the batch — we can't shrink any further, so retrying is futile.
+        // Matches posthog-android's `deleteFilesIfAPIError`.
+        if statusCode == 413 {
+            let halvedCap: Int? = batchSizeLock.withLock {
+                guard currentBatchCap > 1 else { return nil }
+                currentBatchCap = max(1, currentBatchCap / 2)
+                currentFlushAt = max(1, currentFlushAt / 2)
+                return currentBatchCap
+            }
+            if let halvedCap {
+                hedgeLog("Queue: HTTP 413, halved batch cap to \(halvedCap)")
+                retryCount = 0
+                payload.completion(false)
+                return
+            }
+            hedgeLog("Queue: dropping batch after HTTP 413 (cap == 1)")
+            retryCount = 0
+            payload.completion(true)
+            return
+        }
+
+        // 2xx success or non-retriable 4xx (auth, malformed, etc.): pop the
+        // batch. The cap stays where it is — no ramp-up, matching
+        // posthog-android and posthog-js-lite.
+        retryCount = 0
+        payload.completion(true)
     }
 
     func start(disableReachabilityForTesting: Bool,
@@ -199,7 +255,8 @@ class PostHogQueue {
             return
         }
 
-        take(config.maxBatchSize) { payload in
+        let cap = batchSizeLock.withLock { currentBatchCap }
+        take(cap) { payload in
             if !payload.events.isEmpty {
                 self.eventHandler(payload)
             } else {
@@ -210,7 +267,8 @@ class PostHogQueue {
     }
 
     func flushIfOverThreshold() {
-        if fileQueue.depth >= config.flushAt {
+        let threshold = batchSizeLock.withLock { currentFlushAt }
+        if fileQueue.depth >= threshold {
             flush()
         }
     }

--- a/PostHog/PostHogQueue.swift
+++ b/PostHog/PostHogQueue.swift
@@ -33,12 +33,14 @@ private struct BatchLimits {
     /// Halves both `cap` and `flushAt`, returning the new cap. `actualBatchSize`
     /// (the number of events actually sent) bounds the halving so a 413 with
     /// a partial batch — queue depth was below `cap` — doesn't waste halvings
-    /// on a cap that wasn't reached anyway. Mirrors posthog-js-lite's
-    /// behaviour; posthog-android halves from `config.maxBatchSize` directly.
+    /// on a cap that wasn't reached anyway. `flushAt` is also clamped to the
+    /// new `cap` so we never buffer more events than a single batch can drain
+    /// (e.g. cap=1 with flushAt=10 would otherwise pile 10 events to send 1
+    /// at a time). Mirrors posthog-js-lite's behaviour.
     @discardableResult
     mutating func halve(actualBatchSize: Int) -> Int {
         cap = clamped(min(cap, actualBatchSize) / 2)
-        flushAt = clamped(flushAt / 2)
+        flushAt = clamped(min(flushAt / 2, cap))
         return cap
     }
 }

--- a/PostHog/PostHogQueue.swift
+++ b/PostHog/PostHogQueue.swift
@@ -30,10 +30,14 @@ private struct BatchLimits {
         BatchLimits(cap: clamped(config.maxBatchSize), flushAt: clamped(config.flushAt))
     }
 
-    /// Halves both `cap` and `flushAt`, returning the new cap.
+    /// Halves both `cap` and `flushAt`, returning the new cap. `actualBatchSize`
+    /// (the number of events actually sent) bounds the halving so a 413 with
+    /// a partial batch — queue depth was below `cap` — doesn't waste halvings
+    /// on a cap that wasn't reached anyway. Mirrors posthog-js-lite's
+    /// behaviour; posthog-android halves from `config.maxBatchSize` directly.
     @discardableResult
-    mutating func halve() -> Int {
-        cap = clamped(cap / 2)
+    mutating func halve(actualBatchSize: Int) -> Int {
+        cap = clamped(min(cap, actualBatchSize) / 2)
         flushAt = clamped(flushAt / 2)
         return cap
     }
@@ -162,9 +166,10 @@ class PostHogQueue {
         // `config.maxRetries` consecutive failures (PostHogQueue.kt:208-212).
         // We don't have an equivalent safeguard yet — track as a follow-up.
         if statusCode == 413 {
+            let actualBatchSize = payload.events.count
             let halvedCap: Int? = batchLimitsLock.withLock {
                 guard batchLimits.cap > 1 else { return nil }
-                return batchLimits.halve()
+                return batchLimits.halve(actualBatchSize: actualBatchSize)
             }
             if let halvedCap {
                 hedgeLog("Queue: HTTP 413, halved batch cap to \(halvedCap)")

--- a/PostHogTests/PostHogQueueTest.swift
+++ b/PostHogTests/PostHogQueueTest.swift
@@ -7,15 +7,18 @@
 
 import Foundation
 import Nimble
+import OHHTTPStubs
+import OHHTTPStubsSwift
 @testable import PostHog
 import Quick
 import XCTest
 
 class PostHogQueueTest: QuickSpec {
-    func getSut(flushAt: Int = 1, maxQueueSize: Int = 1000) -> PostHogQueue {
+    func getSut(flushAt: Int = 1, maxQueueSize: Int = 1000, maxBatchSize: Int = 50) -> PostHogQueue {
         let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
         config.flushAt = flushAt
         config.maxQueueSize = maxQueueSize
+        config.maxBatchSize = maxBatchSize
         config.sendFeatureFlagEvent = false
         let storage = PostHogStorage(config)
         let api = PostHogApi(config)
@@ -95,6 +98,178 @@ class PostHogQueueTest: QuickSpec {
             let last = events.last!
             expect(first.event) == "event2"
             expect(last.event) == "event3"
+
+            sut.clear()
+        }
+
+        it("halves both batch cap and flush threshold and retains batch on HTTP 413 when cap > 1") {
+            let sut = self.getSut(flushAt: 4, maxBatchSize: 4)
+            server.batchResponseHandler = { _, _ in
+                HTTPStubsResponse(jsonObject: [], statusCode: 413, headers: nil)
+            }
+
+            for i in 0 ..< 4 {
+                sut.add(PostHogEvent(event: "event\(i)", distinctId: "id\(i)"))
+            }
+
+            _ = getBatchedEvents(server)
+
+            expect(sut.currentBatchCapForTesting).toEventually(equal(2))
+            expect(sut.currentFlushAtForTesting).toEventually(equal(2))
+            expect(sut.depth).toEventually(equal(4))
+
+            sut.clear()
+        }
+
+        it("drops batch on HTTP 413 when cap is already 1") {
+            let sut = self.getSut(flushAt: 1, maxBatchSize: 1)
+            server.batchResponseHandler = { _, _ in
+                HTTPStubsResponse(jsonObject: [], statusCode: 413, headers: nil)
+            }
+
+            sut.add(PostHogEvent(event: "oversized", distinctId: "id"))
+
+            _ = getBatchedEvents(server)
+
+            expect(sut.depth).toEventually(equal(0))
+            // Cap stays at 1 — no reset to maxBatchSize, matching Android.
+            expect(sut.currentBatchCapForTesting) == 1
+
+            sut.clear()
+        }
+
+        it("retains batch on retriable 5xx and does not change cap") {
+            let sut = self.getSut(flushAt: 2, maxBatchSize: 4)
+            server.batchResponseHandler = { _, _ in
+                HTTPStubsResponse(jsonObject: [], statusCode: 500, headers: nil)
+            }
+
+            sut.add(PostHogEvent(event: "event1", distinctId: "id1"))
+            sut.add(PostHogEvent(event: "event2", distinctId: "id2"))
+
+            _ = getBatchedEvents(server)
+
+            expect(sut.depth).toEventually(equal(2))
+            expect(sut.currentBatchCapForTesting).toEventually(equal(4))
+
+            sut.clear()
+        }
+
+        it("retains batch on HTTP 429 and does not change cap") {
+            let sut = self.getSut(flushAt: 2, maxBatchSize: 4)
+            server.batchResponseHandler = { _, _ in
+                HTTPStubsResponse(jsonObject: [], statusCode: 429, headers: nil)
+            }
+
+            sut.add(PostHogEvent(event: "event1", distinctId: "id1"))
+            sut.add(PostHogEvent(event: "event2", distinctId: "id2"))
+
+            _ = getBatchedEvents(server)
+
+            expect(sut.depth).toEventually(equal(2))
+            expect(sut.currentBatchCapForTesting).toEventually(equal(4))
+
+            sut.clear()
+        }
+
+        it("halves cap repeatedly across multiple 413s and drops once cap reaches 1") {
+            // flushAt is high so add() doesn't trigger an auto-flush — we drive
+            // each flush manually to observe the multi-step halving sequence.
+            let sut = self.getSut(flushAt: 100, maxBatchSize: 4)
+            server.start(batchCount: 3)
+            server.batchResponseHandler = { _, _ in
+                HTTPStubsResponse(jsonObject: [], statusCode: 413, headers: nil)
+            }
+
+            for i in 0 ..< 4 {
+                sut.add(PostHogEvent(event: "event\(i)", distinctId: "id\(i)"))
+            }
+
+            // First flush: batch=4 → 413 → cap halves to 2, batch retained.
+            sut.flush()
+            expect(sut.currentBatchCapForTesting).toEventually(equal(2))
+            expect(sut.depth) == 4
+
+            // Second flush: batch=2 → 413 → cap halves to 1, batch retained.
+            sut.flush()
+            expect(sut.currentBatchCapForTesting).toEventually(equal(1))
+            expect(sut.depth) == 4
+
+            // Third flush: batch=1, cap already at 1 → drop one record. Cap
+            // stays at 1 (no reset, matching Android).
+            sut.flush()
+            expect(sut.depth).toEventually(equal(3))
+            expect(sut.currentBatchCapForTesting) == 1
+
+            sut.clear()
+        }
+
+        it("pops batch on 5xx codes outside the narrow retriable set") {
+            // 501/505/etc. are NOT in {429, 500, 502, 503, 504} — match
+            // posthog-android's RETRYABLE_STATUS_CODES exactly. Treat as
+            // non-retriable so a poison record can't block the queue.
+            let sut = self.getSut(flushAt: 2, maxBatchSize: 4)
+            server.batchResponseHandler = { _, _ in
+                HTTPStubsResponse(jsonObject: [], statusCode: 501, headers: nil)
+            }
+
+            sut.add(PostHogEvent(event: "event1", distinctId: "id1"))
+            sut.add(PostHogEvent(event: "event2", distinctId: "id2"))
+
+            _ = getBatchedEvents(server)
+
+            expect(sut.depth).toEventually(equal(0))
+            expect(sut.currentBatchCapForTesting) == 4
+
+            sut.clear()
+        }
+
+        it("retains batch on a network error") {
+            let sut = self.getSut(flushAt: 2, maxBatchSize: 4)
+            let networkError = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, userInfo: nil)
+            server.batchResponseHandler = { _, _ in
+                HTTPStubsResponse(error: networkError)
+            }
+
+            sut.add(PostHogEvent(event: "event1", distinctId: "id1"))
+            sut.add(PostHogEvent(event: "event2", distinctId: "id2"))
+
+            _ = getBatchedEvents(server)
+
+            expect(sut.depth).toEventually(equal(2))
+            expect(sut.currentBatchCapForTesting).toEventually(equal(4))
+
+            sut.clear()
+        }
+
+        it("pops batch on non-retriable 4xx so a poison record cannot block the queue") {
+            let sut = self.getSut(flushAt: 2, maxBatchSize: 4)
+            server.batchResponseHandler = { _, _ in
+                HTTPStubsResponse(jsonObject: [], statusCode: 401, headers: nil)
+            }
+
+            sut.add(PostHogEvent(event: "event1", distinctId: "id1"))
+            sut.add(PostHogEvent(event: "event2", distinctId: "id2"))
+
+            _ = getBatchedEvents(server)
+
+            expect(sut.depth).toEventually(equal(0))
+            expect(sut.currentBatchCapForTesting).toEventually(equal(4))
+
+            sut.clear()
+        }
+
+        it("pops batch on 2xx and leaves cap unchanged (no ramp-up)") {
+            let sut = self.getSut(flushAt: 2, maxBatchSize: 4)
+
+            sut.add(PostHogEvent(event: "event1", distinctId: "id1"))
+            sut.add(PostHogEvent(event: "event2", distinctId: "id2"))
+
+            _ = getBatchedEvents(server)
+
+            expect(sut.depth).toEventually(equal(0))
+            // Cap was never reduced, so it should still be at maxBatchSize.
+            expect(sut.currentBatchCapForTesting) == 4
 
             sut.clear()
         }

--- a/PostHogTests/PostHogQueueTest.swift
+++ b/PostHogTests/PostHogQueueTest.swift
@@ -14,11 +14,12 @@ import Quick
 import XCTest
 
 class PostHogQueueTest: QuickSpec {
-    func getSut(flushAt: Int = 1, maxQueueSize: Int = 1000, maxBatchSize: Int = 50) -> PostHogQueue {
+    func getSut(flushAt: Int = 1, maxQueueSize: Int = 1000, maxBatchSize: Int = 50, maxRetries: Int = 3) -> PostHogQueue {
         let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
         config.flushAt = flushAt
         config.maxQueueSize = maxQueueSize
         config.maxBatchSize = maxBatchSize
+        config.maxRetries = maxRetries
         config.sendFeatureFlagEvent = false
         let storage = PostHogStorage(config)
         let api = PostHogApi(config)
@@ -155,6 +156,29 @@ class PostHogQueueTest: QuickSpec {
             expect(sut.depth).toEventually(equal(0))
             // Cap stays at 1 — no reset to maxBatchSize, matching Android.
             expect(sut.currentBatchCapForTesting) == 1
+
+            sut.clear()
+        }
+
+        it("drops the entire queue once retryCount exceeds maxRetries on repeated 413") {
+            // 413 increments retryCount the same way 5xx / network errors do
+            // — they go through the same `retryCountExceededMax()` check —
+            // so this test covers both paths' drop logic. We use 413 here
+            // because it doesn't set `pausedUntil`, letting the test drive
+            // multiple retries without waiting out the exponential backoff.
+            //
+            // maxBatchSize large enough that 413-halving alone wouldn't drop
+            // the batch within maxRetries attempts; the maxRetries cap fires
+            // first.
+            let sut = self.getSut(flushAt: 1, maxBatchSize: 50, maxRetries: 2)
+            server.batchResponseHandler = { _, _ in
+                HTTPStubsResponse(jsonObject: [], statusCode: 413, headers: nil)
+            }
+
+            sut.add(PostHogEvent(event: "evt", distinctId: "id"))
+
+            for _ in 0 ..< 5 { sut.flush() }
+            expect(sut.depth).toEventually(equal(0), timeout: .seconds(5))
 
             sut.clear()
         }

--- a/PostHogTests/PostHogQueueTest.swift
+++ b/PostHogTests/PostHogQueueTest.swift
@@ -184,12 +184,11 @@ class PostHogQueueTest: QuickSpec {
         }
 
         it("maxRetries drop wipes the entire queue, not just the current batch") {
-            // Five events queued, batch cap of 1 → at most one event sent per
-            // attempt. Without `dropAllQueuedEvents`, a maxRetries drop would
-            // only pop the failing batch (1 event), leaving the other 4
-            // queued. The Android-style "drop everything" semantics is what
-            // we want.
-            let sut = self.getSut(flushAt: 1, maxBatchSize: 1, maxRetries: 1)
+            // Multiple events queued. After enough 413s to trip maxRetries,
+            // the drop must clear ALL of them, not just whatever batch was
+            // in flight. Matches posthog-android's `dropAllEvents`.
+            let sut = self.getSut(flushAt: 100, maxBatchSize: 50, maxRetries: 1)
+            server.start(batchCount: 2)
             server.batchResponseHandler = { _, _ in
                 HTTPStubsResponse(jsonObject: [], statusCode: 413, headers: nil)
             }
@@ -198,8 +197,15 @@ class PostHogQueueTest: QuickSpec {
                 sut.add(PostHogEvent(event: "event\(i)", distinctId: "id\(i)"))
             }
 
-            for _ in 0 ..< 5 { sut.flush() }
-            expect(sut.depth).toEventually(equal(0), timeout: .seconds(5))
+            // First flush: batch=5 → 413 → retryCount=1 (not > 1) → halve.
+            sut.flush()
+            expect(sut.currentBatchCapForTesting).toEventually(equal(2))
+            expect(sut.depth) == 5
+
+            // Second flush: batch=2 → 413 → retryCount=2 (> 1) → drop ALL,
+            // not just the 2 in this batch.
+            sut.flush()
+            expect(sut.depth).toEventually(equal(0))
 
             sut.clear()
         }
@@ -208,52 +214,33 @@ class PostHogQueueTest: QuickSpec {
             // After events get dropped the queue must continue to accept and
             // flush new ones; otherwise the SDK is permanently broken until
             // the host app restarts.
-            let sut = self.getSut(flushAt: 1, maxBatchSize: 50, maxRetries: 1)
+            let sut = self.getSut(flushAt: 100, maxBatchSize: 50, maxRetries: 1)
             var attempt = 0
+            server.start(batchCount: 3)
             server.batchResponseHandler = { _, _ in
                 attempt += 1
                 // First two attempts fail with 413 → triggers maxRetries drop.
-                // Subsequent attempts succeed.
+                // Third attempt (the post-drop add) succeeds.
                 return attempt <= 2
                     ? HTTPStubsResponse(jsonObject: [], statusCode: 413, headers: nil)
                     : HTTPStubsResponse(jsonObject: ["status": "ok"], statusCode: 200, headers: nil)
             }
 
-            sut.add(PostHogEvent(event: "doomed", distinctId: "id"))
-            for _ in 0 ..< 5 { sut.flush() }
-            expect(sut.depth).toEventually(equal(0), timeout: .seconds(5))
-
-            // New event after the drop should flush successfully.
-            sut.add(PostHogEvent(event: "after-drop", distinctId: "id"))
-            let events = getBatchedEvents(server)
-            expect(events.contains(where: { $0.event == "after-drop" })) == true
-            expect(sut.depth).toEventually(equal(0))
-
-            sut.clear()
-        }
-
-        it("retryCount resets on a successful 2xx after prior failures") {
-            // Mixed sequence: 5xx → 5xx → 200. The 200 must reset retryCount
-            // so that subsequent failures restart counting from zero, not
-            // from the accumulated value. Without this reset, a flaky network
-            // would eventually trip maxRetries and drop events even though
-            // most attempts succeeded.
-            let sut = self.getSut(flushAt: 1, maxBatchSize: 50, maxRetries: 3)
-            var attempt = 0
-            server.batchResponseHandler = { _, _ in
-                attempt += 1
-                if attempt <= 2 {
-                    return HTTPStubsResponse(jsonObject: [], statusCode: 500, headers: nil)
-                }
-                return HTTPStubsResponse(jsonObject: ["status": "ok"], statusCode: 200, headers: nil)
+            for i in 0 ..< 5 {
+                sut.add(PostHogEvent(event: "doomed\(i)", distinctId: "id\(i)"))
             }
 
-            sut.add(PostHogEvent(event: "evt", distinctId: "id"))
-            // The 5xx path sets pausedUntil with exponential backoff (~5s,
-            // 10s); we just need the eventual success to land within the
-            // test's wait window.
-            let events = getBatchedEvents(server, timeout: 30)
-            expect(events.contains(where: { $0.event == "evt" })) == true
+            sut.flush()
+            expect(sut.currentBatchCapForTesting).toEventually(equal(2))
+            sut.flush()
+            expect(sut.depth).toEventually(equal(0))
+
+            // New event after the drop should flush successfully — retryCount
+            // and pausedUntil were reset by dropAllQueuedEvents.
+            sut.add(PostHogEvent(event: "after-drop", distinctId: "id"))
+            sut.flush()
+            let events = getBatchedEvents(server)
+            expect(events.contains(where: { $0.event == "after-drop" })) == true
             expect(sut.depth).toEventually(equal(0))
 
             sut.clear()

--- a/PostHogTests/PostHogQueueTest.swift
+++ b/PostHogTests/PostHogQueueTest.swift
@@ -143,6 +143,29 @@ class PostHogQueueTest: QuickSpec {
             sut.clear()
         }
 
+        it("clamps flushAt to cap on halve so we don't buffer more than a batch") {
+            // cap=20, flushAt=10. A 413 fires on a partial batch of 2 events.
+            // Cap halves aggressively (min(20, 2) / 2 = 1) while flushAt would
+            // halve to 5 — leaving flushAt > cap and piling 5 events to send
+            // 1 at a time. Clamping flushAt to cap keeps them in step.
+            let sut = self.getSut(flushAt: 10, maxBatchSize: 20)
+            server.batchResponseHandler = { _, _ in
+                HTTPStubsResponse(jsonObject: [], statusCode: 413, headers: nil)
+            }
+
+            for i in 0 ..< 2 {
+                sut.add(PostHogEvent(event: "event\(i)", distinctId: "id\(i)"))
+            }
+            sut.flush()
+
+            _ = getBatchedEvents(server)
+
+            expect(sut.currentBatchCapForTesting).toEventually(equal(1))
+            expect(sut.currentFlushAtForTesting).toEventually(equal(1))
+
+            sut.clear()
+        }
+
         it("drops batch on HTTP 413 when cap is already 1") {
             let sut = self.getSut(flushAt: 1, maxBatchSize: 1)
             server.batchResponseHandler = { _, _ in

--- a/PostHogTests/PostHogQueueTest.swift
+++ b/PostHogTests/PostHogQueueTest.swift
@@ -177,7 +177,9 @@ class PostHogQueueTest: QuickSpec {
 
             sut.add(PostHogEvent(event: "evt", distinctId: "id"))
 
-            for _ in 0 ..< 5 { sut.flush() }
+            for _ in 0 ..< 5 {
+                sut.flush()
+            }
             expect(sut.depth).toEventually(equal(0), timeout: .seconds(5))
 
             sut.clear()

--- a/PostHogTests/PostHogQueueTest.swift
+++ b/PostHogTests/PostHogQueueTest.swift
@@ -183,6 +183,82 @@ class PostHogQueueTest: QuickSpec {
             sut.clear()
         }
 
+        it("maxRetries drop wipes the entire queue, not just the current batch") {
+            // Five events queued, batch cap of 1 → at most one event sent per
+            // attempt. Without `dropAllQueuedEvents`, a maxRetries drop would
+            // only pop the failing batch (1 event), leaving the other 4
+            // queued. The Android-style "drop everything" semantics is what
+            // we want.
+            let sut = self.getSut(flushAt: 1, maxBatchSize: 1, maxRetries: 1)
+            server.batchResponseHandler = { _, _ in
+                HTTPStubsResponse(jsonObject: [], statusCode: 413, headers: nil)
+            }
+
+            for i in 0 ..< 5 {
+                sut.add(PostHogEvent(event: "event\(i)", distinctId: "id\(i)"))
+            }
+
+            for _ in 0 ..< 5 { sut.flush() }
+            expect(sut.depth).toEventually(equal(0), timeout: .seconds(5))
+
+            sut.clear()
+        }
+
+        it("queue keeps working after a maxRetries drop — retryCount is reset") {
+            // After events get dropped the queue must continue to accept and
+            // flush new ones; otherwise the SDK is permanently broken until
+            // the host app restarts.
+            let sut = self.getSut(flushAt: 1, maxBatchSize: 50, maxRetries: 1)
+            var attempt = 0
+            server.batchResponseHandler = { _, _ in
+                attempt += 1
+                // First two attempts fail with 413 → triggers maxRetries drop.
+                // Subsequent attempts succeed.
+                return attempt <= 2
+                    ? HTTPStubsResponse(jsonObject: [], statusCode: 413, headers: nil)
+                    : HTTPStubsResponse(jsonObject: ["status": "ok"], statusCode: 200, headers: nil)
+            }
+
+            sut.add(PostHogEvent(event: "doomed", distinctId: "id"))
+            for _ in 0 ..< 5 { sut.flush() }
+            expect(sut.depth).toEventually(equal(0), timeout: .seconds(5))
+
+            // New event after the drop should flush successfully.
+            sut.add(PostHogEvent(event: "after-drop", distinctId: "id"))
+            let events = getBatchedEvents(server)
+            expect(events.contains(where: { $0.event == "after-drop" })) == true
+            expect(sut.depth).toEventually(equal(0))
+
+            sut.clear()
+        }
+
+        it("retryCount resets on a successful 2xx after prior failures") {
+            // Mixed sequence: 5xx → 5xx → 200. The 200 must reset retryCount
+            // so that subsequent failures restart counting from zero, not
+            // from the accumulated value. Without this reset, a flaky network
+            // would eventually trip maxRetries and drop events even though
+            // most attempts succeeded.
+            let sut = self.getSut(flushAt: 1, maxBatchSize: 50, maxRetries: 3)
+            var attempt = 0
+            server.batchResponseHandler = { _, _ in
+                attempt += 1
+                if attempt <= 2 {
+                    return HTTPStubsResponse(jsonObject: [], statusCode: 500, headers: nil)
+                }
+                return HTTPStubsResponse(jsonObject: ["status": "ok"], statusCode: 200, headers: nil)
+            }
+
+            sut.add(PostHogEvent(event: "evt", distinctId: "id"))
+            // The 5xx path sets pausedUntil with exponential backoff (~5s,
+            // 10s); we just need the eventual success to land within the
+            // test's wait window.
+            let events = getBatchedEvents(server, timeout: 30)
+            expect(events.contains(where: { $0.event == "evt" })) == true
+            expect(sut.depth).toEventually(equal(0))
+
+            sut.clear()
+        }
+
         it("retains batch on retriable 5xx and does not change cap") {
             let sut = self.getSut(flushAt: 2, maxBatchSize: 4)
             server.batchResponseHandler = { _, _ in

--- a/PostHogTests/PostHogQueueTest.swift
+++ b/PostHogTests/PostHogQueueTest.swift
@@ -121,6 +121,27 @@ class PostHogQueueTest: QuickSpec {
             sut.clear()
         }
 
+        it("halves cap based on actual batch size when queue depth was below cap") {
+            // cap=10, but only 4 events were sent (queue depth was below cap).
+            // Halve from `min(cap, batchSize)` = 4 → cap = 2, not 5. Avoids
+            // wasted halvings on a cap that wasn't reached anyway.
+            let sut = self.getSut(flushAt: 4, maxBatchSize: 10)
+            server.batchResponseHandler = { _, _ in
+                HTTPStubsResponse(jsonObject: [], statusCode: 413, headers: nil)
+            }
+
+            for i in 0 ..< 4 {
+                sut.add(PostHogEvent(event: "event\(i)", distinctId: "id\(i)"))
+            }
+
+            _ = getBatchedEvents(server)
+
+            expect(sut.currentBatchCapForTesting).toEventually(equal(2))
+            expect(sut.depth).toEventually(equal(4))
+
+            sut.clear()
+        }
+
         it("drops batch on HTTP 413 when cap is already 1") {
             let sut = self.getSut(flushAt: 1, maxBatchSize: 1)
             server.batchResponseHandler = { _, _ in

--- a/PostHogTests/TestUtils/MockPostHogServer.swift
+++ b/PostHogTests/TestUtils/MockPostHogServer.swift
@@ -56,6 +56,11 @@ class MockPostHogServer {
 
     var errorsWhileComputingFlags = false
     var return500 = false
+    /// Optional override for `/batch` responses. When set, takes precedence
+    /// over `return500`. The closure receives the incoming request and the
+    /// 1-based index of that request in the batch sequence so callers can
+    /// vary the response (e.g. 413 then 200).
+    var batchResponseHandler: ((URLRequest, Int) -> HTTPStubsResponse)?
     var returnReplay = false
     var returnReplayWithVariant = false
     var returnReplayWithMultiVariant = false
@@ -306,12 +311,15 @@ class MockPostHogServer {
             return response
         })
 
-        stubDescriptors.append(stub(condition: pathEndsWith("/batch")) { _ in
-            if self.return500 {
-                HTTPStubsResponse(jsonObject: [], statusCode: 500, headers: nil)
-            } else {
-                HTTPStubsResponse(jsonObject: ["status": "ok"], statusCode: 200, headers: nil)
+        stubDescriptors.append(stub(condition: pathEndsWith("/batch")) { request in
+            if let handler = self.batchResponseHandler {
+                let index = self.batchRequests.count + 1
+                return handler(request, index)
             }
+            if self.return500 {
+                return HTTPStubsResponse(jsonObject: [], statusCode: 500, headers: nil)
+            }
+            return HTTPStubsResponse(jsonObject: ["status": "ok"], statusCode: 200, headers: nil)
         })
 
         stubDescriptors.append(stub(condition: pathEndsWith("/s")) { _ in
@@ -438,6 +446,7 @@ class MockPostHogServer {
         flagsResponseHandler = nil
         errorsWhileComputingFlags = false
         return500 = false
+        batchResponseHandler = nil
     }
 
     func parseRequest(_ context: URLRequest, gzip: Bool = true) -> [String: Any]? {


### PR DESCRIPTION
## :bulb: Motivation and Context

This was added to RN for logs but iOS is missing this. There was a TODO pointing to match [posthog-android#130](https://github.com/PostHog/posthog-android/pull/130). 

On 413, halve both the batch cap and the flush threshold and retry; drop the batch once the cap reaches 1. Reductions stay reduced for the SDK lifetime (no ramp-up, matching Android/RN). Retriable set widened to `{-1, 3xx, 429, 500, 502, 503, 504}` — narrow 5xx subset matches Android's `RETRYABLE_STATUS_CODES` exactly.

The cap and flushAt reductions are kept in private state rather than mutating user-supplied `config.maxBatchSize` / `config.flushAt`.

## :green_heart: How did you test it?

`make test` — 9 new `PostHogQueueTest` cases covering: single 413 halve, multi-step halve→halve→drop sequence, drop at cap=1, 500/429/network-error retain, 501 (outside narrow set) pop, non-retriable 4xx pop, 2xx pop without ramp-up.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
