### PR TITLE
fix: silence vendored libwebp macro redefinition warning

### DIFF
--- a/.changeset/fine-pugs-like.md
+++ b/.changeset/fine-pugs-like.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+fix: silence vendored libwebp macro redefinition warning

--- a/vendor/libwebp/ph_sharpyuv_cpu.h
+++ b/vendor/libwebp/ph_sharpyuv_cpu.h
@@ -18,6 +18,9 @@
 // SharpYuvInit() replaces the use of the function pointer.
 #undef WEBP_EXTERN
 #define WEBP_EXTERN extern
+// phlibwebp_prefix.h prefixes VP8GetCPUInfo globally. This header intentionally
+// remaps it locally while including ph_cpu.h to create SharpYuvGetCPUInfo.
+#undef VP8GetCPUInfo
 #define VP8GetCPUInfo SharpYuvGetCPUInfo
 #include "./ph_cpu.h"
 


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #599 

Fixes noisy VP8GetCPUInfo macro redefinition warnings 

## :green_heart: How did you test it?

Validated with the full integration matrix across SPM, CocoaPods, WebP collision cases, platform builds, and XCFramework packaging.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
