### PR TITLE
refactor(api): share a single URLSession across all PostHogApi requests

### DIFF
--- a/PostHog/PostHogApi.swift
+++ b/PostHog/PostHogApi.swift
@@ -43,33 +43,31 @@ class PostHogApi {
     // default is 60s but we do 10s
     private let defaultTimeout: TimeInterval = 10
 
-    /// One `URLSession` instance shared by every request the SDK makes.
-    /// Per-request `URLSession` is an anti-pattern — Apple's guidance (WWDC 2018
-    /// session 714) is to reuse a single session so the connection pool stays
-    /// warm, TLS handshakes amortise across requests, and HTTP/2 multiplexing
-    /// can carry concurrent flushes (events / replay / logs / flags) over one
-    /// TCP connection.
+    /// Shared so connection pool, TLS state, and HTTP/2 streams survive
+    /// between calls instead of being torn down per request.
     private let session: URLSession
 
     init(_ config: PostHogConfig) {
         self.config = config
 
-        let sessionConfig = config.urlSessionConfiguration ?? URLSessionConfiguration.default
-        // Sends a conditional request (If-Modified-Since/If-None-Match) to the
-        // server. Used by /array/<token>/config so we don't operate with stale
-        // config or flags.
+        // Copy first so SDK mutations don't leak back to the caller's object.
+        let sessionConfig = (config.urlSessionConfiguration?.copy() as? URLSessionConfiguration)
+            ?? URLSessionConfiguration.default
+        // Conditional request (If-Modified-Since/If-None-Match): server returns
+        // 304 → cache hit, otherwise fresh body. Needed for /array/<token>/config
+        // so we don't operate on stale config or flags.
         sessionConfig.requestCachePolicy = .reloadRevalidatingCacheData
-        sessionConfig.httpAdditionalHeaders = [
-            "Content-Type": "application/json; charset=utf-8",
-            "User-Agent": "\(postHogSdkName)/\(postHogVersion)",
-            "Accept-Encoding": "gzip",
-        ]
+        // Merge over caller-supplied headers; SDK keys overwrite collisions.
+        var headers = sessionConfig.httpAdditionalHeaders ?? [:]
+        headers["Content-Type"] = "application/json; charset=utf-8"
+        headers["User-Agent"] = "\(postHogSdkName)/\(postHogVersion)"
+        headers["Accept-Encoding"] = "gzip"
+        sessionConfig.httpAdditionalHeaders = headers
         session = URLSession(configuration: sessionConfig)
     }
 
-    /// Builds a POST `URLRequest`. Pass `gzipped: true` for upload endpoints
-    /// (/batch, /s/, /i/v1/logs) that send gzipped bodies — the
-    /// `Content-Encoding: gzip` header tells the server to decompress.
+    /// `gzipped: true` adds `Content-Encoding: gzip` for upload endpoints
+    /// (/batch, /s/, /i/v1/logs) whose bodies are gzipped.
     private func getURLRequest(_ url: URL, gzipped: Bool = false) -> URLRequest {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"

--- a/PostHog/PostHogApi.swift
+++ b/PostHog/PostHogApi.swift
@@ -43,42 +43,40 @@ class PostHogApi {
     // default is 60s but we do 10s
     private let defaultTimeout: TimeInterval = 10
 
+    /// One `URLSession` instance shared by every request the SDK makes.
+    /// Per-request `URLSession` is an anti-pattern — Apple's guidance (WWDC 2018
+    /// session 714) is to reuse a single session so the connection pool stays
+    /// warm, TLS handshakes amortise across requests, and HTTP/2 multiplexing
+    /// can carry concurrent flushes (events / replay / logs / flags) over one
+    /// TCP connection.
+    private let session: URLSession
+
     init(_ config: PostHogConfig) {
         self.config = config
-    }
 
-    func sessionConfig() -> URLSessionConfiguration {
-        // Use custom configuration if provided, otherwise use default
-        let config = self.config.urlSessionConfiguration ?? URLSessionConfiguration.default
-
-        // Sends a conditional request (If-Modified-Since/If-None-Match) to the server.
-        // If server returns 304 Not Modified, uses cache; otherwise downloads fresh data.
-        // This only affects static resources like /config and it ensures that we don't operate with stale config or flags.
-        config.requestCachePolicy = .reloadRevalidatingCacheData
-
-        config.httpAdditionalHeaders = [
+        let sessionConfig = config.urlSessionConfiguration ?? URLSessionConfiguration.default
+        // Sends a conditional request (If-Modified-Since/If-None-Match) to the
+        // server. Used by /array/<token>/config so we don't operate with stale
+        // config or flags.
+        sessionConfig.requestCachePolicy = .reloadRevalidatingCacheData
+        sessionConfig.httpAdditionalHeaders = [
             "Content-Type": "application/json; charset=utf-8",
             "User-Agent": "\(postHogSdkName)/\(postHogVersion)",
+            "Accept-Encoding": "gzip",
         ]
-
-        return config
+        session = URLSession(configuration: sessionConfig)
     }
 
-    /// `sessionConfig()` plus gzip request/response encoding. Used by the upload
-    /// endpoints (/batch, /s/, /i/v1/logs) which always send gzipped bodies.
-    private func gzippedSessionConfig() -> URLSessionConfiguration {
-        let config = sessionConfig()
-        var headers = config.httpAdditionalHeaders ?? [:]
-        headers["Accept-Encoding"] = "gzip"
-        headers["Content-Encoding"] = "gzip"
-        config.httpAdditionalHeaders = headers
-        return config
-    }
-
-    private func getURLRequest(_ url: URL) -> URLRequest {
+    /// Builds a POST `URLRequest`. Pass `gzipped: true` for upload endpoints
+    /// (/batch, /s/, /i/v1/logs) that send gzipped bodies — the
+    /// `Content-Encoding: gzip` header tells the server to decompress.
+    private func getURLRequest(_ url: URL, gzipped: Bool = false) -> URLRequest {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.timeoutInterval = defaultTimeout
+        if gzipped {
+            request.setValue("gzip", forHTTPHeaderField: "Content-Encoding")
+        }
         return request
     }
 
@@ -126,13 +124,11 @@ class PostHogApi {
             return completion(PostHogUploadInfo(statusCode: nil, error: nil))
         }
 
-        let config = gzippedSessionConfig()
-
-        let request = getURLRequest(url)
+        let request = getURLRequest(url, gzipped: true)
 
         let toSend: [String: Any] = [
             // Wire field name remains api_key, but it carries the PostHog project token.
-            "api_key": self.config.projectToken,
+            "api_key": config.projectToken,
             "batch": events.map { $0.toJSON() },
             "sent_at": toISO8601String(Date()),
         ]
@@ -142,7 +138,7 @@ class PostHogApi {
             return completion(PostHogUploadInfo(statusCode: nil, error: nil))
         }
 
-        var gzippedPayload: Data?
+        let gzippedPayload: Data
         do {
             gzippedPayload = try data.gzipped()
         } catch {
@@ -150,7 +146,7 @@ class PostHogApi {
             return completion(PostHogUploadInfo(statusCode: nil, error: error))
         }
 
-        URLSession(configuration: config).uploadTask(with: request, from: gzippedPayload!) { data, response, error in
+        session.uploadTask(with: request, from: gzippedPayload) { data, response, error in
             processUploadResponse(endpointName: "batch", data: data, response: response, error: error, completion: completion)
         }.resume()
     }
@@ -162,12 +158,10 @@ class PostHogApi {
         }
 
         for event in events {
-            event.apiKey = self.config.projectToken
+            event.apiKey = config.projectToken
         }
 
-        let config = gzippedSessionConfig()
-
-        let request = getURLRequest(url)
+        let request = getURLRequest(url, gzipped: true)
 
         let toSend = events.map { $0.toJSON() }
 
@@ -176,7 +170,7 @@ class PostHogApi {
             return completion(PostHogUploadInfo(statusCode: nil, error: nil))
         }
 
-        var gzippedPayload: Data?
+        let gzippedPayload: Data
         do {
             gzippedPayload = try data.gzipped()
         } catch {
@@ -184,7 +178,7 @@ class PostHogApi {
             return completion(PostHogUploadInfo(statusCode: nil, error: error))
         }
 
-        URLSession(configuration: config).uploadTask(with: request, from: gzippedPayload!) { data, response, error in
+        session.uploadTask(with: request, from: gzippedPayload) { data, response, error in
             processUploadResponse(endpointName: "snapshot", data: data, response: response, error: error, completion: completion)
         }.resume()
     }
@@ -206,9 +200,7 @@ class PostHogApi {
             return completion(PostHogUploadInfo(statusCode: nil, error: nil))
         }
 
-        let sessionConfig = gzippedSessionConfig()
-
-        let request = getURLRequest(url)
+        let request = getURLRequest(url, gzipped: true)
 
         guard let data = try? JSONSerialization.data(withJSONObject: payload) else {
             hedgeLog("Error parsing the logs body")
@@ -223,7 +215,7 @@ class PostHogApi {
             return completion(PostHogUploadInfo(statusCode: nil, error: error))
         }
 
-        URLSession(configuration: sessionConfig).uploadTask(with: request, from: gzippedPayload) { data, response, error in
+        session.uploadTask(with: request, from: gzippedPayload) { data, response, error in
             processUploadResponse(endpointName: "logs", data: data, response: response, error: error, completion: completion)
         }.resume()
     }
@@ -248,13 +240,11 @@ class PostHogApi {
             return completion(nil, nil)
         }
 
-        let config = sessionConfig()
-
         let request = getURLRequest(url)
 
         var toSend: [String: Any] = [
             // Wire field name remains api_key, but it carries the PostHog project token.
-            "api_key": self.config.projectToken,
+            "api_key": config.projectToken,
             "distinct_id": distinctId,
             "groups": groups,
             "timezone": TimeZone.current.identifier,
@@ -276,7 +266,7 @@ class PostHogApi {
             toSend["group_properties"] = groupProperties
         }
 
-        if let evaluationContexts = self.config.evaluationContexts, !evaluationContexts.isEmpty {
+        if let evaluationContexts = config.evaluationContexts, !evaluationContexts.isEmpty {
             toSend["evaluation_contexts"] = evaluationContexts
         }
 
@@ -285,7 +275,7 @@ class PostHogApi {
             return completion(nil, nil)
         }
 
-        URLSession(configuration: config).uploadTask(with: request, from: data) { data, response, error in
+        session.uploadTask(with: request, from: data) { data, response, error in
             if error != nil {
                 hedgeLog("Error calling the flags API: \(String(describing: error))")
                 return completion(nil, error)
@@ -327,9 +317,7 @@ class PostHogApi {
             return
         }
 
-        let config = sessionConfig()
-
-        let task = URLSession(configuration: config).dataTask(with: request) { data, response, error in
+        let task = session.dataTask(with: request) { data, response, error in
             if let error {
                 hedgeLog("Error calling the remote config API: \(error.localizedDescription)")
                 return completion(nil, error)

--- a/PostHogTests/PostHogApiTest.swift
+++ b/PostHogTests/PostHogApiTest.swift
@@ -146,13 +146,9 @@ enum PostHogApiTests {
         }
     }
 
-    /// Pins the Content-Encoding policy that the shared-URLSession refactor
-    /// depends on: gzip moved off the session's `httpAdditionalHeaders` and
-    /// onto each `URLRequest` instead. Upload endpoints (/batch, /s, /i/v1/logs)
-    /// must declare `Content-Encoding: gzip` because their bodies are gzipped;
-    /// /flags must NOT declare it because its body is plain JSON. Without this
-    /// guard, a regression that re-introduced session-level gzip would silently
-    /// mis-label /flags requests on the wire.
+    /// Guards the per-request Content-Encoding policy: upload endpoints
+    /// declare `gzip`, /flags does not. A regression that re-added
+    /// session-level gzip would silently mis-label /flags on the wire.
     @Suite("Content-Encoding header per endpoint")
     class TestContentEncodingHeader: BaseTestSuite {
         @Test("/batch declares gzip Content-Encoding")
@@ -178,7 +174,7 @@ enum PostHogApiTests {
         @Test("/i/v1/logs declares gzip Content-Encoding")
         func logsDeclaresGzip() async throws {
             let sut = getSut(host: "http://localhost")
-            _ = await getApiResponse { (completion: @escaping (PostHogUploadInfo) -> Void) in
+            _ = await getApiResponse { completion in
                 sut.logs(payload: ["resourceLogs": []], completion: completion)
             }
             let request = try #require(server.logsRequests.first)

--- a/PostHogTests/PostHogApiTest.swift
+++ b/PostHogTests/PostHogApiTest.swift
@@ -146,6 +146,58 @@ enum PostHogApiTests {
         }
     }
 
+    /// Pins the Content-Encoding policy that the shared-URLSession refactor
+    /// depends on: gzip moved off the session's `httpAdditionalHeaders` and
+    /// onto each `URLRequest` instead. Upload endpoints (/batch, /s, /i/v1/logs)
+    /// must declare `Content-Encoding: gzip` because their bodies are gzipped;
+    /// /flags must NOT declare it because its body is plain JSON. Without this
+    /// guard, a regression that re-introduced session-level gzip would silently
+    /// mis-label /flags requests on the wire.
+    @Suite("Content-Encoding header per endpoint")
+    class TestContentEncodingHeader: BaseTestSuite {
+        @Test("/batch declares gzip Content-Encoding")
+        func batchDeclaresGzip() async throws {
+            let sut = getSut(host: "http://localhost")
+            _ = await getApiResponse { completion in
+                sut.batch(events: [], completion: completion)
+            }
+            let request = try #require(server.batchRequests.first)
+            #expect(request.value(forHTTPHeaderField: "Content-Encoding") == "gzip")
+        }
+
+        @Test("/s declares gzip Content-Encoding")
+        func snapshotDeclaresGzip() async throws {
+            let sut = getSut(host: "http://localhost")
+            _ = await getApiResponse { completion in
+                sut.snapshot(events: [], completion: completion)
+            }
+            let request = try #require(server.snapshotRequests.first)
+            #expect(request.value(forHTTPHeaderField: "Content-Encoding") == "gzip")
+        }
+
+        @Test("/i/v1/logs declares gzip Content-Encoding")
+        func logsDeclaresGzip() async throws {
+            let sut = getSut(host: "http://localhost")
+            _ = await getApiResponse { (completion: @escaping (PostHogUploadInfo) -> Void) in
+                sut.logs(payload: ["resourceLogs": []], completion: completion)
+            }
+            let request = try #require(server.logsRequests.first)
+            #expect(request.value(forHTTPHeaderField: "Content-Encoding") == "gzip")
+        }
+
+        @Test("/flags does not declare Content-Encoding")
+        func flagsDoesNotDeclareGzip() async throws {
+            let sut = getSut(host: "http://localhost")
+            _ = await getApiResponse { completion in
+                sut.flags(distinctId: "x", anonymousId: nil, groups: [:], personProperties: [:]) { data, _ in
+                    completion(data)
+                }
+            }
+            let request = try #require(server.flagsRequests.first)
+            #expect(request.value(forHTTPHeaderField: "Content-Encoding") == nil)
+        }
+    }
+
     @Suite("Test flags endpoint with different host paths")
     class TestFlagsEndpoint: BaseTestSuite {
         @Test("with host containing no path")


### PR DESCRIPTION
## :bulb: Motivation and Context

Per-request `URLSession` is an anti-pattern. The SDK currently constructs a fresh `URLSession(configuration: ...).uploadTask(...)` for every batch / snapshot / logs / flags / remoteConfig call (5 sites in `PostHogApi.swift`). Each fresh session has its own connection pool, so back-to-back requests pay a TCP + TLS handshake every time and HTTP/2 multiplexing — which the PostHog backend supports (`us.i.posthog.com` and `eu.i.posthog.com` both negotiate HTTP/2 via Envoy) — never engages.

Apple's guidance (WWDC 2018 session 714 + DTS forum thread 84663) is explicit: reuse a single `URLSession` instance. Quinn the Eskimo: *"This is a common anti-pattern… creating a session per request prevents connection reuse, which can radically slow down back-to-back requests. This is especially bad for HTTP/2."*

This PR lifts `URLSession` to a stored property on `PostHogApi`, built once in `init`. All five API methods now share the same session and connection pool. Per-request gzip semantics move from session-level `httpAdditionalHeaders` onto `URLRequest` via `Content-Encoding`, so `/flags` and `/array/<token>/config` don't carry a misleading gzip header (their bodies aren't gzipped).

Concrete wins:

- **TLS handshake amortised** across requests instead of paid per-call (~150-300ms on cellular per handshake).
- **HTTP/2 multiplexing** kicks in when events / replay / logs / flags flush concurrently — one TCP connection carries all four streams.
- **Reduced per-request setup cost.** Apple says `URLSession` is "fairly expensive to create" with "non-trivial memory footprint."

## :green_heart: How did you test it?

`make test` — **496 tests pass**. Request bodies and response handling are unchanged. (`Accept-Encoding: gzip` is now also sent on `/flags` and `/array` requests, which it wasn't before — but `URLSession` adds that header implicitly when unset and decompresses gzipped responses transparently, so handlers receive the same bytes as before.)

Adds four new test cases in `PostHogApiTest.swift` under a `Content-Encoding header per endpoint` suite that pin the policy this refactor depends on:

- `/batch`, `/s`, `/i/v1/logs` requests must declare `Content-Encoding: gzip` on the `URLRequest` (because their bodies are gzipped).
- `/flags` requests must NOT declare `Content-Encoding`.

Without these guards a regression that re-introduced session-level gzip would silently mis-label `/flags` on the wire.

`make buildSdk` — green across iOS / macOS / tvOS / watchOS / visionOS.

Manual: ran `PostHogExampleMacOS` against the real backend with a CFNetwork unified-log capture. `/array/<token>/config` → 304, `/flags` → 200, both over HTTP/2 (`alpn=h2`) on one connection per host. No errors; new `Accept-Encoding: gzip` on `/flags` decodes correctly. Multi-request reuse on a single host (the multiplexing claim) wasn't exercised in this trace — would need user-driven activity to fire multiple `/batch` calls.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file.

