### PR TITLE
fix: silence PHPLCrashReporter CocoaPods module warnings

### DIFF
--- a/.changeset/clear-ants-dress.md
+++ b/.changeset/clear-ants-dress.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+fix: silence PHPLCrashReporter CocoaPods module warnings

--- a/PostHog/PrivateModules/PHPLCrashReporter/module.modulemap
+++ b/PostHog/PrivateModules/PHPLCrashReporter/module.modulemap
@@ -1,4 +1,4 @@
 module PHPLCrashReporter {
-  umbrella header "../../../vendor/PHPLCrashReporter/Source/CrashReporter.h"
+  header "../../../vendor/PHPLCrashReporter/Source/CrashReporter.h"
   export *
 }


### PR DESCRIPTION
## :bulb: Motivation and Context

 - Change the private PHPLCrashReporter module map from `umbrella header` to `header`
 - Prevent Clang from warning that `CrashReporter.h` does not include every vendored PHPLCrashReporter header

 ## Validation

 - Confirmed CocoaPods PHPLCrashReporter umbrella warnings are now `0`
 - Ran public header exposure audit; private vendored headers remain unexposed


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
