### PR TITLE
ci: check pod version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,8 +280,54 @@ jobs:
         with:
           xcode-version: '16.2'
 
+      - name: Check if CocoaPods version already exists
+        id: check-cocoapods-version
+        env:
+          RELEASE_VERSION: ${{ needs.create-github-release.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          version_exists_on_cocoapods() {
+            pod trunk info PostHog --no-ansi | grep -F -- "- $1 (" > /dev/null
+          }
+
+          if version_exists_on_cocoapods "$RELEASE_VERSION"; then
+            echo "PostHog ($RELEASE_VERSION) already exists on CocoaPods. Skipping publish."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "PostHog ($RELEASE_VERSION) is not on CocoaPods yet. Publishing..."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to CocoaPods
-        run: make releaseCocoaPods
+        if: steps.check-cocoapods-version.outputs.exists != 'true'
+        env:
+          RELEASE_VERSION: ${{ needs.create-github-release.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          set +e
+          make releaseCocoaPods
+          publish_exit_code=$?
+          set -e
+
+          if [ "$publish_exit_code" -eq 0 ]; then
+            exit 0
+          fi
+
+          echo "::warning::CocoaPods publish failed with exit code $publish_exit_code. Checking if PostHog ($RELEASE_VERSION) was published anyway..."
+
+          version_exists_on_cocoapods() {
+            pod trunk info PostHog --no-ansi | grep -F -- "- $1 (" > /dev/null
+          }
+
+          if version_exists_on_cocoapods "$RELEASE_VERSION"; then
+            echo "PostHog ($RELEASE_VERSION) is available on CocoaPods after the failed publish. Treating the publish as successful."
+            exit 0
+          fi
+
+          echo "::error::PostHog ($RELEASE_VERSION) is still not available on CocoaPods after the failed publish."
+          exit 1
 
       # Notify in case of failure
       - name: Send failure event to PostHog


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

CocoaPods trunk can successfully publish a version but still return a transient/internal server error to CI. When the release job is rerun, pod trunk push then fails with a
 duplicate version error, even though the pod is already available.

 This updates the release workflow to make CocoaPods publishing idempotent:

 - Checks whether the release version already exists on CocoaPods before publishing.
 - Skips pod trunk push and succeeds if the version is already present.
 - If make releaseCocoaPods fails, captures the exit code, logs a warning, then checks CocoaPods again.
 - Treats the publish as successful if the version appeared despite the failure.
 - Still fails the job if the version is not available after the failed publish.

## :green_heart: How did you test it?

- Validated the CocoaPods version check locally with:
     - 3.57.4 → detected as existing
     - fake version → detected as missing

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
