### PR TITLE
fix: synchronize SDK enabled state

### DIFF
--- a/.changeset/breezy-vans-report.md
+++ b/.changeset/breezy-vans-report.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+fix: synchronize SDK enabled state

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -30,7 +30,7 @@ let maxRetryDelay = 30.0
     }
 
     private var enabled = false
-    private let setupLock = NSLock()
+    private let setupLock = NSRecursiveLock()
     private let optOutLock = NSLock()
     private let groupsLock = NSLock()
     private let flagCallReportedLock = NSLock()

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -1713,6 +1713,7 @@ let maxRetryDelay = 30.0
     }
 
     private func isEnabled() -> Bool {
+        let enabled = setupLock.withLock { self.enabled }
         if !enabled {
             hedgeLog("PostHog method was called without `setup` being complete. Call wil be ignored.")
         }


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

PostHogSDK.enabled was written while holding setupLock, but read without synchronization in isEnabled()

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
