### PR TITLE
fix: clean up CocoaPods validation warnings

### DIFF
--- a/.changeset/calm-geese-clean.md
+++ b/.changeset/calm-geese-clean.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Clean up CocoaPods validation warnings from deprecated sanitizer access, unused lock results, and duplicate C++ linker flags.

--- a/PostHog.podspec
+++ b/PostHog.podspec
@@ -28,7 +28,6 @@ Pod::Spec.new do |s|
   # Vendored PLCrashReporter source (not available on watchOS/visionOS)
   s.libraries = 'c++'
   s.pod_target_xcconfig = {
-    'OTHER_LDFLAGS' => '-lc++',
     'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) PLCR_PRIVATE PLCF_RELEASE_BUILD PLCRASHREPORTER_PREFIX=PH SWIFT_PACKAGE',
     'HEADER_SEARCH_PATHS' => '$(inherited) "${PODS_TARGET_SRCROOT}/vendor/PHPLCrashReporter/Dependencies/protobuf-c" "${PODS_TARGET_SRCROOT}/vendor/PHPLCrashReporter/Dependencies/protobuf-c/protobuf-c" "${PODS_TARGET_SRCROOT}/vendor/PHPLCrashReporter/Source"',
     'SWIFT_INCLUDE_PATHS' => '$(inherited) "${PODS_TARGET_SRCROOT}/PostHog/PrivateModules/phlibwebp" "${PODS_TARGET_SRCROOT}/PostHog/PrivateModules/PHPLCrashReporter"'

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -110,10 +110,18 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
     /// Defaults to false.
     @objc public var reuseAnonymousId: Bool = false
 
+    private var _propertiesSanitizer: PostHogPropertiesSanitizer?
+    var legacyPropertiesSanitizer: PostHogPropertiesSanitizer? {
+        _propertiesSanitizer
+    }
+
     /// Hook that allows to sanitize the event properties
     /// The hook is called before the event is cached or sent over the wire
     @available(*, deprecated, message: "Use beforeSend instead")
-    @objc public var propertiesSanitizer: PostHogPropertiesSanitizer?
+    @objc public var propertiesSanitizer: PostHogPropertiesSanitizer? {
+        get { _propertiesSanitizer }
+        set { _propertiesSanitizer = newValue }
+    }
     /// Determines the behavior for processing user profiles.
     @objc public var personProfiles: PostHogPersonProfiles = .identifiedOnly
 

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -1074,7 +1074,7 @@ let maxRetryDelay = 30.0
     }
 
     private func sanitizeProperties(_ properties: [String: Any]) -> [String: Any] {
-        if let sanitizer = config.propertiesSanitizer {
+        if let sanitizer = config.legacyPropertiesSanitizer {
             return sanitizer.sanitize(properties)
         }
         return properties

--- a/PostHog/Replay/Plugins/Network/URLSessionSwizzler.swift
+++ b/PostHog/Replay/Plugins/Network/URLSessionSwizzler.swift
@@ -72,7 +72,7 @@
                 return id
             } catch {
                 lock.withLock {
-                    registrations.removeValue(forKey: id)
+                    _ = registrations.removeValue(forKey: id)
                 }
                 throw error
             }


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Clean up the CocoaPods validation warnings we can address directly in SDK code/config:

- Keep the deprecated `propertiesSanitizer` public API, but read it internally through a non-deprecated backing accessor so SDK builds do not warn on their own deprecated API.
- Explicitly discard the `removeValue(forKey:)` result inside the URLSession swizzler lock closure.
- Remove the duplicate `-lc++` linker flag from the podspec while keeping `s.libraries = 'c++'`.

Possible follow-ups from the same CI log:

- Change the private PHPLCrashReporter module map from an `umbrella header` to a regular `header` to avoid umbrella-header warnings without exposing vendored internals.
- Suppress or otherwise handle `-Wshorten-64-to-32` warnings from vendored `protobuf-c` separately.


## :green_heart: How did you test it?

- `make format`
- `make test`
- `make lint`


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
