### PR TITLE
feat(surveys): add survey translations support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+### Minor Changes
+
+- Add survey translations support. Surveys can carry per-language overrides for user-visible strings via a `translations` map keyed by language code. At display time the SDK resolves a language (`PostHogSurveysConfig.overrideDisplayLanguage` → person property `"language"` → device locale), applies any matching translation onto the display model, and stamps the matched key as `$survey_language` on every survey event when a translation actually took effect. Matching is case-insensitive with a base-language fallback (e.g. `"pt-BR"` falls back to `"pt"`).
+
 ## 3.58.1
 
 ### Patch Changes

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -20,15 +20,12 @@
 		238D24DE5A56F04CE3FF0928 /* PLCrashReportExceptionInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = F9BB47DFE51AFE8F516B8550 /* PLCrashReportExceptionInfo.m */; };
 		291141AEC376DC2C5BB2308F /* PLCrashReport.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C2E5E5D0EEB539A69D3E21F /* PLCrashReport.m */; };
 		2B66AB398C6E33DEEE924455 /* PostHogLogsQueueTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 275EEC0C4B14408F0D049966 /* PostHogLogsQueueTest.swift */; };
-		E0DDAAD7BBCC494EBAA8FE9F /* PostHogLogsCaptureTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3621762A151044A195A3A554 /* PostHogLogsCaptureTest.swift */; };
 		2E3684934C68D1CAFCF0358C /* PLCrashReportProcessorInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 4360B9439C3B5722C115465A /* PLCrashReportProcessorInfo.m */; };
 		305D4CDD7792799DE5455EB2 /* PLCrashAsyncImageList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 991CFA923BC02DA7DD6506C6 /* PLCrashAsyncImageList.cpp */; };
 		31D7081F45C6FAB2478BC354 /* PLCrashReport.pb-c.c in Sources */ = {isa = PBXBuildFile; fileRef = F808F6F63C4473F4570FE32B /* PLCrashReport.pb-c.c */; };
 		38CBA527DA86F6A20DA50F80 /* PostHogLogRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68181997A5803BEDE63ABDEA /* PostHogLogRecord.swift */; };
-		4A1B2C3D4E5F60718293A4B6 /* PostHogLogSeverity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1B2C3D4E5F60718293A4B6 /* PostHogLogSeverity.swift */; };
 		39C70993C85FF7165C85BD4D /* PLCrashAsyncDwarfFDE.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5B4E325C19D4C707C5FA9255 /* PLCrashAsyncDwarfFDE.cpp */; };
 		3A0F108329C47940002C0084 /* UIViewExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0F108229C47940002C0084 /* UIViewExample.swift */; };
-		A54E1C29388E43AEA3B0FC83 /* LogsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A7B59CE7B8148E5A72D554F /* LogsView.swift */; };
 		3A0F108929C9BD76002C0084 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0F108829C9BD76002C0084 /* Errors.swift */; };
 		3A580B4329E489D000C5C6F3 /* URLSession+body.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A580B4229E489D000C5C6F3 /* URLSession+body.swift */; };
 		3A62646A29C9E385007E8C07 /* MockPostHogServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A62646929C9E385007E8C07 /* MockPostHogServer.swift */; };
@@ -53,6 +50,7 @@
 		3D1C111BCD386DDBAB6E598C /* PLCrashFrameStackUnwind.c in Sources */ = {isa = PBXBuildFile; fileRef = 481CB44DF30DBC62657AAC48 /* PLCrashFrameStackUnwind.c */; };
 		40CA51784E9B51965327C3A2 /* PLCrashAsyncSymbolication.c in Sources */ = {isa = PBXBuildFile; fileRef = C032F7F5B744465BA103BC94 /* PLCrashAsyncSymbolication.c */; };
 		46A911BC1659B0FEFA8D1E43 /* BundleUtilsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E781EB127B3DC1290199836 /* BundleUtilsTest.swift */; };
+		4A1B2C3D4E5F60718293A4B6 /* PostHogLogSeverity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1B2C3D4E5F60718293A4B6 /* PostHogLogSeverity.swift */; };
 		4B3E620C85BFCE7C9F3800D2 /* PLCrashReportMachExceptionInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DBE5F51C6078BEF346BFDBB /* PLCrashReportMachExceptionInfo.m */; };
 		4C2DC69C9F10ED07CFC374C1 /* PLCrashAsyncThread_x86.c in Sources */ = {isa = PBXBuildFile; fileRef = 351BB1903238AF5443032040 /* PLCrashAsyncThread_x86.c */; };
 		5BAE9162D28D34E0FECB29B4 /* PLCrashSysctl.c in Sources */ = {isa = PBXBuildFile; fileRef = 1A8704E270B2737239AB8A64 /* PLCrashSysctl.c */; };
@@ -61,8 +59,6 @@
 		690B2DF32C205B5600AE3B45 /* TimeBasedEpochGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690B2DF22C205B5600AE3B45 /* TimeBasedEpochGenerator.swift */; };
 		690FF05F2AE7E2D400A0B06B /* Data+Gzip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690FF05E2AE7E2D400A0B06B /* Data+Gzip.swift */; };
 		690FF0AF2AEB9C1400A0B06B /* DateUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690FF0AE2AEB9C1400A0B06B /* DateUtils.swift */; };
-		D9CC0D1E00010000000000B2 /* BeforeSendChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9CC0D1E00010000000000B1 /* BeforeSendChain.swift */; };
-		C236F4F79DBF4F55B918D685 /* BoxedBeforeSend.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4085030E312423F8599009D /* BoxedBeforeSend.swift */; };
 		690FF0B52AEBBD3C00A0B06B /* DictUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690FF0B42AEBBD3C00A0B06B /* DictUtils.swift */; };
 		690FF0BB2AEF8B8200A0B06B /* PostHogContextTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690FF0BA2AEF8B8200A0B06B /* PostHogContextTest.swift */; };
 		690FF0BF2AEFA97F00A0B06B /* FileUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690FF0BE2AEFA97F00A0B06B /* FileUtils.swift */; };
@@ -145,21 +141,26 @@
 		8A85D64A2CA4FB9728087065 /* PLCrashReportSymbolInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 61B25EED847481E0988A65E3 /* PLCrashReportSymbolInfo.m */; };
 		8B5424D711C21127F7ED3761 /* PLCrashReportThreadInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = DB51A204FB088EC14375B43D /* PLCrashReportThreadInfo.m */; };
 		8B64BD0F89B007D41E635B6C /* PLCrashFrameDWARFUnwind.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05FCF0F4BD9EEC66BF95699E /* PLCrashFrameDWARFUnwind.cpp */; };
+		8BA17B211DFE45AA8DCAD1F1 /* PostHogLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045078ECC7B3488DA27D06E9 /* PostHogLogger.swift */; };
 		8CD8EBAFCE863F53F01805B1 /* PLCrashReporterNSError.m in Sources */ = {isa = PBXBuildFile; fileRef = AA43A324507226180D2483CD /* PLCrashReporterNSError.m */; };
 		8CF9034E1B95A54CD3717236 /* PostHogReachabilityTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F98E7D98CC906E4BA3D582 /* PostHogReachabilityTest.swift */; };
 		8E8274A87B1CEE071C5A487C /* PLCrashFrameWalker.c in Sources */ = {isa = PBXBuildFile; fileRef = 6957A9B66813CC8C7E9B818C /* PLCrashFrameWalker.c */; };
 		8F28575066306D4DD0692AD4 /* PLCrashReportTextFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E23F6C473BBAA67C23A0812 /* PLCrashReportTextFormatter.m */; };
 		990B703A6620B474798DD770 /* PLCrashAsyncCompactUnwindEncoding.c in Sources */ = {isa = PBXBuildFile; fileRef = CB453C289F1DC872BE9945FC /* PLCrashAsyncCompactUnwindEncoding.c */; };
+		9B05C5E931164645BE9DA249 /* QueueEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D8E83880254E4B86DEBF70 /* QueueEndpoint.swift */; };
 		9B5D780354DF24461DFC69D6 /* PLCrashAsyncMachExceptionInfo.c in Sources */ = {isa = PBXBuildFile; fileRef = 20C01091B0ACF69D36D3B7AE /* PLCrashAsyncMachExceptionInfo.c */; };
+		9D16D700F4598774FB0A3C6F /* SurveyTranslationResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9473A633747872EA43FDCA3A /* SurveyTranslationResolver.swift */; };
 		9D6E3423A194FC87AEB412B4 /* PLCrashAsyncDwarfExpression.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A0C71E02B9407F33DAE8EA5A /* PLCrashAsyncDwarfExpression.cpp */; };
 		9F0D955E2EAE34FC1AAF83C6 /* PLCrashAsyncObjCSection.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7BBC5F0B51D6B521B4AC49B2 /* PLCrashAsyncObjCSection.mm */; };
 		A03BB3574B8F7087AF350F5E /* PLCrashAsyncThread_current.c in Sources */ = {isa = PBXBuildFile; fileRef = 57E2779AF27A014DB1B40BCB /* PLCrashAsyncThread_current.c */; };
 		A1B2C3D401234567DEADBEEF /* PostHogDeepLinkHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D501234567DEADBEEF /* PostHogDeepLinkHelper.swift */; };
 		A1B2C3D601234567DEADBEEF /* PostHogDeepLinkListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D701234567DEADBEEF /* PostHogDeepLinkListener.swift */; };
+		A54E1C29388E43AEA3B0FC83 /* LogsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A7B59CE7B8148E5A72D554F /* LogsView.swift */; };
 		A9B17C56137763FF18EFD0C0 /* CrashReporter.m in Sources */ = {isa = PBXBuildFile; fileRef = ECBFEE10291A87FD4E8A2E5B /* CrashReporter.m */; };
 		ABB09493E02B20855285B547 /* PLCrashAsyncMObject.c in Sources */ = {isa = PBXBuildFile; fileRef = D81133CFD99A504078A7C854 /* PLCrashAsyncMObject.c */; };
 		BE35097A002BF72D11C07FF6 /* PLCrashAsyncMachOImage.c in Sources */ = {isa = PBXBuildFile; fileRef = DB8675A0F452E915420ED0AC /* PLCrashAsyncMachOImage.c */; };
 		C1604B68CADF9BB54A3911EF /* PLCrashReportProcessInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F885D26FB2B0DE9BDAF22BF /* PLCrashReportProcessInfo.m */; };
+		C236F4F79DBF4F55B918D685 /* BoxedBeforeSend.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4085030E312423F8599009D /* BoxedBeforeSend.swift */; };
 		C37F162E2DDFDCDCF1577CE6 /* PLCrashAsyncThread_current.S in Sources */ = {isa = PBXBuildFile; fileRef = 9BB480CAA746FD368A680D33 /* PLCrashAsyncThread_current.S */; };
 		C7FDD5F50FB39B99A3314785 /* PLCrashAsyncDwarfCFAStateEvaluation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8A53C31C8B0DDB72E7F1F15 /* PLCrashAsyncDwarfCFAStateEvaluation.cpp */; };
 		C89D871D0B220C168FD2EB5B /* PLCrashAsyncDwarfCFAState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 64F80D1792DC64921EF42266 /* PLCrashAsyncDwarfCFAState.cpp */; };
@@ -172,6 +173,7 @@
 		D44A33B824C72C49F5A38E0E /* PLCrashAsync.c in Sources */ = {isa = PBXBuildFile; fileRef = FB9F9CC224AC280F8A3C55E0 /* PLCrashAsync.c */; };
 		D53D57A93B4EA103E8E99819 /* BundleUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826D9ED566BF6FEFBA430555 /* BundleUtils.swift */; };
 		D7AA5AECE9BEA97FC1D001AC /* CrashReporterFramework.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AC7B7E5D1441557C48E5951 /* CrashReporterFramework.m */; };
+		D9CC0D1E00010000000000B2 /* BeforeSendChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9CC0D1E00010000000000B1 /* BeforeSendChain.swift */; };
 		DA0B66A52D64EC00006F5FF3 /* ph_sharpyuv_csp.h in Headers */ = {isa = PBXBuildFile; fileRef = DA0B66982D64EC00006F5FF3 /* ph_sharpyuv_csp.h */; };
 		DA0B66A62D64EC00006F5FF3 /* ph_sharpyuv_dsp.h in Headers */ = {isa = PBXBuildFile; fileRef = DA0B66992D64EC00006F5FF3 /* ph_sharpyuv_dsp.h */; };
 		DA0B66A72D64EC00006F5FF3 /* ph_huffman_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = DA0B668A2D64EC00006F5FF3 /* ph_huffman_utils.h */; };
@@ -557,14 +559,16 @@
 		DB7100012F80000100000001 /* PostHogTracingHeadersIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7100022F80000100000001 /* PostHogTracingHeadersIntegration.swift */; };
 		DB7100042F80000100000001 /* PostHogTracingHeadersTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7100052F80000100000001 /* PostHogTracingHeadersTest.swift */; };
 		DDEC07CF597D0652AE1516BB /* PLCrashMachExceptionServer.m in Sources */ = {isa = PBXBuildFile; fileRef = 42AF538C180FBEEACEBAB53F /* PLCrashMachExceptionServer.m */; };
+		E0DDAAD7BBCC494EBAA8FE9F /* PostHogLogsCaptureTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3621762A151044A195A3A554 /* PostHogLogsCaptureTest.swift */; };
 		E73A7268E94F45E9B079BDAD /* PLCrashReportApplicationInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B24F86E2D8348C00685A2F9 /* PLCrashReportApplicationInfo.m */; };
 		E82B0039B6834A439AD214E9 /* PostHogRageClickConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = F78338D55B15449D9EB8507B /* PostHogRageClickConfig.swift */; };
+		E88BDD35158F81ACD33C3EAE /* PostHogSurveyTranslationsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80D0EFDC8AA37740A78B15E /* PostHogSurveyTranslationsTest.swift */; };
+		E89B5DEB2E380EF6D86E66A8 /* fixture_survey_translations.json in Resources */ = {isa = PBXBuildFile; fileRef = 0DD06A7329293F85392FD46C /* fixture_survey_translations.json */; };
 		ED008D9300E24D2ED5DEEB00 /* PLCrashAsyncDwarfPrimitives.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8C82A825494404A8958F15C /* PLCrashAsyncDwarfPrimitives.cpp */; };
 		EE47DB8C906D409AB6C2A23F /* RageClickDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E974D4AD3C438FAE6FE0C5 /* RageClickDetector.swift */; };
-		F6DADC57034D5B70B502F251 /* PostHogLogsConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAA5E5DBE9861837899D553 /* PostHogLogsConfig.swift */; };
-		9B05C5E931164645BE9DA249 /* QueueEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D8E83880254E4B86DEBF70 /* QueueEndpoint.swift */; };
 		F01DFEA6844945E7A794FCC9 /* QueueEndpoint+Factories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C0C245B05D4C29890560B8 /* QueueEndpoint+Factories.swift */; };
-		8BA17B211DFE45AA8DCAD1F1 /* PostHogLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045078ECC7B3488DA27D06E9 /* PostHogLogger.swift */; };
+		F0FBEDFF37952921D60EF57C /* PostHogSurveyTranslation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E41CC6ED20D266FB2357B81 /* PostHogSurveyTranslation.swift */; };
+		F6DADC57034D5B70B502F251 /* PostHogLogsConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAA5E5DBE9861837899D553 /* PostHogLogsConfig.swift */; };
 		FAAA4C305C550B22060A9905 /* PLCrashReportMachineInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 42CE9EE391A5AE700A1D688F /* PLCrashReportMachineInfo.m */; };
 /* End PBXBuildFile section */
 
@@ -734,24 +738,26 @@
 /* Begin PBXFileReference section */
 		001A4831298758176E2711B8 /* PLCrashLogWriter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PLCrashLogWriter.m; path = vendor/PHPLCrashReporter/Source/PLCrashLogWriter.m; sourceTree = "<group>"; };
 		00F98E7D98CC906E4BA3D582 /* PostHogReachabilityTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostHogReachabilityTest.swift; sourceTree = "<group>"; };
+		045078ECC7B3488DA27D06E9 /* PostHogLogger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostHogLogger.swift; sourceTree = "<group>"; };
 		05FCF0F4BD9EEC66BF95699E /* PLCrashFrameDWARFUnwind.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PLCrashFrameDWARFUnwind.cpp; path = vendor/PHPLCrashReporter/Source/PLCrashFrameDWARFUnwind.cpp; sourceTree = "<group>"; };
 		09F0CB0EF4DFD9469CE01CDD /* PLCrashAsyncThread_arm.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = PLCrashAsyncThread_arm.c; path = vendor/PHPLCrashReporter/Source/PLCrashAsyncThread_arm.c; sourceTree = "<group>"; };
 		0B24F86E2D8348C00685A2F9 /* PLCrashReportApplicationInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PLCrashReportApplicationInfo.m; path = vendor/PHPLCrashReporter/Source/PLCrashReportApplicationInfo.m; sourceTree = "<group>"; };
 		0D784BEF45D7E472FBE56B84 /* PLCrashMachExceptionPort.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PLCrashMachExceptionPort.m; path = vendor/PHPLCrashReporter/Source/PLCrashMachExceptionPort.m; sourceTree = "<group>"; };
+		0DD06A7329293F85392FD46C /* fixture_survey_translations.json */ = {isa = PBXFileReference; includeInIndex = 1; path = fixture_survey_translations.json; sourceTree = "<group>"; };
 		12DC9426FD779BD7FE34A29F /* PLCrashReportSystemInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PLCrashReportSystemInfo.m; path = vendor/PHPLCrashReporter/Source/PLCrashReportSystemInfo.m; sourceTree = "<group>"; };
 		1A8704E270B2737239AB8A64 /* PLCrashSysctl.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = PLCrashSysctl.c; path = vendor/PHPLCrashReporter/Source/PLCrashSysctl.c; sourceTree = "<group>"; };
+		1E41CC6ED20D266FB2357B81 /* PostHogSurveyTranslation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostHogSurveyTranslation.swift; sourceTree = "<group>"; };
 		1F55581F2DFC47E8007643C0 /* PostHogStorageMergeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogStorageMergeTest.swift; sourceTree = "<group>"; };
 		20C01091B0ACF69D36D3B7AE /* PLCrashAsyncMachExceptionInfo.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = PLCrashAsyncMachExceptionInfo.c; path = vendor/PHPLCrashReporter/Source/PLCrashAsyncMachExceptionInfo.c; sourceTree = "<group>"; };
 		26E974D4AD3C438FAE6FE0C5 /* RageClickDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RageClickDetector.swift; sourceTree = "<group>"; };
 		275EEC0C4B14408F0D049966 /* PostHogLogsQueueTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostHogLogsQueueTest.swift; sourceTree = "<group>"; };
-		3621762A151044A195A3A554 /* PostHogLogsCaptureTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostHogLogsCaptureTest.swift; sourceTree = "<group>"; };
 		2ADEF41FAC443C7CF9136BBA /* PLCrashReportStackFrameInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PLCrashReportStackFrameInfo.m; path = vendor/PHPLCrashReporter/Source/PLCrashReportStackFrameInfo.m; sourceTree = "<group>"; };
 		3139B45C2A22C4B82C567453 /* PLCrashReporter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PLCrashReporter.m; path = vendor/PHPLCrashReporter/Source/PLCrashReporter.m; sourceTree = "<group>"; };
 		351BB1903238AF5443032040 /* PLCrashAsyncThread_x86.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = PLCrashAsyncThread_x86.c; path = vendor/PHPLCrashReporter/Source/PLCrashAsyncThread_x86.c; sourceTree = "<group>"; };
+		3621762A151044A195A3A554 /* PostHogLogsCaptureTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostHogLogsCaptureTest.swift; sourceTree = "<group>"; };
 		38BFD5AA5F8B02385336F3D4 /* PLCrashReportRegisterInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PLCrashReportRegisterInfo.m; path = vendor/PHPLCrashReporter/Source/PLCrashReportRegisterInfo.m; sourceTree = "<group>"; };
 		39511B75AEBE275A433E3298 /* PLCrashUncaughtExceptionHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PLCrashUncaughtExceptionHandler.m; path = vendor/PHPLCrashReporter/Source/PLCrashUncaughtExceptionHandler.m; sourceTree = "<group>"; };
 		3A0F108229C47940002C0084 /* UIViewExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewExample.swift; sourceTree = "<group>"; };
-		4A7B59CE7B8148E5A72D554F /* LogsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsView.swift; sourceTree = "<group>"; };
 		3A0F108829C9BD76002C0084 /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		3A580B4229E489D000C5C6F3 /* URLSession+body.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+body.swift"; sourceTree = "<group>"; };
 		3A62646929C9E385007E8C07 /* MockPostHogServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPostHogServer.swift; sourceTree = "<group>"; };
@@ -777,6 +783,7 @@
 		3AE3FB48299391DF00AFFC18 /* PostHogStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogStorage.swift; sourceTree = "<group>"; };
 		3AE3FB4A2993A68500AFFC18 /* PostHogStorageTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogStorageTest.swift; sourceTree = "<group>"; };
 		3AE3FB4D2993D1D600AFFC18 /* PostHogStorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogStorageManager.swift; sourceTree = "<group>"; };
+		40C0C245B05D4C29890560B8 /* QueueEndpoint+Factories.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "QueueEndpoint+Factories.swift"; sourceTree = "<group>"; };
 		42AF538C180FBEEACEBAB53F /* PLCrashMachExceptionServer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PLCrashMachExceptionServer.m; path = vendor/PHPLCrashReporter/Source/PLCrashMachExceptionServer.m; sourceTree = "<group>"; };
 		42CE9EE391A5AE700A1D688F /* PLCrashReportMachineInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PLCrashReportMachineInfo.m; path = vendor/PHPLCrashReporter/Source/PLCrashReportMachineInfo.m; sourceTree = "<group>"; };
 		4360B9439C3B5722C115465A /* PLCrashReportProcessorInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PLCrashReportProcessorInfo.m; path = vendor/PHPLCrashReporter/Source/PLCrashReportProcessorInfo.m; sourceTree = "<group>"; };
@@ -784,7 +791,9 @@
 		4794C39420D22C8B91124E48 /* PLCrashAsyncDwarfCIE.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PLCrashAsyncDwarfCIE.cpp; path = vendor/PHPLCrashReporter/Source/PLCrashAsyncDwarfCIE.cpp; sourceTree = "<group>"; };
 		47D619C6488AA0E8B84944FF /* PLCrashMachExceptionPortSet.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PLCrashMachExceptionPortSet.m; path = vendor/PHPLCrashReporter/Source/PLCrashMachExceptionPortSet.m; sourceTree = "<group>"; };
 		481CB44DF30DBC62657AAC48 /* PLCrashFrameStackUnwind.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = PLCrashFrameStackUnwind.c; path = vendor/PHPLCrashReporter/Source/PLCrashFrameStackUnwind.c; sourceTree = "<group>"; };
+		4A7B59CE7B8148E5A72D554F /* LogsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsView.swift; sourceTree = "<group>"; };
 		57E2779AF27A014DB1B40BCB /* PLCrashAsyncThread_current.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = PLCrashAsyncThread_current.c; path = vendor/PHPLCrashReporter/Source/PLCrashAsyncThread_current.c; sourceTree = "<group>"; };
+		5A1B2C3D4E5F60718293A4B6 /* PostHogLogSeverity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostHogLogSeverity.swift; sourceTree = "<group>"; };
 		5B4E325C19D4C707C5FA9255 /* PLCrashAsyncDwarfFDE.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PLCrashAsyncDwarfFDE.cpp; path = vendor/PHPLCrashReporter/Source/PLCrashAsyncDwarfFDE.cpp; sourceTree = "<group>"; };
 		60CCBF99708406E47F683455 /* dwarf_opstream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = dwarf_opstream.cpp; path = vendor/PHPLCrashReporter/Source/dwarf_opstream.cpp; sourceTree = "<group>"; };
 		61B25EED847481E0988A65E3 /* PLCrashReportSymbolInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PLCrashReportSymbolInfo.m; path = vendor/PHPLCrashReporter/Source/PLCrashReportSymbolInfo.m; sourceTree = "<group>"; };
@@ -794,14 +803,11 @@
 		64544DAFC6E061EFD58C57D1 /* PLCrashReportBinaryImageInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PLCrashReportBinaryImageInfo.m; path = vendor/PHPLCrashReporter/Source/PLCrashReportBinaryImageInfo.m; sourceTree = "<group>"; };
 		64F80D1792DC64921EF42266 /* PLCrashAsyncDwarfCFAState.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PLCrashAsyncDwarfCFAState.cpp; path = vendor/PHPLCrashReporter/Source/PLCrashAsyncDwarfCFAState.cpp; sourceTree = "<group>"; };
 		68181997A5803BEDE63ABDEA /* PostHogLogRecord.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostHogLogRecord.swift; sourceTree = "<group>"; };
-		5A1B2C3D4E5F60718293A4B6 /* PostHogLogSeverity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostHogLogSeverity.swift; sourceTree = "<group>"; };
 		690B2DF22C205B5600AE3B45 /* TimeBasedEpochGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeBasedEpochGenerator.swift; sourceTree = "<group>"; };
 		690FF02F2AE7C5BA00A0B06B /* PostHogExampleWithPods.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = PostHogExampleWithPods.xcodeproj; path = PostHogExampleWithPods/PostHogExampleWithPods.xcodeproj; sourceTree = "<group>"; };
 		690FF0532AE7DB3700A0B06B /* PostHogExampleWithSPM.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = PostHogExampleWithSPM.xcodeproj; path = PostHogExampleWithSPM/PostHogExampleWithSPM.xcodeproj; sourceTree = "<group>"; };
 		690FF05E2AE7E2D400A0B06B /* Data+Gzip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Gzip.swift"; sourceTree = "<group>"; };
 		690FF0AE2AEB9C1400A0B06B /* DateUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateUtils.swift; sourceTree = "<group>"; };
-		D9CC0D1E00010000000000B1 /* BeforeSendChain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeforeSendChain.swift; sourceTree = "<group>"; };
-		D4085030E312423F8599009D /* BoxedBeforeSend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxedBeforeSend.swift; sourceTree = "<group>"; };
 		690FF0B42AEBBD3C00A0B06B /* DictUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictUtils.swift; sourceTree = "<group>"; };
 		690FF0BA2AEF8B8200A0B06B /* PostHogContextTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogContextTest.swift; sourceTree = "<group>"; };
 		690FF0BE2AEFA97F00A0B06B /* FileUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUtils.swift; sourceTree = "<group>"; };
@@ -890,6 +896,7 @@
 		8A7639E3BB936A53A6ED17AC /* PostHogLogsOTLP.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostHogLogsOTLP.swift; sourceTree = "<group>"; };
 		8AC7B7E5D1441557C48E5951 /* CrashReporterFramework.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = CrashReporterFramework.m; path = vendor/PHPLCrashReporter/Source/CrashReporterFramework.m; sourceTree = "<group>"; };
 		91792EADDC2A0458982154FC /* protobuf-c.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = "protobuf-c.c"; path = "vendor/PHPLCrashReporter/Dependencies/protobuf-c/protobuf-c/protobuf-c.c"; sourceTree = "<group>"; };
+		9473A633747872EA43FDCA3A /* SurveyTranslationResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SurveyTranslationResolver.swift; sourceTree = "<group>"; };
 		97A462C12E6F54A281DE5023 /* PLCrashProcessInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PLCrashProcessInfo.m; path = vendor/PHPLCrashReporter/Source/PLCrashProcessInfo.m; sourceTree = "<group>"; };
 		991CFA923BC02DA7DD6506C6 /* PLCrashAsyncImageList.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PLCrashAsyncImageList.cpp; path = vendor/PHPLCrashReporter/Source/PLCrashAsyncImageList.cpp; sourceTree = "<group>"; };
 		9BB480CAA746FD368A680D33 /* PLCrashAsyncThread_current.S */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm; name = PLCrashAsyncThread_current.S; path = vendor/PHPLCrashReporter/Source/PLCrashAsyncThread_current.S; sourceTree = "<group>"; };
@@ -903,14 +910,14 @@
 		A8C82A825494404A8958F15C /* PLCrashAsyncDwarfPrimitives.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PLCrashAsyncDwarfPrimitives.cpp; path = vendor/PHPLCrashReporter/Source/PLCrashAsyncDwarfPrimitives.cpp; sourceTree = "<group>"; };
 		AA43A324507226180D2483CD /* PLCrashReporterNSError.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PLCrashReporterNSError.m; path = vendor/PHPLCrashReporter/Source/PLCrashReporterNSError.m; sourceTree = "<group>"; };
 		BDAA5E5DBE9861837899D553 /* PostHogLogsConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostHogLogsConfig.swift; sourceTree = "<group>"; };
-		E5D8E83880254E4B86DEBF70 /* QueueEndpoint.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QueueEndpoint.swift; sourceTree = "<group>"; };
-		40C0C245B05D4C29890560B8 /* QueueEndpoint+Factories.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "QueueEndpoint+Factories.swift"; sourceTree = "<group>"; };
-		045078ECC7B3488DA27D06E9 /* PostHogLogger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostHogLogger.swift; sourceTree = "<group>"; };
 		C032F7F5B744465BA103BC94 /* PLCrashAsyncSymbolication.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = PLCrashAsyncSymbolication.c; path = vendor/PHPLCrashReporter/Source/PLCrashAsyncSymbolication.c; sourceTree = "<group>"; };
 		CB453C289F1DC872BE9945FC /* PLCrashAsyncCompactUnwindEncoding.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = PLCrashAsyncCompactUnwindEncoding.c; path = vendor/PHPLCrashReporter/Source/PLCrashAsyncCompactUnwindEncoding.c; sourceTree = "<group>"; };
 		CL000001CDE129010001FF00 /* PostHogFeatureFlagResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogFeatureFlagResult.swift; sourceTree = "<group>"; };
+		D4085030E312423F8599009D /* BoxedBeforeSend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxedBeforeSend.swift; sourceTree = "<group>"; };
 		D647E3BDAF428D331D684092 /* PLCrashReporterConfig.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PLCrashReporterConfig.m; path = vendor/PHPLCrashReporter/Source/PLCrashReporterConfig.m; sourceTree = "<group>"; };
+		D80D0EFDC8AA37740A78B15E /* PostHogSurveyTranslationsTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostHogSurveyTranslationsTest.swift; sourceTree = "<group>"; };
 		D81133CFD99A504078A7C854 /* PLCrashAsyncMObject.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = PLCrashAsyncMObject.c; path = vendor/PHPLCrashReporter/Source/PLCrashAsyncMObject.c; sourceTree = "<group>"; };
+		D9CC0D1E00010000000000B1 /* BeforeSendChain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeforeSendChain.swift; sourceTree = "<group>"; };
 		DA0B66792D64EC00006F5FF3 /* ph_backward_references_enc.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ph_backward_references_enc.h; sourceTree = "<group>"; };
 		DA0B667A2D64EC00006F5FF3 /* ph_bit_reader_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ph_bit_reader_utils.h; sourceTree = "<group>"; };
 		DA0B667B2D64EC00006F5FF3 /* ph_bit_writer_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ph_bit_writer_utils.h; sourceTree = "<group>"; };
@@ -1351,6 +1358,7 @@
 		DB7100022F80000100000001 /* PostHogTracingHeadersIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogTracingHeadersIntegration.swift; sourceTree = "<group>"; };
 		DB7100052F80000100000001 /* PostHogTracingHeadersTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogTracingHeadersTest.swift; sourceTree = "<group>"; };
 		DB8675A0F452E915420ED0AC /* PLCrashAsyncMachOImage.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = PLCrashAsyncMachOImage.c; path = vendor/PHPLCrashReporter/Source/PLCrashAsyncMachOImage.c; sourceTree = "<group>"; };
+		E5D8E83880254E4B86DEBF70 /* QueueEndpoint.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QueueEndpoint.swift; sourceTree = "<group>"; };
 		E8A53C31C8B0DDB72E7F1F15 /* PLCrashAsyncDwarfCFAStateEvaluation.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PLCrashAsyncDwarfCFAStateEvaluation.cpp; path = vendor/PHPLCrashReporter/Source/PLCrashAsyncDwarfCFAStateEvaluation.cpp; sourceTree = "<group>"; };
 		E8E1E01C22EB902B360AE5A3 /* PLCrashAsyncDwarfEncoding.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PLCrashAsyncDwarfEncoding.cpp; path = vendor/PHPLCrashReporter/Source/PLCrashAsyncDwarfEncoding.cpp; sourceTree = "<group>"; };
 		ECBFEE10291A87FD4E8A2E5B /* CrashReporter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = CrashReporter.m; path = vendor/PHPLCrashReporter/Source/CrashReporter.m; sourceTree = "<group>"; };
@@ -1632,6 +1640,7 @@
 				00F98E7D98CC906E4BA3D582 /* PostHogReachabilityTest.swift */,
 				275EEC0C4B14408F0D049966 /* PostHogLogsQueueTest.swift */,
 				3621762A151044A195A3A554 /* PostHogLogsCaptureTest.swift */,
+				D80D0EFDC8AA37740A78B15E /* PostHogSurveyTranslationsTest.swift */,
 			);
 			path = PostHogTests;
 			sourceTree = "<group>";
@@ -1825,6 +1834,7 @@
 				DA263D482D8039F9004C100D /* EmojiRating.swift */,
 				DA263D412D800856004C100D /* SurveyButton.swift */,
 				DA263D392D7F1054004C100D /* Resources.swift */,
+				9473A633747872EA43FDCA3A /* SurveyTranslationResolver.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1902,6 +1912,7 @@
 				DA690C692DA54BC70045FF4E /* PostHogSurveyAppearance.swift */,
 				DA690C742DA54C4B0045FF4E /* PostHogSurveyEnums.swift */,
 				DACB3ED12E0193B20061FC7D /* PostHogSurvey+Display.swift */,
+				1E41CC6ED20D266FB2357B81 /* PostHogSurveyTranslation.swift */,
 			);
 			path = Surveys;
 			sourceTree = "<group>";
@@ -2445,6 +2456,7 @@
 				DA7185452D07E11200396388 /* output_1.webp */,
 				DA7185462D07E11200396388 /* output_2.webp */,
 				DA7185472D07E11200396388 /* output_3.webp */,
+				0DD06A7329293F85392FD46C /* fixture_survey_translations.json */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -2929,6 +2941,7 @@
 				DAA5EE2D2D43605000D437E0 /* fixture_survey_basic.json in Resources */,
 				DAA5EE2E2D43605000D437E0 /* fixture_survey_branching_response_based.json in Resources */,
 				DA71854D2D07E11200396388 /* input_1.png in Resources */,
+				E89B5DEB2E380EF6D86E66A8 /* fixture_survey_translations.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3282,6 +3295,8 @@
 				F01DFEA6844945E7A794FCC9 /* QueueEndpoint+Factories.swift in Sources */,
 				8BA17B211DFE45AA8DCAD1F1 /* PostHogLogger.swift in Sources */,
 				88D516A0861C2F4F6D57CA7A /* PostHogLogsOTLP.swift in Sources */,
+				F0FBEDFF37952921D60EF57C /* PostHogSurveyTranslation.swift in Sources */,
+				9D16D700F4598774FB0A3C6F /* SurveyTranslationResolver.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3342,6 +3357,7 @@
 				8CF9034E1B95A54CD3717236 /* PostHogReachabilityTest.swift in Sources */,
 				2B66AB398C6E33DEEE924455 /* PostHogLogsQueueTest.swift in Sources */,
 				E0DDAAD7BBCC494EBAA8FE9F /* PostHogLogsCaptureTest.swift in Sources */,
+				E88BDD35158F81ACD33C3EAE /* PostHogSurveyTranslationsTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -158,6 +158,7 @@
 		A54E1C29388E43AEA3B0FC83 /* LogsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A7B59CE7B8148E5A72D554F /* LogsView.swift */; };
 		A9B17C56137763FF18EFD0C0 /* CrashReporter.m in Sources */ = {isa = PBXBuildFile; fileRef = ECBFEE10291A87FD4E8A2E5B /* CrashReporter.m */; };
 		ABB09493E02B20855285B547 /* PLCrashAsyncMObject.c in Sources */ = {isa = PBXBuildFile; fileRef = D81133CFD99A504078A7C854 /* PLCrashAsyncMObject.c */; };
+		BB04FDE3FEF9ED62590825AC /* fixture_survey_translation_noop.json in Resources */ = {isa = PBXBuildFile; fileRef = F4F3132F8AB899CDD425012C /* fixture_survey_translation_noop.json */; };
 		BE35097A002BF72D11C07FF6 /* PLCrashAsyncMachOImage.c in Sources */ = {isa = PBXBuildFile; fileRef = DB8675A0F452E915420ED0AC /* PLCrashAsyncMachOImage.c */; };
 		C1604B68CADF9BB54A3911EF /* PLCrashReportProcessInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F885D26FB2B0DE9BDAF22BF /* PLCrashReportProcessInfo.m */; };
 		C236F4F79DBF4F55B918D685 /* BoxedBeforeSend.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4085030E312423F8599009D /* BoxedBeforeSend.swift */; };
@@ -1362,6 +1363,7 @@
 		E8A53C31C8B0DDB72E7F1F15 /* PLCrashAsyncDwarfCFAStateEvaluation.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PLCrashAsyncDwarfCFAStateEvaluation.cpp; path = vendor/PHPLCrashReporter/Source/PLCrashAsyncDwarfCFAStateEvaluation.cpp; sourceTree = "<group>"; };
 		E8E1E01C22EB902B360AE5A3 /* PLCrashAsyncDwarfEncoding.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PLCrashAsyncDwarfEncoding.cpp; path = vendor/PHPLCrashReporter/Source/PLCrashAsyncDwarfEncoding.cpp; sourceTree = "<group>"; };
 		ECBFEE10291A87FD4E8A2E5B /* CrashReporter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = CrashReporter.m; path = vendor/PHPLCrashReporter/Source/CrashReporter.m; sourceTree = "<group>"; };
+		F4F3132F8AB899CDD425012C /* fixture_survey_translation_noop.json */ = {isa = PBXFileReference; includeInIndex = 1; path = fixture_survey_translation_noop.json; sourceTree = "<group>"; };
 		F78338D55B15449D9EB8507B /* PostHogRageClickConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogRageClickConfig.swift; sourceTree = "<group>"; };
 		F808F6F63C4473F4570FE32B /* PLCrashReport.pb-c.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = "PLCrashReport.pb-c.c"; path = "vendor/PHPLCrashReporter/Source/PLCrashReport.pb-c.c"; sourceTree = "<group>"; };
 		F9BB47DFE51AFE8F516B8550 /* PLCrashReportExceptionInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PLCrashReportExceptionInfo.m; path = vendor/PHPLCrashReporter/Source/PLCrashReportExceptionInfo.m; sourceTree = "<group>"; };
@@ -2457,6 +2459,7 @@
 				DA7185462D07E11200396388 /* output_2.webp */,
 				DA7185472D07E11200396388 /* output_3.webp */,
 				0DD06A7329293F85392FD46C /* fixture_survey_translations.json */,
+				F4F3132F8AB899CDD425012C /* fixture_survey_translation_noop.json */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -2942,6 +2945,7 @@
 				DAA5EE2E2D43605000D437E0 /* fixture_survey_branching_response_based.json in Resources */,
 				DA71854D2D07E11200396388 /* input_1.png in Resources */,
 				E89B5DEB2E380EF6D86E66A8 /* fixture_survey_translations.json in Resources */,
+				BB04FDE3FEF9ED62590825AC /* fixture_survey_translation_noop.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PostHog/Models/Surveys/PostHogSurvey+Display.swift
+++ b/PostHog/Models/Surveys/PostHogSurvey+Display.swift
@@ -2,66 +2,78 @@
     import Foundation
 
     extension PostHogSurvey {
-        func toDisplaySurvey() -> PostHogDisplaySurvey {
-            PostHogDisplaySurvey(
+        func toDisplaySurvey(
+            surveyTranslation: PostHogSurveyTranslation? = nil,
+            questionTranslations: [PostHogSurveyQuestionTranslation?]? = nil
+        ) -> PostHogDisplaySurvey {
+            let translatedQuestions = questions.enumerated().compactMap { index, question in
+                question.toDisplayQuestion(translation: questionTranslations?[safe: index] ?? nil)
+            }
+            return PostHogDisplaySurvey(
                 id: id,
-                name: name,
-                questions: questions.compactMap { $0.toDisplayQuestion() },
-                appearance: appearance?.toDisplayAppearance(),
+                name: surveyTranslation?.name ?? name,
+                questions: translatedQuestions,
+                appearance: appearance?.toDisplayAppearance(translation: surveyTranslation),
                 startDate: startDate,
                 endDate: endDate
             )
         }
     }
 
+    private extension Array {
+        subscript(safe index: Int) -> Element? {
+            indices.contains(index) ? self[index] : nil
+        }
+    }
+
     extension PostHogSurveyQuestion {
-        func toDisplayQuestion() -> PostHogDisplaySurveyQuestion? {
+        func toDisplayQuestion(translation: PostHogSurveyQuestionTranslation? = nil) -> PostHogDisplaySurveyQuestion? {
             switch self {
             case let .open(question):
                 return PostHogDisplayOpenQuestion(
                     id: question.id,
-                    question: question.question,
-                    questionDescription: question.description,
+                    question: translation?.question ?? question.question,
+                    questionDescription: translation?.description ?? question.description,
                     questionDescriptionContentType: question.descriptionContentType?.toDisplayContentType(),
                     isOptional: question.optional ?? false,
-                    buttonText: question.buttonText
+                    buttonText: translation?.buttonText ?? question.buttonText
                 )
 
             case let .link(question):
                 return PostHogDisplayLinkQuestion(
                     id: question.id,
-                    question: question.question,
-                    questionDescription: question.description,
+                    question: translation?.question ?? question.question,
+                    questionDescription: translation?.description ?? question.description,
                     questionDescriptionContentType: question.descriptionContentType?.toDisplayContentType(),
                     isOptional: question.optional ?? false,
-                    buttonText: question.buttonText,
-                    link: question.link ?? ""
+                    buttonText: translation?.buttonText ?? question.buttonText,
+                    link: translation?.link ?? question.link ?? ""
                 )
 
             case let .rating(question):
                 return PostHogDisplayRatingQuestion(
                     id: question.id,
-                    question: question.question,
-                    questionDescription: question.description,
+                    question: translation?.question ?? question.question,
+                    questionDescription: translation?.description ?? question.description,
                     questionDescriptionContentType: question.descriptionContentType?.toDisplayContentType(),
                     isOptional: question.optional ?? false,
-                    buttonText: question.buttonText,
+                    buttonText: translation?.buttonText ?? question.buttonText,
                     ratingType: question.display.toDisplayRatingType(),
                     scaleLowerBound: question.scale.range.lowerBound,
                     scaleUpperBound: question.scale.range.upperBound,
-                    lowerBoundLabel: question.lowerBoundLabel,
-                    upperBoundLabel: question.upperBoundLabel
+                    lowerBoundLabel: translation?.lowerBoundLabel ?? question.lowerBoundLabel,
+                    upperBoundLabel: translation?.upperBoundLabel ?? question.upperBoundLabel
                 )
 
             case let .singleChoice(question), let .multipleChoice(question):
                 return PostHogDisplayChoiceQuestion(
                     id: question.id,
-                    question: question.question,
-                    questionDescription: question.description,
+                    question: translation?.question ?? question.question,
+                    questionDescription: translation?.description ?? question.description,
                     questionDescriptionContentType: question.descriptionContentType?.toDisplayContentType(),
                     isOptional: question.optional ?? false,
-                    buttonText: question.buttonText,
-                    choices: question.choices,
+                    buttonText: translation?.buttonText ?? question.buttonText,
+                    choices: translation?.choices ?? question.choices,
                     hasOpenChoice: question.hasOpenChoice ?? false,
                     shuffleOptions: question.shuffleOptions ?? false,
                     isMultipleChoice: isMultipleChoice
@@ -99,7 +111,7 @@
     }
 
     extension PostHogSurveyAppearance {
-        func toDisplayAppearance() -> PostHogDisplaySurveyAppearance {
+        func toDisplayAppearance(translation: PostHogSurveyTranslation? = nil) -> PostHogDisplaySurveyAppearance {
             PostHogDisplaySurveyAppearance(
                 fontFamily: fontFamily,
                 backgroundColor: backgroundColor,
@@ -116,10 +128,10 @@
                 placeholder: placeholder,
                 surveyPopupDelaySeconds: surveyPopupDelaySeconds,
                 displayThankYouMessage: displayThankYouMessage ?? true,
-                thankYouMessageHeader: thankYouMessageHeader,
-                thankYouMessageDescription: thankYouMessageDescription,
+                thankYouMessageHeader: translation?.thankYouMessageHeader ?? thankYouMessageHeader,
+                thankYouMessageDescription: translation?.thankYouMessageDescription ?? thankYouMessageDescription,
                 thankYouMessageDescriptionContentType: thankYouMessageDescriptionContentType?.toDisplayContentType(),
-                thankYouMessageCloseButtonText: thankYouMessageCloseButtonText
+                thankYouMessageCloseButtonText: translation?.thankYouMessageCloseButtonText ?? thankYouMessageCloseButtonText
             )
         }
     }

--- a/PostHog/Models/Surveys/PostHogSurvey+Display.swift
+++ b/PostHog/Models/Surveys/PostHogSurvey+Display.swift
@@ -7,7 +7,8 @@
             questionTranslations: [PostHogSurveyQuestionTranslation?]? = nil
         ) -> PostHogDisplaySurvey {
             let translatedQuestions = questions.enumerated().compactMap { index, question in
-                question.toDisplayQuestion(translation: questionTranslations?[safe: index] ?? nil)
+                let translation = questionTranslations.flatMap { index < $0.count ? $0[index] : nil }
+                return question.toDisplayQuestion(translation: translation)
             }
             return PostHogDisplaySurvey(
                 id: id,
@@ -17,12 +18,6 @@
                 startDate: startDate,
                 endDate: endDate
             )
-        }
-    }
-
-    private extension Array {
-        subscript(safe index: Int) -> Element? {
-            indices.contains(index) ? self[index] : nil
         }
     }
 

--- a/PostHog/Models/Surveys/PostHogSurvey.swift
+++ b/PostHog/Models/Surveys/PostHogSurvey.swift
@@ -40,6 +40,45 @@ struct PostHogSurvey: Decodable, Identifiable {
     let endDate: Date?
     /// The schedule for the survey (optional). Determines how often the survey can be shown.
     let schedule: PostHogSurveySchedule?
+    /// Optional localized overrides keyed by language code (e.g. "fr", "pt-BR").
+    /// Applied at display time based on the resolved survey display language.
+    let translations: [String: PostHogSurveyTranslation]?
+
+    init(
+        id: String,
+        name: String,
+        type: PostHogSurveyType,
+        questions: [PostHogSurveyQuestion],
+        featureFlagKeys: [PostHogSurveyFeatureFlagKeyValue]?,
+        linkedFlagKey: String?,
+        targetingFlagKey: String?,
+        internalTargetingFlagKey: String?,
+        conditions: PostHogSurveyConditions?,
+        appearance: PostHogSurveyAppearance?,
+        currentIteration: Int?,
+        currentIterationStartDate: Date?,
+        startDate: Date?,
+        endDate: Date?,
+        schedule: PostHogSurveySchedule?,
+        translations: [String: PostHogSurveyTranslation]? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.type = type
+        self.questions = questions
+        self.featureFlagKeys = featureFlagKeys
+        self.linkedFlagKey = linkedFlagKey
+        self.targetingFlagKey = targetingFlagKey
+        self.internalTargetingFlagKey = internalTargetingFlagKey
+        self.conditions = conditions
+        self.appearance = appearance
+        self.currentIteration = currentIteration
+        self.currentIterationStartDate = currentIterationStartDate
+        self.startDate = startDate
+        self.endDate = endDate
+        self.schedule = schedule
+        self.translations = translations
+    }
 }
 
 struct PostHogSurveyFeatureFlagKeyValue: Equatable, Decodable {

--- a/PostHog/Models/Surveys/PostHogSurvey.swift
+++ b/PostHog/Models/Surveys/PostHogSurvey.swift
@@ -40,8 +40,6 @@ struct PostHogSurvey: Decodable, Identifiable {
     let endDate: Date?
     /// The schedule for the survey (optional). Determines how often the survey can be shown.
     let schedule: PostHogSurveySchedule?
-    /// Optional localized overrides keyed by language code (e.g. "fr", "pt-BR").
-    /// Applied at display time based on the resolved survey display language.
     let translations: [String: PostHogSurveyTranslation]?
 
     init(

--- a/PostHog/Models/Surveys/PostHogSurvey.swift
+++ b/PostHog/Models/Surveys/PostHogSurvey.swift
@@ -41,42 +41,6 @@ struct PostHogSurvey: Decodable, Identifiable {
     /// The schedule for the survey (optional). Determines how often the survey can be shown.
     let schedule: PostHogSurveySchedule?
     let translations: [String: PostHogSurveyTranslation]?
-
-    init(
-        id: String,
-        name: String,
-        type: PostHogSurveyType,
-        questions: [PostHogSurveyQuestion],
-        featureFlagKeys: [PostHogSurveyFeatureFlagKeyValue]?,
-        linkedFlagKey: String?,
-        targetingFlagKey: String?,
-        internalTargetingFlagKey: String?,
-        conditions: PostHogSurveyConditions?,
-        appearance: PostHogSurveyAppearance?,
-        currentIteration: Int?,
-        currentIterationStartDate: Date?,
-        startDate: Date?,
-        endDate: Date?,
-        schedule: PostHogSurveySchedule?,
-        translations: [String: PostHogSurveyTranslation]? = nil
-    ) {
-        self.id = id
-        self.name = name
-        self.type = type
-        self.questions = questions
-        self.featureFlagKeys = featureFlagKeys
-        self.linkedFlagKey = linkedFlagKey
-        self.targetingFlagKey = targetingFlagKey
-        self.internalTargetingFlagKey = internalTargetingFlagKey
-        self.conditions = conditions
-        self.appearance = appearance
-        self.currentIteration = currentIteration
-        self.currentIterationStartDate = currentIterationStartDate
-        self.startDate = startDate
-        self.endDate = endDate
-        self.schedule = schedule
-        self.translations = translations
-    }
 }
 
 struct PostHogSurveyFeatureFlagKeyValue: Equatable, Decodable {

--- a/PostHog/Models/Surveys/PostHogSurveyQuestion.swift
+++ b/PostHog/Models/Surveys/PostHogSurveyQuestion.swift
@@ -27,6 +27,9 @@ protocol PostHogSurveyQuestionProperties {
     var originalQuestionIndex: Int? { get }
     /// Question branching logic if any (optional)
     var branching: PostHogSurveyQuestionBranching? { get }
+    /// Optional localized overrides keyed by language code (e.g. "fr", "pt-BR").
+    /// Applied at display time based on the resolved survey display language.
+    var translations: [String: PostHogSurveyQuestionTranslation]? { get }
 }
 
 /// Represents different types of survey questions with their associated data
@@ -90,6 +93,10 @@ enum PostHogSurveyQuestion: PostHogSurveyQuestionProperties, Decodable {
         wrappedQuestion?.branching
     }
 
+    var translations: [String: PostHogSurveyQuestionTranslation]? {
+        wrappedQuestion?.translations
+    }
+
     private var wrappedQuestion: PostHogSurveyQuestionProperties? {
         switch self {
         case let .open(question): question
@@ -116,6 +123,29 @@ struct PostHogOpenSurveyQuestion: PostHogSurveyQuestionProperties, Decodable {
     let buttonText: String?
     let originalQuestionIndex: Int?
     let branching: PostHogSurveyQuestionBranching?
+    let translations: [String: PostHogSurveyQuestionTranslation]?
+
+    init(
+        id: String,
+        question: String,
+        description: String?,
+        descriptionContentType: PostHogSurveyTextContentType?,
+        optional: Bool?,
+        buttonText: String?,
+        originalQuestionIndex: Int?,
+        branching: PostHogSurveyQuestionBranching?,
+        translations: [String: PostHogSurveyQuestionTranslation]? = nil
+    ) {
+        self.id = id
+        self.question = question
+        self.description = description
+        self.descriptionContentType = descriptionContentType
+        self.optional = optional
+        self.buttonText = buttonText
+        self.originalQuestionIndex = originalQuestionIndex
+        self.branching = branching
+        self.translations = translations
+    }
 }
 
 /// Represents a survey question with an associated link
@@ -128,8 +158,33 @@ struct PostHogLinkSurveyQuestion: PostHogSurveyQuestionProperties, Decodable {
     let buttonText: String?
     let originalQuestionIndex: Int?
     let branching: PostHogSurveyQuestionBranching?
+    let translations: [String: PostHogSurveyQuestionTranslation]?
     /// URL link associated with the question
     let link: String?
+
+    init(
+        id: String,
+        question: String,
+        description: String?,
+        descriptionContentType: PostHogSurveyTextContentType?,
+        optional: Bool?,
+        buttonText: String?,
+        originalQuestionIndex: Int?,
+        branching: PostHogSurveyQuestionBranching?,
+        link: String?,
+        translations: [String: PostHogSurveyQuestionTranslation]? = nil
+    ) {
+        self.id = id
+        self.question = question
+        self.description = description
+        self.descriptionContentType = descriptionContentType
+        self.optional = optional
+        self.buttonText = buttonText
+        self.originalQuestionIndex = originalQuestionIndex
+        self.branching = branching
+        self.link = link
+        self.translations = translations
+    }
 }
 
 /// Represents a rating-based survey question
@@ -142,12 +197,43 @@ struct PostHogRatingSurveyQuestion: PostHogSurveyQuestionProperties, Decodable {
     let buttonText: String?
     let originalQuestionIndex: Int?
     let branching: PostHogSurveyQuestionBranching?
+    let translations: [String: PostHogSurveyQuestionTranslation]?
     /// Display type for the rating ("number" or "emoji")
     let display: PostHogSurveyRatingDisplayType
     /// Scale of the rating (3, 5, 7, or 10)
     let scale: PostHogSurveyRatingScale
     let lowerBoundLabel: String
     let upperBoundLabel: String
+
+    init(
+        id: String,
+        question: String,
+        description: String?,
+        descriptionContentType: PostHogSurveyTextContentType?,
+        optional: Bool?,
+        buttonText: String?,
+        originalQuestionIndex: Int?,
+        branching: PostHogSurveyQuestionBranching?,
+        display: PostHogSurveyRatingDisplayType,
+        scale: PostHogSurveyRatingScale,
+        lowerBoundLabel: String,
+        upperBoundLabel: String,
+        translations: [String: PostHogSurveyQuestionTranslation]? = nil
+    ) {
+        self.id = id
+        self.question = question
+        self.description = description
+        self.descriptionContentType = descriptionContentType
+        self.optional = optional
+        self.buttonText = buttonText
+        self.originalQuestionIndex = originalQuestionIndex
+        self.branching = branching
+        self.display = display
+        self.scale = scale
+        self.lowerBoundLabel = lowerBoundLabel
+        self.upperBoundLabel = upperBoundLabel
+        self.translations = translations
+    }
 }
 
 /// Represents a multiple-choice or single-choice survey question
@@ -160,12 +246,41 @@ struct PostHogMultipleSurveyQuestion: PostHogSurveyQuestionProperties, Decodable
     let buttonText: String?
     let originalQuestionIndex: Int?
     let branching: PostHogSurveyQuestionBranching?
+    let translations: [String: PostHogSurveyQuestionTranslation]?
     /// List of choices for multiple-choice or single-choice questions
     let choices: [String]
     /// Indicates if there is an open choice option (optional)
     let hasOpenChoice: Bool?
     /// Indicates if choices should be shuffled or not (optional)
     let shuffleOptions: Bool?
+
+    init(
+        id: String,
+        question: String,
+        description: String?,
+        descriptionContentType: PostHogSurveyTextContentType?,
+        optional: Bool?,
+        buttonText: String?,
+        originalQuestionIndex: Int?,
+        branching: PostHogSurveyQuestionBranching?,
+        choices: [String],
+        hasOpenChoice: Bool?,
+        shuffleOptions: Bool?,
+        translations: [String: PostHogSurveyQuestionTranslation]? = nil
+    ) {
+        self.id = id
+        self.question = question
+        self.description = description
+        self.descriptionContentType = descriptionContentType
+        self.optional = optional
+        self.buttonText = buttonText
+        self.originalQuestionIndex = originalQuestionIndex
+        self.branching = branching
+        self.choices = choices
+        self.hasOpenChoice = hasOpenChoice
+        self.shuffleOptions = shuffleOptions
+        self.translations = translations
+    }
 }
 
 /// Represents branching logic for a question based on user responses

--- a/PostHog/Models/Surveys/PostHogSurveyQuestion.swift
+++ b/PostHog/Models/Surveys/PostHogSurveyQuestion.swift
@@ -122,28 +122,6 @@ struct PostHogOpenSurveyQuestion: PostHogSurveyQuestionProperties, Decodable {
     let originalQuestionIndex: Int?
     let branching: PostHogSurveyQuestionBranching?
     let translations: [String: PostHogSurveyQuestionTranslation]?
-
-    init(
-        id: String,
-        question: String,
-        description: String?,
-        descriptionContentType: PostHogSurveyTextContentType?,
-        optional: Bool?,
-        buttonText: String?,
-        originalQuestionIndex: Int?,
-        branching: PostHogSurveyQuestionBranching?,
-        translations: [String: PostHogSurveyQuestionTranslation]? = nil
-    ) {
-        self.id = id
-        self.question = question
-        self.description = description
-        self.descriptionContentType = descriptionContentType
-        self.optional = optional
-        self.buttonText = buttonText
-        self.originalQuestionIndex = originalQuestionIndex
-        self.branching = branching
-        self.translations = translations
-    }
 }
 
 /// Represents a survey question with an associated link
@@ -159,30 +137,6 @@ struct PostHogLinkSurveyQuestion: PostHogSurveyQuestionProperties, Decodable {
     let translations: [String: PostHogSurveyQuestionTranslation]?
     /// URL link associated with the question
     let link: String?
-
-    init(
-        id: String,
-        question: String,
-        description: String?,
-        descriptionContentType: PostHogSurveyTextContentType?,
-        optional: Bool?,
-        buttonText: String?,
-        originalQuestionIndex: Int?,
-        branching: PostHogSurveyQuestionBranching?,
-        link: String?,
-        translations: [String: PostHogSurveyQuestionTranslation]? = nil
-    ) {
-        self.id = id
-        self.question = question
-        self.description = description
-        self.descriptionContentType = descriptionContentType
-        self.optional = optional
-        self.buttonText = buttonText
-        self.originalQuestionIndex = originalQuestionIndex
-        self.branching = branching
-        self.link = link
-        self.translations = translations
-    }
 }
 
 /// Represents a rating-based survey question
@@ -202,36 +156,6 @@ struct PostHogRatingSurveyQuestion: PostHogSurveyQuestionProperties, Decodable {
     let scale: PostHogSurveyRatingScale
     let lowerBoundLabel: String
     let upperBoundLabel: String
-
-    init(
-        id: String,
-        question: String,
-        description: String?,
-        descriptionContentType: PostHogSurveyTextContentType?,
-        optional: Bool?,
-        buttonText: String?,
-        originalQuestionIndex: Int?,
-        branching: PostHogSurveyQuestionBranching?,
-        display: PostHogSurveyRatingDisplayType,
-        scale: PostHogSurveyRatingScale,
-        lowerBoundLabel: String,
-        upperBoundLabel: String,
-        translations: [String: PostHogSurveyQuestionTranslation]? = nil
-    ) {
-        self.id = id
-        self.question = question
-        self.description = description
-        self.descriptionContentType = descriptionContentType
-        self.optional = optional
-        self.buttonText = buttonText
-        self.originalQuestionIndex = originalQuestionIndex
-        self.branching = branching
-        self.display = display
-        self.scale = scale
-        self.lowerBoundLabel = lowerBoundLabel
-        self.upperBoundLabel = upperBoundLabel
-        self.translations = translations
-    }
 }
 
 /// Represents a multiple-choice or single-choice survey question
@@ -251,34 +175,6 @@ struct PostHogMultipleSurveyQuestion: PostHogSurveyQuestionProperties, Decodable
     let hasOpenChoice: Bool?
     /// Indicates if choices should be shuffled or not (optional)
     let shuffleOptions: Bool?
-
-    init(
-        id: String,
-        question: String,
-        description: String?,
-        descriptionContentType: PostHogSurveyTextContentType?,
-        optional: Bool?,
-        buttonText: String?,
-        originalQuestionIndex: Int?,
-        branching: PostHogSurveyQuestionBranching?,
-        choices: [String],
-        hasOpenChoice: Bool?,
-        shuffleOptions: Bool?,
-        translations: [String: PostHogSurveyQuestionTranslation]? = nil
-    ) {
-        self.id = id
-        self.question = question
-        self.description = description
-        self.descriptionContentType = descriptionContentType
-        self.optional = optional
-        self.buttonText = buttonText
-        self.originalQuestionIndex = originalQuestionIndex
-        self.branching = branching
-        self.choices = choices
-        self.hasOpenChoice = hasOpenChoice
-        self.shuffleOptions = shuffleOptions
-        self.translations = translations
-    }
 }
 
 /// Represents branching logic for a question based on user responses

--- a/PostHog/Models/Surveys/PostHogSurveyQuestion.swift
+++ b/PostHog/Models/Surveys/PostHogSurveyQuestion.swift
@@ -27,8 +27,6 @@ protocol PostHogSurveyQuestionProperties {
     var originalQuestionIndex: Int? { get }
     /// Question branching logic if any (optional)
     var branching: PostHogSurveyQuestionBranching? { get }
-    /// Optional localized overrides keyed by language code (e.g. "fr", "pt-BR").
-    /// Applied at display time based on the resolved survey display language.
     var translations: [String: PostHogSurveyQuestionTranslation]? { get }
 }
 

--- a/PostHog/Models/Surveys/PostHogSurveyTranslation.swift
+++ b/PostHog/Models/Surveys/PostHogSurveyTranslation.swift
@@ -7,14 +7,10 @@
 
 import Foundation
 
-/// Localized overrides for a survey's user-visible strings.
+/// Localized overrides for a survey, keyed by language code (e.g. `"fr"`, `"pt-BR"`).
 ///
-/// Attached to `PostHogSurvey.translations` as a map keyed by language code
-/// (e.g. `"fr"`, `"pt-BR"`). All fields are optional — missing fields fall back to the
-/// original survey value.
-///
-/// Note: the survey-level `description` is intentionally NOT translatable. It is only
-/// used for internal previews and never rendered to end users.
+/// The survey-level `description` is intentionally NOT translatable — it is only used
+/// for internal previews and never rendered to end users.
 struct PostHogSurveyTranslation: Decodable {
     let name: String?
     let thankYouMessageHeader: String?
@@ -22,11 +18,11 @@ struct PostHogSurveyTranslation: Decodable {
     let thankYouMessageCloseButtonText: String?
 }
 
-/// Localized overrides for a survey question's user-visible strings.
+/// Localized overrides for a survey question.
 ///
-/// Attached to each `PostHogSurveyQuestion`-conforming struct as a map keyed by
-/// language code. All fields are optional. Fields irrelevant to a given question type
-/// (e.g. `choices` on a rating question) are ignored.
+/// Fields are a superset across question types: `link` only applies to link questions,
+/// `lowerBoundLabel` / `upperBoundLabel` only to rating questions, and `choices` only
+/// to single/multiple choice questions. Irrelevant fields are ignored for other types.
 struct PostHogSurveyQuestionTranslation: Decodable {
     let question: String?
     let description: String?

--- a/PostHog/Models/Surveys/PostHogSurveyTranslation.swift
+++ b/PostHog/Models/Surveys/PostHogSurveyTranslation.swift
@@ -1,0 +1,38 @@
+//
+//  PostHogSurveyTranslation.swift
+//  PostHog
+//
+//  Created by PostHog Code on 2026-05-13.
+//
+
+import Foundation
+
+/// Localized overrides for a survey's user-visible strings.
+///
+/// Attached to `PostHogSurvey.translations` as a map keyed by language code
+/// (e.g. `"fr"`, `"pt-BR"`). All fields are optional — missing fields fall back to the
+/// original survey value.
+///
+/// Note: the survey-level `description` is intentionally NOT translatable. It is only
+/// used for internal previews and never rendered to end users.
+struct PostHogSurveyTranslation: Decodable {
+    let name: String?
+    let thankYouMessageHeader: String?
+    let thankYouMessageDescription: String?
+    let thankYouMessageCloseButtonText: String?
+}
+
+/// Localized overrides for a survey question's user-visible strings.
+///
+/// Attached to each `PostHogSurveyQuestion`-conforming struct as a map keyed by
+/// language code. All fields are optional. Fields irrelevant to a given question type
+/// (e.g. `choices` on a rating question) are ignored.
+struct PostHogSurveyQuestionTranslation: Decodable {
+    let question: String?
+    let description: String?
+    let buttonText: String?
+    let link: String?
+    let lowerBoundLabel: String?
+    let upperBoundLabel: String?
+    let choices: [String]?
+}

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -673,7 +673,7 @@ class PostHogRemoteConfig {
         }
     }
 
-    private func getPersonPropertiesForFlags() -> [String: Any] {
+    func getPersonPropertiesForFlags() -> [String: Any] {
         personPropertiesForFlagsLock.withLock {
             var properties = personPropertiesForFlags
 

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -1082,12 +1082,32 @@
                 sendSurveyShownEvent(survey: survey, language: language)
             }
 
-            func testSendSurveySentEvent(survey: PostHogSurvey, responses: [String: PostHogSurveyResponse], language: String? = nil) {
-                sendSurveySentEvent(survey: survey, responses: responses, language: language)
+            func testSendSurveySentEvent(
+                survey: PostHogSurvey,
+                responses: [String: PostHogSurveyResponse],
+                language: String? = nil,
+                questionTranslations: [PostHogSurveyQuestionTranslation?]? = nil
+            ) {
+                sendSurveySentEvent(
+                    survey: survey,
+                    responses: responses,
+                    language: language,
+                    questionTranslations: questionTranslations
+                )
             }
 
-            func testSendSurveyDismissedEvent(survey: PostHogSurvey, responses: [String: PostHogSurveyResponse] = [:], language: String? = nil) {
-                sendSurveyDismissedEvent(survey: survey, responses: responses, language: language)
+            func testSendSurveyDismissedEvent(
+                survey: PostHogSurvey,
+                responses: [String: PostHogSurveyResponse] = [:],
+                language: String? = nil,
+                questionTranslations: [PostHogSurveyQuestionTranslation?]? = nil
+            ) {
+                sendSurveyDismissedEvent(
+                    survey: survey,
+                    responses: responses,
+                    language: language,
+                    questionTranslations: questionTranslations
+                )
             }
 
             func testGetBaseSurveyEventProperties(for survey: PostHogSurvey) -> [String: Any] {

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -570,7 +570,11 @@
             )
         }
 
-        /// Sends a `survey sent` event with all collected responses.
+        /// Sends a `survey sent` event to PostHog instance
+        /// Sends a survey completion event to PostHog with all collected responses
+        /// - Parameters:
+        ///   - survey: The completed survey
+        ///   - responses: Dictionary of collected responses for each question
         private func sendSurveySentEvent(
             survey: PostHogSurvey,
             responses: [String: PostHogSurveyResponse],

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -293,11 +293,8 @@
                 // Check if there is a new popover surveys to be displayed
                 getActiveMatchingSurveys { activeSurveys in
                     if let survey = activeSurveys.first(where: self.canRenderSurvey) {
-                        // resolve the user's language once, apply translations to a display copy
                         let language = self.resolveDisplayLanguage()
                         let translations = resolveSurveyTranslations(survey: survey, targetLanguage: language)
-
-                        // set survey as active, stamping the matched language + per-question translations for events
                         self.setActiveSurvey(survey: survey, language: translations.matchedKey, questionTranslations: translations.questions)
 
                         DispatchQueue.main.async { [weak self] in
@@ -573,12 +570,7 @@
             )
         }
 
-        /// Sends a `survey sent` event to PostHog instance
-        /// Sends a survey completion event to PostHog with all collected responses
-        /// - Parameters:
-        ///   - survey: The completed survey
-        ///   - responses: Dictionary of collected responses for each question
-        ///   - language: The resolved survey display language (matched key from `translations`), or nil
+        /// Sends a `survey sent` event with all collected responses.
         private func sendSurveySentEvent(
             survey: PostHogSurvey,
             responses: [String: PostHogSurveyResponse],
@@ -737,13 +729,10 @@
             }
         }
 
-        /// Resolves the language to use for the next survey display. Priority chain:
-        ///   1. `PostHogSurveysConfig.overrideDisplayLanguage`
-        ///   2. The `"language"` person property persisted by `identify()`
-        ///   3. The device locale (BCP-47 form — underscores converted to hyphens)
         private func resolveDisplayLanguage() -> String? {
-            // `surveysConfig` is `@available(macOS, unavailable)` — use the package-internal
-            // backing property to stay compilable across all SwiftPM platforms.
+            // `surveysConfig` is `@available(macOS, unavailable)`, but this integration is
+            // also compiled for non-iOS targets under TESTING. Read the backing property
+            // directly so the file stays compilable on every platform.
             let override = config?._surveysConfig.overrideDisplayLanguage
             let personProperties = storage?.getDictionary(forKey: .personPropertiesForFlags) as? [String: Any]
             let rawLocale = Locale.current.identifier

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -47,6 +47,7 @@
         private var activeSurveyLock = NSLock()
         private var activeSurvey: PostHogSurvey?
         private var activeSurveyLanguage: String?
+        private var activeSurveyQuestionTranslations: [PostHogSurveyQuestionTranslation?]?
         private var activeSurveyResponses: [String: PostHogSurveyResponse] = [:] // keyed by question identifier
         private var activeSurveyCompleted: Bool = false
         private var activeSurveyQuestionIndex: Int = 0
@@ -296,8 +297,8 @@
                         let language = self.resolveDisplayLanguage()
                         let translations = resolveSurveyTranslations(survey: survey, targetLanguage: language)
 
-                        // set survey as active, stamping the matched language for events
-                        self.setActiveSurvey(survey: survey, language: translations.matchedKey)
+                        // set survey as active, stamping the matched language + per-question translations for events
+                        self.setActiveSurvey(survey: survey, language: translations.matchedKey, questionTranslations: translations.questions)
 
                         DispatchQueue.main.async { [weak self] in
                             if let self {
@@ -465,8 +466,8 @@
         ///   - response: The user's response to the current question
         /// - Returns: The next question to display based on branching logic, or nil if there was an error
         private func handleSurveyResponse(survey: PostHogDisplaySurvey, index: Int, response: PostHogSurveyResponse) -> PostHogNextSurveyQuestion? {
-            let (activeSurvey, activeSurveyQuestionIndex, activeSurveyLanguage) = activeSurveyLock.withLock {
-                (self.activeSurvey, self.activeSurveyQuestionIndex, self.activeSurveyLanguage)
+            let (activeSurvey, activeSurveyQuestionIndex, activeSurveyLanguage, activeSurveyQuestionTranslations) = activeSurveyLock.withLock {
+                (self.activeSurvey, self.activeSurveyQuestionIndex, self.activeSurveyLanguage, self.activeSurveyQuestionTranslations)
             }
 
             guard let activeSurvey, survey.id == activeSurvey.id else {
@@ -507,7 +508,12 @@
             // send event if needed
             // TODO: Partial responses
             if isCompleted {
-                sendSurveySentEvent(survey: activeSurvey, responses: allResponses, language: activeSurveyLanguage)
+                sendSurveySentEvent(
+                    survey: activeSurvey,
+                    responses: allResponses,
+                    language: activeSurveyLanguage,
+                    questionTranslations: activeSurveyQuestionTranslations
+                )
             }
 
             return nextSurveyQuestion
@@ -515,8 +521,20 @@
 
         /// Handle a survey dismiss
         private func handleSurveyClosed(survey: PostHogDisplaySurvey) {
-            let (activeSurvey, activeSurveyCompleted, activeSurveyResponses, activeSurveyLanguage) = activeSurveyLock.withLock {
-                (self.activeSurvey, self.activeSurveyCompleted, self.activeSurveyResponses, self.activeSurveyLanguage)
+            let (
+                activeSurvey,
+                activeSurveyCompleted,
+                activeSurveyResponses,
+                activeSurveyLanguage,
+                activeSurveyQuestionTranslations
+            ) = activeSurveyLock.withLock {
+                (
+                    self.activeSurvey,
+                    self.activeSurveyCompleted,
+                    self.activeSurveyResponses,
+                    self.activeSurveyLanguage,
+                    self.activeSurveyQuestionTranslations
+                )
             }
 
             guard let activeSurvey, survey.id == activeSurvey.id else {
@@ -526,7 +544,12 @@
 
             // send survey dismissed event if needed
             if !activeSurveyCompleted {
-                sendSurveyDismissedEvent(survey: activeSurvey, responses: activeSurveyResponses, language: activeSurveyLanguage)
+                sendSurveyDismissedEvent(
+                    survey: activeSurvey,
+                    responses: activeSurveyResponses,
+                    language: activeSurveyLanguage,
+                    questionTranslations: activeSurveyQuestionTranslations
+                )
             }
 
             // mark as seen
@@ -556,8 +579,17 @@
         ///   - survey: The completed survey
         ///   - responses: Dictionary of collected responses for each question
         ///   - language: The resolved survey display language (matched key from `translations`), or nil
-        private func sendSurveySentEvent(survey: PostHogSurvey, responses: [String: PostHogSurveyResponse], language: String? = nil) {
-            let additionalProperties = buildSurveyResponseProperties(survey: survey, responses: responses).merging(
+        private func sendSurveySentEvent(
+            survey: PostHogSurvey,
+            responses: [String: PostHogSurveyResponse],
+            language: String? = nil,
+            questionTranslations: [PostHogSurveyQuestionTranslation?]? = nil
+        ) {
+            let additionalProperties = buildSurveyResponseProperties(
+                survey: survey,
+                responses: responses,
+                questionTranslations: questionTranslations
+            ).merging(
                 [
                     "$set": [getSurveyInteractionProperty(survey: survey, property: "responded"): true],
                 ],
@@ -573,8 +605,17 @@
         }
 
         /// Sends a `survey dismissed` event to PostHog instance
-        private func sendSurveyDismissedEvent(survey: PostHogSurvey, responses: [String: PostHogSurveyResponse], language: String? = nil) {
-            let additionalProperties = buildSurveyResponseProperties(survey: survey, responses: responses).merging(
+        private func sendSurveyDismissedEvent(
+            survey: PostHogSurvey,
+            responses: [String: PostHogSurveyResponse],
+            language: String? = nil,
+            questionTranslations: [PostHogSurveyQuestionTranslation?]? = nil
+        ) {
+            let additionalProperties = buildSurveyResponseProperties(
+                survey: survey,
+                responses: responses,
+                questionTranslations: questionTranslations
+            ).merging(
                 [
                     "$survey_partially_completed": surveyHasResponses(responses),
                     "$set": [
@@ -594,15 +635,22 @@
 
         private func buildSurveyResponseProperties(
             survey: PostHogSurvey,
-            responses: [String: PostHogSurveyResponse]
+            responses: [String: PostHogSurveyResponse],
+            questionTranslations: [PostHogSurveyQuestionTranslation?]? = nil
         ) -> [String: Any] {
             let responsesProperties: [String: Any] = responses.compactMapValues { getSurveyResponseValue(for: $0) }
 
             let surveyQuestions = survey.questions.enumerated().map { index, question in
                 let responseKey = question.id.isEmpty ? getOldResponseKey(for: index) : getNewResponseKey(for: question.id)
+                // Use translated question text (if applied) so $survey_questions matches what the user saw.
+                let translatedText: String? = {
+                    guard let translations = questionTranslations, translations.indices.contains(index) else { return nil }
+                    return translations[index]?.question
+                }()
+                let effectiveQuestion = translatedText ?? question.question
                 var questionData: [String: Any] = [
                     "id": question.id,
-                    "question": question.question,
+                    "question": effectiveQuestion,
                 ]
 
                 if let response = responsesProperties[responseKey] {
@@ -665,11 +713,12 @@
             return surveyProperty
         }
 
-        private func setActiveSurvey(survey: PostHogSurvey, language: String? = nil) {
+        private func setActiveSurvey(survey: PostHogSurvey, language: String? = nil, questionTranslations: [PostHogSurveyQuestionTranslation?]? = nil) {
             activeSurveyLock.withLock {
                 if activeSurvey == nil {
                     activeSurvey = survey
                     activeSurveyLanguage = language
+                    activeSurveyQuestionTranslations = questionTranslations
                     activeSurveyCompleted = false
                     activeSurveyResponses = [:]
                     activeSurveyQuestionIndex = 0
@@ -681,6 +730,7 @@
             activeSurveyLock.withLock {
                 activeSurvey = nil
                 activeSurveyLanguage = nil
+                activeSurveyQuestionTranslations = nil
                 activeSurveyCompleted = false
                 activeSurveyResponses = [:]
                 activeSurveyQuestionIndex = 0

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -46,6 +46,7 @@
 
         private var activeSurveyLock = NSLock()
         private var activeSurvey: PostHogSurvey?
+        private var activeSurveyLanguage: String?
         private var activeSurveyResponses: [String: PostHogSurveyResponse] = [:] // keyed by question identifier
         private var activeSurveyCompleted: Bool = false
         private var activeSurveyQuestionIndex: Int = 0
@@ -291,14 +292,21 @@
                 // Check if there is a new popover surveys to be displayed
                 getActiveMatchingSurveys { activeSurveys in
                     if let survey = activeSurveys.first(where: self.canRenderSurvey) {
-                        // set survey as active
-                        self.setActiveSurvey(survey: survey)
+                        // resolve the user's language once, apply translations to a display copy
+                        let language = self.resolveDisplayLanguage()
+                        let translations = resolveSurveyTranslations(survey: survey, targetLanguage: language)
+
+                        // set survey as active, stamping the matched language for events
+                        self.setActiveSurvey(survey: survey, language: translations.matchedKey)
 
                         DispatchQueue.main.async { [weak self] in
                             if let self {
                                 // render the survey
                                 self.postHog?.config.surveysConfig.surveysDelegate.renderSurvey(
-                                    survey.toDisplaySurvey(),
+                                    survey.toDisplaySurvey(
+                                        surveyTranslation: translations.survey,
+                                        questionTranslations: translations.questions
+                                    ),
                                     onSurveyShown: self.handleSurveyShown,
                                     onSurveyResponse: self.handleSurveyResponse,
                                     onSurveyClosed: self.handleSurveyClosed
@@ -432,14 +440,14 @@
 
         /// Handle a survey that is shown
         private func handleSurveyShown(survey: PostHogDisplaySurvey) {
-            let activeSurvey = activeSurveyLock.withLock { self.activeSurvey }
+            let (activeSurvey, language) = activeSurveyLock.withLock { (self.activeSurvey, self.activeSurveyLanguage) }
 
             guard let activeSurvey, survey.id == activeSurvey.id else {
                 hedgeLog("[Surveys] Received a show event for a non-active survey")
                 return
             }
 
-            sendSurveyShownEvent(survey: activeSurvey)
+            sendSurveyShownEvent(survey: activeSurvey, language: language)
 
             // clear up event-activated surveys
             if activeSurvey.hasEvents {
@@ -457,7 +465,9 @@
         ///   - response: The user's response to the current question
         /// - Returns: The next question to display based on branching logic, or nil if there was an error
         private func handleSurveyResponse(survey: PostHogDisplaySurvey, index: Int, response: PostHogSurveyResponse) -> PostHogNextSurveyQuestion? {
-            let (activeSurvey, activeSurveyQuestionIndex) = activeSurveyLock.withLock { (self.activeSurvey, self.activeSurveyQuestionIndex) }
+            let (activeSurvey, activeSurveyQuestionIndex, activeSurveyLanguage) = activeSurveyLock.withLock {
+                (self.activeSurvey, self.activeSurveyQuestionIndex, self.activeSurveyLanguage)
+            }
 
             guard let activeSurvey, survey.id == activeSurvey.id else {
                 hedgeLog("[Surveys] Received a response event for a non-active survey")
@@ -497,7 +507,7 @@
             // send event if needed
             // TODO: Partial responses
             if isCompleted {
-                sendSurveySentEvent(survey: activeSurvey, responses: allResponses)
+                sendSurveySentEvent(survey: activeSurvey, responses: allResponses, language: activeSurveyLanguage)
             }
 
             return nextSurveyQuestion
@@ -505,8 +515,8 @@
 
         /// Handle a survey dismiss
         private func handleSurveyClosed(survey: PostHogDisplaySurvey) {
-            let (activeSurvey, activeSurveyCompleted, activeSurveyResponses) = activeSurveyLock.withLock {
-                (self.activeSurvey, self.activeSurveyCompleted, self.activeSurveyResponses)
+            let (activeSurvey, activeSurveyCompleted, activeSurveyResponses, activeSurveyLanguage) = activeSurveyLock.withLock {
+                (self.activeSurvey, self.activeSurveyCompleted, self.activeSurveyResponses, self.activeSurveyLanguage)
             }
 
             guard let activeSurvey, survey.id == activeSurvey.id else {
@@ -516,7 +526,7 @@
 
             // send survey dismissed event if needed
             if !activeSurveyCompleted {
-                sendSurveyDismissedEvent(survey: activeSurvey, responses: activeSurveyResponses)
+                sendSurveyDismissedEvent(survey: activeSurvey, responses: activeSurveyResponses, language: activeSurveyLanguage)
             }
 
             // mark as seen
@@ -532,10 +542,11 @@
         }
 
         /// Sends a `survey shown` event to PostHog instance
-        private func sendSurveyShownEvent(survey: PostHogSurvey) {
+        private func sendSurveyShownEvent(survey: PostHogSurvey, language: String? = nil) {
             sendSurveyEvent(
                 event: "survey shown",
-                survey: survey
+                survey: survey,
+                language: language
             )
         }
 
@@ -544,7 +555,8 @@
         /// - Parameters:
         ///   - survey: The completed survey
         ///   - responses: Dictionary of collected responses for each question
-        private func sendSurveySentEvent(survey: PostHogSurvey, responses: [String: PostHogSurveyResponse]) {
+        ///   - language: The resolved survey display language (matched key from `translations`), or nil
+        private func sendSurveySentEvent(survey: PostHogSurvey, responses: [String: PostHogSurveyResponse], language: String? = nil) {
             let additionalProperties = buildSurveyResponseProperties(survey: survey, responses: responses).merging(
                 [
                     "$set": [getSurveyInteractionProperty(survey: survey, property: "responded"): true],
@@ -555,12 +567,13 @@
             sendSurveyEvent(
                 event: "survey sent",
                 survey: survey,
-                additionalProperties: additionalProperties
+                additionalProperties: additionalProperties,
+                language: language
             )
         }
 
         /// Sends a `survey dismissed` event to PostHog instance
-        private func sendSurveyDismissedEvent(survey: PostHogSurvey, responses: [String: PostHogSurveyResponse]) {
+        private func sendSurveyDismissedEvent(survey: PostHogSurvey, responses: [String: PostHogSurveyResponse], language: String? = nil) {
             let additionalProperties = buildSurveyResponseProperties(survey: survey, responses: responses).merging(
                 [
                     "$survey_partially_completed": surveyHasResponses(responses),
@@ -574,7 +587,8 @@
             sendSurveyEvent(
                 event: "survey dismissed",
                 survey: survey,
-                additionalProperties: additionalProperties
+                additionalProperties: additionalProperties,
+                language: language
             )
         }
 
@@ -615,7 +629,7 @@
             }
         }
 
-        private func sendSurveyEvent(event: String, survey: PostHogSurvey, additionalProperties: [String: Any] = [:]) {
+        private func sendSurveyEvent(event: String, survey: PostHogSurvey, additionalProperties: [String: Any] = [:], language: String? = nil) {
             guard let postHog else {
                 hedgeLog("[\(event)] event not captured, PostHog instance not found.")
                 return
@@ -623,6 +637,9 @@
 
             var properties = getBaseSurveyEventProperties(for: survey)
             properties.merge(additionalProperties) { _, new in new }
+            if let language, !language.isEmpty {
+                properties["$survey_language"] = language
+            }
 
             postHog.capture(event, properties: properties)
         }
@@ -648,10 +665,11 @@
             return surveyProperty
         }
 
-        private func setActiveSurvey(survey: PostHogSurvey) {
+        private func setActiveSurvey(survey: PostHogSurvey, language: String? = nil) {
             activeSurveyLock.withLock {
                 if activeSurvey == nil {
                     activeSurvey = survey
+                    activeSurveyLanguage = language
                     activeSurveyCompleted = false
                     activeSurveyResponses = [:]
                     activeSurveyQuestionIndex = 0
@@ -662,10 +680,29 @@
         private func clearActiveSurvey() {
             activeSurveyLock.withLock {
                 activeSurvey = nil
+                activeSurveyLanguage = nil
                 activeSurveyCompleted = false
                 activeSurveyResponses = [:]
                 activeSurveyQuestionIndex = 0
             }
+        }
+
+        /// Resolves the language to use for the next survey display. Priority chain:
+        ///   1. `PostHogSurveysConfig.overrideDisplayLanguage`
+        ///   2. The `"language"` person property persisted by `identify()`
+        ///   3. The device locale (BCP-47 form — underscores converted to hyphens)
+        private func resolveDisplayLanguage() -> String? {
+            // `surveysConfig` is `@available(macOS, unavailable)` — use the package-internal
+            // backing property to stay compilable across all SwiftPM platforms.
+            let override = config?._surveysConfig.overrideDisplayLanguage
+            let personProperties = storage?.getDictionary(forKey: .personPropertiesForFlags) as? [String: Any]
+            let rawLocale = Locale.current.identifier
+            let deviceLocale = rawLocale.replacingOccurrences(of: "_", with: "-")
+            return detectSurveyLanguage(
+                overrideLanguage: override,
+                personProperties: personProperties,
+                deviceLocale: deviceLocale
+            )
         }
 
         /// Stores a response for the current question in the active survey, and returns updated responses
@@ -998,16 +1035,16 @@
                 return nil
             }
 
-            func testSendSurveyShownEvent(survey: PostHogSurvey) {
-                sendSurveyShownEvent(survey: survey)
+            func testSendSurveyShownEvent(survey: PostHogSurvey, language: String? = nil) {
+                sendSurveyShownEvent(survey: survey, language: language)
             }
 
-            func testSendSurveySentEvent(survey: PostHogSurvey, responses: [String: PostHogSurveyResponse]) {
-                sendSurveySentEvent(survey: survey, responses: responses)
+            func testSendSurveySentEvent(survey: PostHogSurvey, responses: [String: PostHogSurveyResponse], language: String? = nil) {
+                sendSurveySentEvent(survey: survey, responses: responses, language: language)
             }
 
-            func testSendSurveyDismissedEvent(survey: PostHogSurvey, responses: [String: PostHogSurveyResponse] = [:]) {
-                sendSurveyDismissedEvent(survey: survey, responses: responses)
+            func testSendSurveyDismissedEvent(survey: PostHogSurvey, responses: [String: PostHogSurveyResponse] = [:], language: String? = nil) {
+                sendSurveyDismissedEvent(survey: survey, responses: responses, language: language)
             }
 
             func testGetBaseSurveyEventProperties(for survey: PostHogSurvey) -> [String: Any] {

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -738,7 +738,7 @@
             // also compiled for non-iOS targets under TESTING. Read the backing property
             // directly so the file stays compilable on every platform.
             let override = config?._surveysConfig.overrideDisplayLanguage
-            let personProperties = storage?.getDictionary(forKey: .personPropertiesForFlags) as? [String: Any]
+            let personProperties = remoteConfig?.getPersonPropertiesForFlags()
             let rawLocale = Locale.current.identifier
             let deviceLocale = rawLocale.replacingOccurrences(of: "_", with: "-")
             return detectSurveyLanguage(

--- a/PostHog/Surveys/PostHogSurveysConfig.swift
+++ b/PostHog/Surveys/PostHogSurveysConfig.swift
@@ -14,6 +14,20 @@ import Foundation
     ///
     /// Defaults to `PostHogSurveysDefaultDelegate` which provides a standard survey UI.
     public var surveysDelegate: PostHogSurveysDelegate = PostHogSurveysDefaultDelegate()
+
+    /// Optional explicit override for the language used when rendering surveys.
+    ///
+    /// When set, surveys with matching entries in `translations` will be rendered in
+    /// this language regardless of the device locale or any `language` person property.
+    ///
+    /// Format: a language tag such as `"fr"`, `"pt-BR"`, `"zh-CN"`. Matching is
+    /// case-insensitive and falls back to the base language (e.g. `"pt"` if `"pt-BR"`
+    /// is requested but only `"pt"` is provided).
+    ///
+    /// Blank or `nil` values are treated as unset.
+    ///
+    /// Default: `nil`.
+    @objc public var overrideDisplayLanguage: String?
 }
 
 /// To be called when a survey is successfully shown to the user

--- a/PostHog/Surveys/Utils/SurveyTranslationResolver.swift
+++ b/PostHog/Surveys/Utils/SurveyTranslationResolver.swift
@@ -111,9 +111,8 @@
         let surveyTranslation = surveyKey.flatMap { survey.translations?[$0] }
         let surveyChanged = surveyTranslation.map { surveyTranslationChangesAnything(survey: survey, translation: $0) } ?? false
 
-        var anyQuestionChanged = false
+        var firstQuestionKey: String?
         var questionTranslations: [PostHogSurveyQuestionTranslation?] = []
-        var questionKeys: [String?] = []
         for question in survey.questions {
             let key = findBestTranslationMatch(
                 translations: question.translations,
@@ -121,24 +120,16 @@
             )
             let translation = key.flatMap { question.translations?[$0] }
             let changes = translation.map { questionTranslationChangesAnything(question: question, translation: $0) } ?? false
-            if changes {
-                anyQuestionChanged = true
-                questionTranslations.append(translation)
-                questionKeys.append(key)
-            } else {
-                questionTranslations.append(nil)
-                questionKeys.append(nil)
-            }
+            questionTranslations.append(changes ? translation : nil)
+            if changes, firstQuestionKey == nil { firstQuestionKey = key }
         }
 
-        if !surveyChanged, !anyQuestionChanged { return empty }
+        if !surveyChanged, firstQuestionKey == nil { return empty }
 
-        let matchedKey: String?
-        if surveyChanged {
-            matchedKey = surveyKey
-        } else {
-            matchedKey = questionKeys.compactMap { $0 }.first
-        }
+        // Prefer the survey-level key if it actually drove a change; otherwise fall back
+        // to whichever question's translation key did. In the common case both refer to
+        // the same target language and the choice is purely cosmetic.
+        let matchedKey = surveyChanged ? surveyKey : firstQuestionKey
 
         return ResolvedSurveyTranslations(
             matchedKey: matchedKey,

--- a/PostHog/Surveys/Utils/SurveyTranslationResolver.swift
+++ b/PostHog/Surveys/Utils/SurveyTranslationResolver.swift
@@ -9,14 +9,10 @@
 
     import Foundation
 
-    /// Outcome of resolving translations for one survey at display time.
-    ///
-    /// - `matchedKey`: the original-cased key from a `translations` dictionary that drove
-    ///   the change (preferring the survey-level key when both survey and question matched).
-    ///   `nil` when no translation was applied at all.
-    /// - `survey`: the resolved survey-level translation, or `nil` if none matched.
-    /// - `questions`: per-question translation, indexed positionally against
-    ///   `survey.questions`. `nil` entries leave the question untranslated.
+    /// `matchedKey` is the original-cased key from a `translations` dictionary that drove
+    /// the change (preferring the survey-level key when both survey and question matched),
+    /// or `nil` when no user-visible field actually changed. `questions` is indexed
+    /// positionally against `survey.questions`.
     struct ResolvedSurveyTranslations {
         let matchedKey: String?
         let survey: PostHogSurveyTranslation?
@@ -89,10 +85,9 @@
         return nil
     }
 
-    /// Resolves which translations should be applied to `survey` given the user's
-    /// `targetLanguage`. Tracks whether the resolution actually changed any user-visible
-    /// field; if not, `matchedKey` is `nil` so callers don't mistakenly stamp
-    /// `$survey_language` onto events.
+    /// Returns a non-nil `matchedKey` only when applying the matched translation would
+    /// actually change a user-visible field — so callers don't stamp `$survey_language`
+    /// onto events when nothing on screen changed.
     func resolveSurveyTranslations(
         survey: PostHogSurvey,
         targetLanguage: String?

--- a/PostHog/Surveys/Utils/SurveyTranslationResolver.swift
+++ b/PostHog/Surveys/Utils/SurveyTranslationResolver.swift
@@ -1,0 +1,195 @@
+//
+//  SurveyTranslationResolver.swift
+//  PostHog
+//
+//  Created by PostHog Code on 2026-05-13.
+//
+
+#if os(iOS) || TESTING
+
+    import Foundation
+
+    /// Outcome of resolving translations for one survey at display time.
+    ///
+    /// - `matchedKey`: the original-cased key from a `translations` dictionary that drove
+    ///   the change (preferring the survey-level key when both survey and question matched).
+    ///   `nil` when no translation was applied at all.
+    /// - `survey`: the resolved survey-level translation, or `nil` if none matched.
+    /// - `questions`: per-question translation, indexed positionally against
+    ///   `survey.questions`. `nil` entries leave the question untranslated.
+    struct ResolvedSurveyTranslations {
+        let matchedKey: String?
+        let survey: PostHogSurveyTranslation?
+        let questions: [PostHogSurveyQuestionTranslation?]
+    }
+
+    /// Resolves the language code to use for survey translation, in priority order:
+    ///
+    /// 1. Explicit SDK override (`PostHogSurveysConfig.overrideDisplayLanguage`).
+    /// 2. The `"language"` key of the persisted person properties (set via
+    ///    `identify(..., userProperties: ["language": "fr"])`).
+    /// 3. The device locale (BCP-47 form — underscores converted to hyphens).
+    func detectSurveyLanguage(
+        overrideLanguage: String?,
+        personProperties: [String: Any]?,
+        deviceLocale: String?
+    ) -> String? {
+        if let override = overrideLanguage?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !override.isEmpty
+        {
+            return override
+        }
+
+        if let personLanguage = personProperties?[personPropertyLanguageKey] as? String {
+            let trimmed = personLanguage.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { return trimmed }
+        }
+
+        if let locale = deviceLocale?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !locale.isEmpty
+        {
+            return locale
+        }
+
+        return nil
+    }
+
+    /// Finds the best matching translation key in `translations` for `targetLanguage`.
+    ///
+    /// Matching is case-insensitive. If no exact match is found and the target contains a
+    /// region suffix (e.g. `"pt-BR"`), the base language (e.g. `"pt"`) is tried as a
+    /// fallback.
+    ///
+    /// Returns the original-cased key from `translations` (so it can be reported verbatim
+    /// as `$survey_language`), or `nil` if no match.
+    func findBestTranslationMatch<T>(
+        translations: [String: T]?,
+        targetLanguage: String?
+    ) -> String? {
+        guard let translations, !translations.isEmpty,
+              let target = targetLanguage?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !target.isEmpty
+        else {
+            return nil
+        }
+
+        let normalizedTarget = target.lowercased()
+
+        if let exact = translations.keys.first(where: { $0.lowercased() == normalizedTarget }) {
+            return exact
+        }
+
+        if let hyphen = normalizedTarget.firstIndex(of: "-") {
+            let base = String(normalizedTarget[..<hyphen])
+            if let baseMatch = translations.keys.first(where: { $0.lowercased() == base }) {
+                return baseMatch
+            }
+        }
+
+        return nil
+    }
+
+    /// Resolves which translations should be applied to `survey` given the user's
+    /// `targetLanguage`. Tracks whether the resolution actually changed any user-visible
+    /// field; if not, `matchedKey` is `nil` so callers don't mistakenly stamp
+    /// `$survey_language` onto events.
+    func resolveSurveyTranslations(
+        survey: PostHogSurvey,
+        targetLanguage: String?
+    ) -> ResolvedSurveyTranslations {
+        let empty = ResolvedSurveyTranslations(
+            matchedKey: nil,
+            survey: nil,
+            questions: Array(repeating: nil, count: survey.questions.count)
+        )
+
+        guard let targetLanguage,
+              !targetLanguage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return empty
+        }
+
+        let surveyKey = findBestTranslationMatch(
+            translations: survey.translations,
+            targetLanguage: targetLanguage
+        )
+        let surveyTranslation = surveyKey.flatMap { survey.translations?[$0] }
+        let surveyChanged = surveyTranslation.map { surveyTranslationChangesAnything(survey: survey, translation: $0) } ?? false
+
+        var anyQuestionChanged = false
+        var questionTranslations: [PostHogSurveyQuestionTranslation?] = []
+        var questionKeys: [String?] = []
+        for question in survey.questions {
+            let key = findBestTranslationMatch(
+                translations: question.translations,
+                targetLanguage: targetLanguage
+            )
+            let translation = key.flatMap { question.translations?[$0] }
+            let changes = translation.map { questionTranslationChangesAnything(question: question, translation: $0) } ?? false
+            if changes {
+                anyQuestionChanged = true
+                questionTranslations.append(translation)
+                questionKeys.append(key)
+            } else {
+                questionTranslations.append(nil)
+                questionKeys.append(nil)
+            }
+        }
+
+        if !surveyChanged, !anyQuestionChanged { return empty }
+
+        let matchedKey: String?
+        if surveyChanged {
+            matchedKey = surveyKey
+        } else {
+            matchedKey = questionKeys.compactMap { $0 }.first
+        }
+
+        return ResolvedSurveyTranslations(
+            matchedKey: matchedKey,
+            survey: surveyChanged ? surveyTranslation : nil,
+            questions: questionTranslations
+        )
+    }
+
+    private func surveyTranslationChangesAnything(
+        survey: PostHogSurvey,
+        translation: PostHogSurveyTranslation
+    ) -> Bool {
+        if let name = translation.name, name != survey.name { return true }
+        let appearance = survey.appearance
+        if let header = translation.thankYouMessageHeader,
+           header != appearance?.thankYouMessageHeader { return true }
+        if let description = translation.thankYouMessageDescription,
+           description != appearance?.thankYouMessageDescription { return true }
+        if let closeText = translation.thankYouMessageCloseButtonText,
+           closeText != appearance?.thankYouMessageCloseButtonText { return true }
+        return false
+    }
+
+    private func questionTranslationChangesAnything(
+        question: PostHogSurveyQuestion,
+        translation: PostHogSurveyQuestionTranslation
+    ) -> Bool {
+        if let q = translation.question, q != question.question { return true }
+        if let d = translation.description, d != question.description { return true }
+        if let b = translation.buttonText, b != question.buttonText { return true }
+
+        switch question {
+        case let .link(link):
+            if let t = translation.link, t != link.link { return true }
+        case let .rating(rating):
+            if let t = translation.lowerBoundLabel, t != rating.lowerBoundLabel { return true }
+            if let t = translation.upperBoundLabel, t != rating.upperBoundLabel { return true }
+        case let .singleChoice(choice), let .multipleChoice(choice):
+            if let t = translation.choices, t != choice.choices { return true }
+        case .open, .unknown:
+            break
+        }
+
+        return false
+    }
+
+    private let personPropertyLanguageKey = "language"
+
+#endif

--- a/PostHog/Surveys/Utils/SurveyTranslationResolver.swift
+++ b/PostHog/Surveys/Utils/SurveyTranslationResolver.swift
@@ -70,16 +70,15 @@
         }
 
         let normalizedTarget = target.lowercased()
-
-        if let exact = translations.keys.first(where: { $0.lowercased() == normalizedTarget }) {
-            return exact
+        let findKey: (String) -> String? = { target in
+            translations.keys.first(where: { $0.lowercased() == target })
         }
+
+        if let exact = findKey(normalizedTarget) { return exact }
 
         if let hyphen = normalizedTarget.firstIndex(of: "-") {
             let base = String(normalizedTarget[..<hyphen])
-            if let baseMatch = translations.keys.first(where: { $0.lowercased() == base }) {
-                return baseMatch
-            }
+            if let baseMatch = findKey(base) { return baseMatch }
         }
 
         return nil

--- a/PostHog/Surveys/Utils/SurveyTranslationResolver.swift
+++ b/PostHog/Surveys/Utils/SurveyTranslationResolver.swift
@@ -171,18 +171,18 @@
         question: PostHogSurveyQuestion,
         translation: PostHogSurveyQuestionTranslation
     ) -> Bool {
-        if let q = translation.question, q != question.question { return true }
-        if let d = translation.description, d != question.description { return true }
-        if let b = translation.buttonText, b != question.buttonText { return true }
+        if let translated = translation.question, translated != question.question { return true }
+        if let translated = translation.description, translated != question.description { return true }
+        if let translated = translation.buttonText, translated != question.buttonText { return true }
 
         switch question {
         case let .link(link):
-            if let t = translation.link, t != link.link { return true }
+            if let translated = translation.link, translated != link.link { return true }
         case let .rating(rating):
-            if let t = translation.lowerBoundLabel, t != rating.lowerBoundLabel { return true }
-            if let t = translation.upperBoundLabel, t != rating.upperBoundLabel { return true }
+            if let translated = translation.lowerBoundLabel, translated != rating.lowerBoundLabel { return true }
+            if let translated = translation.upperBoundLabel, translated != rating.upperBoundLabel { return true }
         case let .singleChoice(choice), let .multipleChoice(choice):
-            if let t = translation.choices, t != choice.choices { return true }
+            if let translated = translation.choices, translated != choice.choices { return true }
         case .open, .unknown:
             break
         }

--- a/PostHogExample/AppDelegate.swift
+++ b/PostHogExample/AppDelegate.swift
@@ -28,6 +28,11 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         #endif
 
         #if os(iOS)
+            if #available(iOS 15.0, *) {
+                config.surveys = true
+                // Uncomment to force-render any matching survey in a specific language regardless of device locale.
+                // config.surveysConfig.overrideDisplayLanguage = "fr"
+            }
             config.sessionReplay = false
             config.sessionReplayConfig.screenshotMode = true
             config.sessionReplayConfig.maskAllTextInputs = true

--- a/PostHogTests/PostHogSurveyEventsTest.swift
+++ b/PostHogTests/PostHogSurveyEventsTest.swift
@@ -31,7 +31,8 @@ class PostHogSurveyEventsTest {
             optional: false,
             buttonText: nil,
             originalQuestionIndex: 0,
-            branching: nil
+            branching: nil,
+            translations: nil
         )),
         .singleChoice(PostHogMultipleSurveyQuestion(
             id: "qID2",
@@ -42,6 +43,7 @@ class PostHogSurveyEventsTest {
             buttonText: nil,
             originalQuestionIndex: 1,
             branching: nil,
+            translations: nil,
             choices: ["Very likely", "Somewhat likely", "Not likely"],
             hasOpenChoice: false,
             shuffleOptions: false
@@ -55,6 +57,7 @@ class PostHogSurveyEventsTest {
             buttonText: nil,
             originalQuestionIndex: 2,
             branching: nil,
+            translations: nil,
             display: .number,
             scale: .fivePoint,
             lowerBoundLabel: "Poor",
@@ -84,7 +87,8 @@ class PostHogSurveyEventsTest {
             currentIterationStartDate: currentIterationStartDate,
             startDate: Date(),
             endDate: nil,
-            schedule: nil
+            schedule: nil,
+            translations: nil
         )
     }
 
@@ -190,7 +194,8 @@ class PostHogSurveyEventsTest {
                 optional: false,
                 buttonText: nil,
                 originalQuestionIndex: 0,
-                branching: nil
+                branching: nil,
+                translations: nil
             )),
             .singleChoice(PostHogMultipleSurveyQuestion(
                 id: "qID2",
@@ -201,6 +206,7 @@ class PostHogSurveyEventsTest {
                 buttonText: nil,
                 originalQuestionIndex: 1,
                 branching: nil,
+                translations: nil,
                 choices: ["Very likely", "Somewhat likely", "Not likely"],
                 hasOpenChoice: false,
                 shuffleOptions: false
@@ -214,6 +220,7 @@ class PostHogSurveyEventsTest {
                 buttonText: nil,
                 originalQuestionIndex: 2,
                 branching: nil,
+                translations: nil,
                 display: .number,
                 scale: .fivePoint,
                 lowerBoundLabel: "Poor",
@@ -270,7 +277,8 @@ class PostHogSurveyEventsTest {
                     optional: false,
                     buttonText: nil,
                     originalQuestionIndex: 0,
-                    branching: nil
+                    branching: nil,
+                    translations: nil
                 )),
             ]
         )

--- a/PostHogTests/PostHogSurveyTranslationsTest.swift
+++ b/PostHogTests/PostHogSurveyTranslationsTest.swift
@@ -184,6 +184,16 @@
                 #expect(resolved.questions.allSatisfy { $0 == nil })
             }
 
+            @Test("returns nil matchedKey when translation matches but values are identical")
+            func nilWhenTranslationIsNoop() throws {
+                let data = try loadFixture("fixture_survey_translation_noop")
+                let survey = try PostHogApi.jsonDecoder.decode(PostHogSurvey.self, from: data)
+                let resolved = resolveSurveyTranslations(survey: survey, targetLanguage: "fr")
+                #expect(resolved.matchedKey == nil)
+                #expect(resolved.survey == nil)
+                #expect(resolved.questions.allSatisfy { $0 == nil })
+            }
+
             private func decodeTranslationsFixture() throws -> PostHogSurvey {
                 let data = try loadFixture("fixture_survey_translations")
                 return try PostHogApi.jsonDecoder.decode(PostHogSurvey.self, from: data)
@@ -293,6 +303,33 @@
                 #expect(events.count == 1)
                 #expect(events[0].event == "survey sent")
                 #expect(events[0].properties["$survey_language"] as? String == "pt")
+                postHog.close()
+                postHog.reset()
+            }
+
+            @Test("survey sent carries translated question text in $survey_questions")
+            func surveySentCarriesTranslatedQuestionText() async throws {
+                let postHog = getSut()
+                let integration = try getSurveyIntegration(postHog)
+                let translation = PostHogSurveyQuestionTranslation(
+                    question: "Question traduite?",
+                    description: nil,
+                    buttonText: nil,
+                    link: nil,
+                    lowerBoundLabel: nil,
+                    upperBoundLabel: nil,
+                    choices: nil
+                )
+                integration.testSendSurveySentEvent(
+                    survey: minimalSurvey(),
+                    responses: ["$survey_response": .openEnded("ok")],
+                    language: "fr",
+                    questionTranslations: [translation]
+                )
+                let events = try await getServerEvents(server)
+                #expect(events.count == 1)
+                let questions = events[0].properties["$survey_questions"] as? [[String: Any]]
+                #expect(questions?.first?["question"] as? String == "Question traduite?")
                 postHog.close()
                 postHog.reset()
             }

--- a/PostHogTests/PostHogSurveyTranslationsTest.swift
+++ b/PostHogTests/PostHogSurveyTranslationsTest.swift
@@ -237,7 +237,8 @@
                         optional: false,
                         buttonText: nil,
                         originalQuestionIndex: 0,
-                        branching: nil
+                        branching: nil,
+                        translations: nil
                     ))],
                     featureFlagKeys: nil,
                     linkedFlagKey: nil,
@@ -249,7 +250,8 @@
                     currentIterationStartDate: nil,
                     startDate: Date(),
                     endDate: nil,
-                    schedule: nil
+                    schedule: nil,
+                    translations: nil
                 )
             }
 

--- a/PostHogTests/PostHogSurveyTranslationsTest.swift
+++ b/PostHogTests/PostHogSurveyTranslationsTest.swift
@@ -1,0 +1,370 @@
+//
+//  PostHogSurveyTranslationsTest.swift
+//  PostHog
+//
+//  Created by PostHog Code on 2026-05-13.
+//
+
+#if os(iOS) || TESTING
+
+    import Foundation
+    @testable import PostHog
+    import Testing
+
+    @Suite("Test survey translations")
+    enum PostHogSurveyTranslationsTest {
+        @Suite("Test language detection")
+        struct TestLanguageDetection {
+            @Test("override wins over person property and locale")
+            func overrideWinsOverPersonPropertyAndLocale() {
+                let result = detectSurveyLanguage(
+                    overrideLanguage: "fr",
+                    personProperties: ["language": "de"],
+                    deviceLocale: "en-US"
+                )
+                #expect(result == "fr")
+            }
+
+            @Test("trims override whitespace")
+            func trimsOverride() {
+                let result = detectSurveyLanguage(
+                    overrideLanguage: "  pt-BR  ",
+                    personProperties: nil,
+                    deviceLocale: "en-US"
+                )
+                #expect(result == "pt-BR")
+            }
+
+            @Test("falls back to person property when override blank")
+            func fallsBackToPersonProperty() {
+                let result = detectSurveyLanguage(
+                    overrideLanguage: " ",
+                    personProperties: ["language": "de"],
+                    deviceLocale: "en-US"
+                )
+                #expect(result == "de")
+            }
+
+            @Test("falls back to device locale when override and person property absent")
+            func fallsBackToDeviceLocale() {
+                let result = detectSurveyLanguage(
+                    overrideLanguage: nil,
+                    personProperties: ["other": "value"],
+                    deviceLocale: "en-US"
+                )
+                #expect(result == "en-US")
+            }
+
+            @Test("returns nil when nothing is set")
+            func returnsNilWhenNothingSet() {
+                let result = detectSurveyLanguage(
+                    overrideLanguage: nil,
+                    personProperties: nil,
+                    deviceLocale: nil
+                )
+                #expect(result == nil)
+            }
+
+            @Test("ignores non-string person language")
+            func ignoresNonStringPersonLanguage() {
+                let result = detectSurveyLanguage(
+                    overrideLanguage: nil,
+                    personProperties: ["language": 42],
+                    deviceLocale: "en-US"
+                )
+                #expect(result == "en-US")
+            }
+        }
+
+        @Suite("Test translation matching")
+        struct TestTranslationMatching {
+            @Test("returns exact match")
+            func exactMatch() {
+                let translations = ["fr": "x", "pt-BR": "y"]
+                #expect(findBestTranslationMatch(translations: translations, targetLanguage: "fr") == "fr")
+                #expect(findBestTranslationMatch(translations: translations, targetLanguage: "pt-BR") == "pt-BR")
+            }
+
+            @Test("is case insensitive and preserves original key casing")
+            func caseInsensitiveOriginalCasing() {
+                let translations = ["Fr": "x", "PT-br": "y"]
+                #expect(findBestTranslationMatch(translations: translations, targetLanguage: "fr") == "Fr")
+                #expect(findBestTranslationMatch(translations: translations, targetLanguage: "PT-BR") == "PT-br")
+            }
+
+            @Test("falls back to base language when target has hyphen")
+            func baseLanguageFallback() {
+                let translations = ["pt": "x"]
+                #expect(findBestTranslationMatch(translations: translations, targetLanguage: "pt-BR") == "pt")
+            }
+
+            @Test("prefers exact match over base language")
+            func prefersExactMatch() {
+                let translations = ["pt": "base", "pt-BR": "exact"]
+                #expect(findBestTranslationMatch(translations: translations, targetLanguage: "pt-BR") == "pt-BR")
+            }
+
+            @Test("does not fall back when target has no hyphen")
+            func noBaseFallbackWithoutHyphen() {
+                let translations = ["pt-BR": "x"]
+                #expect(findBestTranslationMatch(translations: translations, targetLanguage: "pt") == nil)
+            }
+
+            @Test("returns nil for empty inputs")
+            func emptyInputs() {
+                #expect(findBestTranslationMatch(translations: [String: String](), targetLanguage: "fr") == nil)
+                #expect(findBestTranslationMatch(translations: nil as [String: String]?, targetLanguage: "fr") == nil)
+                #expect(findBestTranslationMatch(translations: ["fr": "x"], targetLanguage: nil) == nil)
+                #expect(findBestTranslationMatch(translations: ["fr": "x"], targetLanguage: "") == nil)
+                #expect(findBestTranslationMatch(translations: ["fr": "x"], targetLanguage: "  ") == nil)
+            }
+        }
+
+        @Suite("Test translation resolution")
+        struct TestTranslationResolution {
+            @Test("survey decodes translations field")
+            func surveyDecodesTranslations() throws {
+                let data = try loadFixture("fixture_survey_translations")
+                let survey = try PostHogApi.jsonDecoder.decode(PostHogSurvey.self, from: data)
+                #expect(survey.translations?["fr"]?.name == "Bonjour")
+                #expect(survey.translations?["fr"]?.thankYouMessageHeader == "Merci!")
+                #expect(survey.translations?["pt"]?.thankYouMessageHeader == "Obrigado")
+            }
+
+            @Test("question decodes translations field")
+            func questionDecodesTranslations() throws {
+                let data = try loadFixture("fixture_survey_translations")
+                let survey = try PostHogApi.jsonDecoder.decode(PostHogSurvey.self, from: data)
+                if case let .rating(rating) = survey.questions[0] {
+                    #expect(rating.translations?["fr"]?.question == "Comment etait-ce?")
+                    #expect(rating.translations?["fr"]?.lowerBoundLabel == "Mauvais")
+                } else {
+                    throw TestError("Expected rating question")
+                }
+                if case let .singleChoice(choice) = survey.questions[1] {
+                    #expect(choice.translations?["fr"]?.choices == ["Un", "Deux"])
+                } else {
+                    throw TestError("Expected single choice question")
+                }
+            }
+
+            @Test("returns empty resolution when target language is nil")
+            func emptyResolutionWhenTargetNil() throws {
+                let survey = try decodeTranslationsFixture()
+                let resolved = resolveSurveyTranslations(survey: survey, targetLanguage: nil)
+                #expect(resolved.matchedKey == nil)
+                #expect(resolved.survey == nil)
+                #expect(resolved.questions.allSatisfy { $0 == nil })
+            }
+
+            @Test("matches exact language")
+            func matchesExactLanguage() throws {
+                let survey = try decodeTranslationsFixture()
+                let resolved = resolveSurveyTranslations(survey: survey, targetLanguage: "fr")
+                #expect(resolved.matchedKey == "fr")
+                #expect(resolved.survey?.name == "Bonjour")
+                #expect(resolved.questions[0]?.question == "Comment etait-ce?")
+                #expect(resolved.questions[1]?.choices == ["Un", "Deux"])
+            }
+
+            @Test("falls back to base language")
+            func basesLanguageFallback() throws {
+                let survey = try decodeTranslationsFixture()
+                let resolved = resolveSurveyTranslations(survey: survey, targetLanguage: "pt-BR")
+                #expect(resolved.matchedKey == "pt")
+                #expect(resolved.survey?.thankYouMessageHeader == "Obrigado")
+            }
+
+            @Test("returns nil matchedKey when translations exist but none match")
+            func nilWhenNoMatch() throws {
+                let survey = try decodeTranslationsFixture()
+                let resolved = resolveSurveyTranslations(survey: survey, targetLanguage: "ja")
+                #expect(resolved.matchedKey == nil)
+                #expect(resolved.survey == nil)
+                #expect(resolved.questions.allSatisfy { $0 == nil })
+            }
+
+            private func decodeTranslationsFixture() throws -> PostHogSurvey {
+                let data = try loadFixture("fixture_survey_translations")
+                return try PostHogApi.jsonDecoder.decode(PostHogSurvey.self, from: data)
+            }
+        }
+
+        @Suite("Test survey_language event property", .serialized)
+        class TestSurveyLanguageEventProperty {
+            let server: MockPostHogServer
+
+            init() {
+                server = MockPostHogServer()
+                server.start()
+            }
+
+            deinit {
+                server.stop()
+            }
+
+            private func getSut() -> PostHogSDK {
+                let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9090")
+                config._surveys = true
+                config.flushAt = 1
+                config.disableReachabilityForTesting = true
+                config.disableQueueTimerForTesting = true
+                config.disableFlushOnBackgroundForTesting = true
+                config.captureApplicationLifecycleEvents = false
+                let storage = PostHogStorage(config)
+                storage.reset()
+                return PostHogSDK.with(config)
+            }
+
+            private func getSurveyIntegration(_ postHog: PostHogSDK) throws -> PostHogSurveyIntegration {
+                PostHogSurveyIntegration.clearInstalls()
+                let integration = PostHogSurveyIntegration()
+                let installResult = integration.install(postHog)
+                try #require(installResult == .installed)
+                return integration
+            }
+
+            private func minimalSurvey() -> PostHogSurvey {
+                PostHogSurvey(
+                    id: "translated-survey",
+                    name: "Original",
+                    type: .popover,
+                    questions: [.open(PostHogOpenSurveyQuestion(
+                        id: "q1",
+                        question: "Question?",
+                        description: nil,
+                        descriptionContentType: .text,
+                        optional: false,
+                        buttonText: nil,
+                        originalQuestionIndex: 0,
+                        branching: nil
+                    ))],
+                    featureFlagKeys: nil,
+                    linkedFlagKey: nil,
+                    targetingFlagKey: nil,
+                    internalTargetingFlagKey: nil,
+                    conditions: nil,
+                    appearance: nil,
+                    currentIteration: nil,
+                    currentIterationStartDate: nil,
+                    startDate: Date(),
+                    endDate: nil,
+                    schedule: nil
+                )
+            }
+
+            @Test("survey shown stamps $survey_language when language is set")
+            func surveyShownStampsLanguage() async throws {
+                let postHog = getSut()
+                let integration = try getSurveyIntegration(postHog)
+                integration.testSendSurveyShownEvent(survey: minimalSurvey(), language: "fr")
+                let events = try await getServerEvents(server)
+                #expect(events.count == 1)
+                #expect(events[0].event == "survey shown")
+                #expect(events[0].properties["$survey_language"] as? String == "fr")
+                postHog.close()
+                postHog.reset()
+            }
+
+            @Test("survey shown omits $survey_language when no language matched")
+            func surveyShownOmitsLanguageWhenNil() async throws {
+                let postHog = getSut()
+                let integration = try getSurveyIntegration(postHog)
+                integration.testSendSurveyShownEvent(survey: minimalSurvey(), language: nil)
+                let events = try await getServerEvents(server)
+                #expect(events.count == 1)
+                #expect(events[0].properties["$survey_language"] == nil)
+                postHog.close()
+                postHog.reset()
+            }
+
+            @Test("survey sent stamps $survey_language when set")
+            func surveySentStampsLanguage() async throws {
+                let postHog = getSut()
+                let integration = try getSurveyIntegration(postHog)
+                integration.testSendSurveySentEvent(
+                    survey: minimalSurvey(),
+                    responses: ["$survey_response": .openEnded("ok")],
+                    language: "pt"
+                )
+                let events = try await getServerEvents(server)
+                #expect(events.count == 1)
+                #expect(events[0].event == "survey sent")
+                #expect(events[0].properties["$survey_language"] as? String == "pt")
+                postHog.close()
+                postHog.reset()
+            }
+
+            @Test("survey dismissed stamps $survey_language when set")
+            func surveyDismissedStampsLanguage() async throws {
+                let postHog = getSut()
+                let integration = try getSurveyIntegration(postHog)
+                integration.testSendSurveyDismissedEvent(survey: minimalSurvey(), language: "fr")
+                let events = try await getServerEvents(server)
+                #expect(events.count == 1)
+                #expect(events[0].event == "survey dismissed")
+                #expect(events[0].properties["$survey_language"] as? String == "fr")
+                postHog.close()
+                postHog.reset()
+            }
+
+            @Test("survey dismissed omits $survey_language when nil")
+            func surveyDismissedOmitsLanguageWhenNil() async throws {
+                let postHog = getSut()
+                let integration = try getSurveyIntegration(postHog)
+                integration.testSendSurveyDismissedEvent(survey: minimalSurvey(), language: nil)
+                let events = try await getServerEvents(server)
+                #expect(events.count == 1)
+                #expect(events[0].properties["$survey_language"] == nil)
+                postHog.close()
+                postHog.reset()
+            }
+        }
+
+        @Suite("Test display survey with translations")
+        struct TestDisplayTranslation {
+            @Test("display survey applies translation fields with fallback")
+            func displaySurveyApplies() throws {
+                let data = try loadFixture("fixture_survey_translations")
+                let survey = try PostHogApi.jsonDecoder.decode(PostHogSurvey.self, from: data)
+                let resolved = resolveSurveyTranslations(survey: survey, targetLanguage: "fr")
+                let display = survey.toDisplaySurvey(
+                    surveyTranslation: resolved.survey,
+                    questionTranslations: resolved.questions
+                )
+                #expect(display.name == "Bonjour")
+                if let rating = display.questions[0] as? PostHogDisplayRatingQuestion {
+                    #expect(rating.question == "Comment etait-ce?")
+                    #expect(rating.lowerBoundLabel == "Mauvais")
+                    // upperBoundLabel was not translated — falls back
+                    #expect(rating.upperBoundLabel == "Great")
+                } else {
+                    throw TestError("Expected rating display question")
+                }
+                if let choice = display.questions[1] as? PostHogDisplayChoiceQuestion {
+                    #expect(choice.choices == ["Un", "Deux"])
+                } else {
+                    throw TestError("Expected choice display question")
+                }
+                #expect(display.appearance?.thankYouMessageHeader == "Merci!")
+            }
+
+            @Test("display survey without translations renders original")
+            func displaySurveyWithoutTranslations() throws {
+                let data = try loadFixture("fixture_survey_translations")
+                let survey = try PostHogApi.jsonDecoder.decode(PostHogSurvey.self, from: data)
+                let display = survey.toDisplaySurvey()
+                #expect(display.name == "Hello")
+                if let rating = display.questions[0] as? PostHogDisplayRatingQuestion {
+                    #expect(rating.question == "How was it?")
+                    #expect(rating.lowerBoundLabel == "Bad")
+                }
+                if let choice = display.questions[1] as? PostHogDisplayChoiceQuestion {
+                    #expect(choice.choices == ["One", "Two"])
+                }
+                #expect(display.appearance?.thankYouMessageHeader == "Thanks!")
+            }
+        }
+    }
+
+#endif

--- a/PostHogTests/PostHogSurveyTranslationsTest.swift
+++ b/PostHogTests/PostHogSurveyTranslationsTest.swift
@@ -168,7 +168,7 @@
             }
 
             @Test("falls back to base language")
-            func basesLanguageFallback() throws {
+            func baseLanguageFallback() throws {
                 let survey = try decodeTranslationsFixture()
                 let resolved = resolveSurveyTranslations(survey: survey, targetLanguage: "pt-BR")
                 #expect(resolved.matchedKey == "pt")

--- a/PostHogTests/PostHogSurveysTest.swift
+++ b/PostHogTests/PostHogSurveysTest.swift
@@ -665,7 +665,8 @@ enum PostHogSurveysTest {
                 currentIterationStartDate: nil,
                 startDate: nil,
                 endDate: nil,
-                schedule: schedule
+                schedule: schedule,
+                translations: nil
             )
         }
 
@@ -1787,7 +1788,8 @@ private extension PostHogSurvey {
                     optional: nil,
                     buttonText: nil,
                     originalQuestionIndex: nil,
-                    branching: nil
+                    branching: nil,
+                    translations: nil
                 )
             ),
         ],
@@ -1818,7 +1820,8 @@ private extension PostHogSurvey {
             currentIterationStartDate: currentIterationStartDate,
             startDate: startDate,
             endDate: endDate,
-            schedule: schedule
+            schedule: schedule,
+            translations: nil
         )
     }
 }
@@ -1836,7 +1839,8 @@ private extension PostHogOpenSurveyQuestion {
             optional: nil,
             buttonText: nil,
             originalQuestionIndex: nil,
-            branching: branching
+            branching: branching,
+            translations: nil
         )
     }
 }
@@ -1856,6 +1860,7 @@ private extension PostHogMultipleSurveyQuestion {
             buttonText: nil,
             originalQuestionIndex: nil,
             branching: branching,
+            translations: nil,
             choices: choices,
             hasOpenChoice: false,
             shuffleOptions: nil
@@ -1879,6 +1884,7 @@ private extension PostHogRatingSurveyQuestion {
             buttonText: nil,
             originalQuestionIndex: nil,
             branching: branching,
+            translations: nil,
             display: display,
             scale: scale,
             lowerBoundLabel: "",

--- a/PostHogTests/Resources/fixture_survey_translation_noop.json
+++ b/PostHogTests/Resources/fixture_survey_translation_noop.json
@@ -1,0 +1,19 @@
+{
+    "id": "noop-translation-survey",
+    "name": "Hello",
+    "type": "popover",
+    "questions": [
+        {
+            "id": "q1",
+            "type": "open",
+            "question": "What's up?",
+            "translations": {
+                "fr": { "question": "What's up?" }
+            }
+        }
+    ],
+    "translations": {
+        "fr": { "name": "Hello" }
+    },
+    "start_date": "2025-01-16T22:23:38.805000Z"
+}

--- a/PostHogTests/Resources/fixture_survey_translations.json
+++ b/PostHogTests/Resources/fixture_survey_translations.json
@@ -1,0 +1,38 @@
+{
+    "id": "translated-survey",
+    "name": "Hello",
+    "type": "popover",
+    "questions": [
+        {
+            "id": "q1",
+            "type": "rating",
+            "question": "How was it?",
+            "scale": 5,
+            "display": "number",
+            "lowerBoundLabel": "Bad",
+            "upperBoundLabel": "Great",
+            "translations": {
+                "fr": { "question": "Comment etait-ce?", "lowerBoundLabel": "Mauvais" }
+            }
+        },
+        {
+            "id": "q2",
+            "type": "single_choice",
+            "question": "Pick one",
+            "choices": ["One", "Two"],
+            "translations": {
+                "fr": { "choices": ["Un", "Deux"] }
+            }
+        }
+    ],
+    "appearance": {
+        "thankYouMessageHeader": "Thanks!",
+        "thankYouMessageDescription": "We appreciate it",
+        "thankYouMessageCloseButtonText": "Close"
+    },
+    "translations": {
+        "fr": { "name": "Bonjour", "thankYouMessageHeader": "Merci!" },
+        "pt": { "thankYouMessageHeader": "Obrigado" }
+    },
+    "start_date": "2025-01-16T22:23:38.805000Z"
+}


### PR DESCRIPTION
## Summary
Brings the posthog-js / posthog-react-native survey translations feature to the native SDK. Surveys can carry per-language overrides for user-visible strings via a `translations` map keyed by language code. At display time the SDK resolves a language (init override → person property `language` → device locale), applies any matching translation onto the display model, and stamps the matched key as `$survey_language` on every survey event when a translation actually took effect.

- Wire model: `translations` on `PostHogSurvey` and on each question struct.
- Config: `PostHogSurveysConfig.overrideDisplayLanguage` (`@objc`) init option.
- Matching: case-insensitive exact match with base-language fallback (`pt-BR` → `pt`); returns the original-cased dict key for event reporting.
- Resolution: only stamps `matchedKey` when at least one user-visible field actually changed.
- Event threading: `survey shown`, `survey sent`, `survey dismissed` all carry `$survey_language` when matched; `$survey_questions` reflects translated text.
- Device locale read via `Locale.current.identifier` with `_`→`-` normalization for BCP-47 parity with other SDKs.
- `PostHogExample` enables `surveys = true` for reviewer testing.

Companion PR: PostHog/posthog-android#513

## Test plan
All tests pass in CI. New coverage:
- Wire-format decoding round-trip (Codable + fixture).
- Matching algorithm: exact, case-insensitive, base-language fallback, no-match, no-fallback-without-hyphen.
- Priority chain: override → person prop → device locale.
- Display model translation with field-level fallback to original.
- Integration: `$survey_language` present on all three events (`shown`/`sent`/`dismissed`) when matched, absent otherwise.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*