### PR TITLE
Add downgrade compatibility CI test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,21 @@ jobs:
             ${{ runner.os }}-spm-
       - name: Test SDK
         run: make test
+
+  downgrade-compatibility:
+    runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        downgrade_ref:
+          # Regression guard for https://github.com/PostHog/posthog-ios/issues/537:
+          # 3.48.0 force-parsed queue filenames as Doubles during startup.
+          - 3.48.0
+    name: Downgrade compatibility (${{ matrix.downgrade_ref }})
+    steps:
+      - uses: actions/checkout@v6
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+        with:
+          xcode-version: latest-stable
+      - name: Test downgrade compatibility
+        run: make testDowngradeCompatibility downgrade_ref=${{ matrix.downgrade_ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,4 +46,6 @@ jobs:
         with:
           xcode-version: latest-stable
       - name: Test downgrade compatibility
-        run: make testDowngradeCompatibility downgrade_ref=${{ matrix.downgrade_ref }}
+        env:
+          DOWNGRADE_REF: ${{ matrix.downgrade_ref }}
+        run: make testDowngradeCompatibility

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
           - 3.58.0
     name: Downgrade compatibility (${{ matrix.downgrade_ref }})
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,13 @@ jobs:
       fail-fast: false
       matrix:
         downgrade_ref:
-          # Regression guard for https://github.com/PostHog/posthog-ios/issues/537:
+          # Pin persisted-storage schema boundaries rather than the last N releases.
           # 3.48.0 force-parsed queue filenames as Doubles during startup.
           - 3.48.0
+          # 3.48.3 introduced the UUID event queue folder.
+          - 3.48.3
+          # 3.58.0 introduced the persisted logs queue.
+          - 3.58.0
     name: Downgrade compatibility (${{ matrix.downgrade_ref }})
     steps:
       - uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ test:
 	set -o pipefail && swift test --no-parallel -Xswiftc -DTESTING $(if $(filter),--filter $(filter))
 
 testDowngradeCompatibility:
-	./scripts/test-downgrade-compatibility.sh $(or $(downgrade_ref),3.48.0)
+	DOWNGRADE_REF="$${DOWNGRADE_REF:-3.48.0}" ./scripts/test-downgrade-compatibility.sh
 
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build buildSdk buildExamples format swiftLint swiftFormat test testOniOSSimulator testOnMacSimulator lint bootstrap releaseCocoaPods api buildIOS
+.PHONY: build buildSdk buildExamples format swiftLint swiftFormat test testDowngradeCompatibility testOniOSSimulator testOnMacSimulator lint bootstrap releaseCocoaPods api buildIOS
 
 build: buildSdk buildExamples
 
@@ -87,6 +87,9 @@ testOnMacSimulator:
 #   make test filter=PostHogPropertiesSerializationTests        # Run specific test suite, class or method
 test:
 	set -o pipefail && swift test --no-parallel -Xswiftc -DTESTING $(if $(filter),--filter $(filter))
+
+testDowngradeCompatibility:
+	./scripts/test-downgrade-compatibility.sh $(or $(downgrade_ref),3.48.0)
 
 
 lint:

--- a/PostHog/PostHogStorage.swift
+++ b/PostHog/PostHogStorage.swift
@@ -230,7 +230,8 @@ class PostHogStorage {
         case queue = "posthog.queueFolder.uuid" // queue from > 3.48.1
         case oldQueueFolder = "posthog.queueFolder" // queue from 3.0.0 - 3.48.1
         case oldQueuePlist = "posthog.queue.plist" // queue from pre-3.0.0
-        case replayQeueue = "posthog.replayFolder"
+        case replayQeueue = "posthog.replayFolder.uuid" // replay queue with UUID filenames
+        case oldReplayQueue = "posthog.replayFolder" // replay queue with legacy timestamp filenames
         case replayBufferQueue = "posthog.replayBufferFolder"
         case logsQueue = "posthog.logsFolder"
         case enabledFeatureFlags = "posthog.enabledFeatureFlags"
@@ -399,6 +400,7 @@ class PostHogStorage {
         // (see PostHogLogRecord) lets in-flight telemetry survive an identity change.
         deleteSafely(url(forKey: .oldQueueFolder))
         deleteSafely(url(forKey: .oldQueuePlist))
+        deleteSafely(url(forKey: .oldReplayQueue))
         deleteSafely(url(forKey: .flags))
         deleteSafely(url(forKey: .enabledFeatureFlags))
         deleteSafely(url(forKey: .enabledFeatureFlagPayloads))

--- a/PostHog/QueueEndpoint+Factories.swift
+++ b/PostHog/QueueEndpoint+Factories.swift
@@ -41,7 +41,7 @@ extension QueueEndpoint where Record == PostHogEvent {
     static func snapshot(api: PostHogApi) -> QueueEndpoint<PostHogEvent> {
         QueueEndpoint<PostHogEvent>(
             storageKey: .replayQeueue,
-            oldStorageKeys: [],
+            oldStorageKeys: [.oldReplayQueue],
             dispatchQueueLabel: "com.posthog.ReplayQueue",
             initialCap: { $0.maxBatchSize },
             initialFlushAt: { $0.flushAt },

--- a/PostHogTests/PostHogReplayQueueTest.swift
+++ b/PostHogTests/PostHogReplayQueueTest.swift
@@ -62,6 +62,29 @@ class PostHogReplayQueueTests {
         }
     }
 
+    @Test("migrates legacy replay queue folder to UUID replay queue")
+    func migratesLegacyReplayQueueFolder() throws {
+        let uniqueKey = UUID().uuidString
+        let config = PostHogConfig(projectToken: uniqueKey, host: "http://localhost:9001")
+        let storage = PostHogStorage(config)
+        let legacyReplayQueue = storage.url(forKey: .oldReplayQueue)
+        let uuidReplayQueue = storage.url(forKey: .replayQeueue)
+
+        try FileManager.default.createDirectory(at: legacyReplayQueue, withIntermediateDirectories: true)
+        try "snapshot-1".data(using: .utf8)!
+            .write(to: legacyReplayQueue.appendingPathComponent("1698236044.407"))
+        try "snapshot-2".data(using: .utf8)!
+            .write(to: legacyReplayQueue.appendingPathComponent("1698236045.123"))
+
+        let queue = PostHogReplayQueue(config, storage, PostHogApi(config), nil)
+
+        #expect(!FileManager.default.fileExists(atPath: legacyReplayQueue.path))
+        #expect(FileManager.default.fileExists(atPath: uuidReplayQueue.path))
+        #expect(queue.depth == 2)
+
+        queue.clear()
+    }
+
     // MARK: - Buffering Mode Tests
 
     @Test("add routes to buffer when delegate.isBuffering is true")

--- a/scripts/downgrade-compatibility-smoke/Package.swift
+++ b/scripts/downgrade-compatibility-smoke/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version:5.3
+import Foundation
+import PackageDescription
+
+let environment = ProcessInfo.processInfo.environment
+let dependencyPath = environment["POSTHOG_DOWNGRADE_SMOKE_DEPENDENCY_PATH"] ?? "../.."
+let dependencyURL = URL(fileURLWithPath: dependencyPath)
+let packageIdentity = dependencyURL.lastPathComponent
+    .replacingOccurrences(of: ".git", with: "")
+    .lowercased()
+let currentWriterSwiftSettings: [SwiftSetting] = environment["POSTHOG_DOWNGRADE_SMOKE_CURRENT_WRITER"] == "1"
+    ? [.define("CURRENT_STORAGE_WRITER")]
+    : []
+
+let package = Package(
+    name: "DowngradeCompatibilitySmoke",
+    platforms: [.macOS(.v10_15)],
+    products: [
+        .executable(name: "DowngradeCompatibilitySmoke", targets: ["DowngradeCompatibilitySmoke"]),
+    ],
+    dependencies: [
+        .package(path: dependencyPath),
+    ],
+    targets: [
+        .target(
+            name: "DowngradeCompatibilitySmoke",
+            dependencies: [.product(name: "PostHog", package: packageIdentity)],
+            swiftSettings: currentWriterSwiftSettings
+        ),
+    ]
+)

--- a/scripts/downgrade-compatibility-smoke/Sources/DowngradeCompatibilitySmoke/main.swift
+++ b/scripts/downgrade-compatibility-smoke/Sources/DowngradeCompatibilitySmoke/main.swift
@@ -1,0 +1,84 @@
+import Foundation
+import PostHog
+
+let mode = CommandLine.arguments.dropFirst().first ?? "read"
+let token = ProcessInfo.processInfo.environment["POSTHOG_DOWNGRADE_TEST_TOKEN"] ?? "downgrade_compatibility_project"
+
+let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+print("Application Support: \(appSupport.path)")
+
+#if CURRENT_STORAGE_WRITER
+    let config = PostHogConfig(projectToken: token, host: "http://127.0.0.1:9")
+#else
+    let config = PostHogConfig(apiKey: token, host: "http://127.0.0.1:9")
+#endif
+config.flushAt = 10_000
+config.maxQueueSize = 10_000
+config.preloadFeatureFlags = false
+config.captureApplicationLifecycleEvents = false
+config.captureScreenViews = false
+config.enableSwizzling = false
+
+#if CURRENT_STORAGE_WRITER
+    config.logs.flushAt = 10_000
+    config.logs.maxBufferSize = 10_000
+#endif
+
+PostHogSDK.shared.setup(config)
+
+switch mode {
+case "write":
+    PostHogSDK.shared.identify(
+        "downgrade-compatibility-user",
+        userProperties: ["source": "downgrade-compatibility"]
+    )
+    PostHogSDK.shared.group(
+        type: "organization",
+        key: "posthog",
+        groupProperties: ["ci": true]
+    )
+
+    for index in 0 ..< 5 {
+        PostHogSDK.shared.capture(
+            "downgrade compatibility event",
+            properties: ["index": index, "source": "current-sdk"]
+        )
+    }
+
+    #if CURRENT_STORAGE_WRITER
+        for index in 0 ..< 2 {
+            PostHogSDK.shared.capture(
+                "$snapshot",
+                properties: [
+                    "$session_id": "downgrade-compatibility-session",
+                    "$snapshot_data": [
+                        "type": 4,
+                        "data": ["href": "http://example.com/\(index)"],
+                    ],
+                ]
+            )
+        }
+
+        PostHogSDK.shared.captureLog(
+            "downgrade compatibility log",
+            level: .warn,
+            attributes: ["source": "current-sdk", "index": 0]
+        )
+        PostHogSDK.shared.captureLog(
+            "downgrade compatibility log",
+            level: .error,
+            attributes: ["source": "current-sdk", "index": 1]
+        )
+    #endif
+
+    print("Wrote SDK state for token \(token)")
+case "read":
+    PostHogSDK.shared.capture(
+        "downgrade compatibility read smoke",
+        properties: ["source": "downgraded-sdk"]
+    )
+    print("Downgraded SDK started and read latest state for token \(token)")
+default:
+    fatalError("Unknown mode: \(mode)")
+}
+

--- a/scripts/downgrade-compatibility-smoke/Sources/DowngradeCompatibilitySmoke/main.swift
+++ b/scripts/downgrade-compatibility-smoke/Sources/DowngradeCompatibilitySmoke/main.swift
@@ -81,4 +81,3 @@ case "read":
 default:
     fatalError("Unknown mode: \(mode)")
 }
-

--- a/scripts/test-downgrade-compatibility.sh
+++ b/scripts/test-downgrade-compatibility.sh
@@ -123,6 +123,14 @@ count_event_queue_files() {
     echo $((current_queue_count + legacy_queue_count))
 }
 
+count_replay_queue_files() {
+    local current_queue_count
+    local legacy_queue_count
+    current_queue_count="$(count_storage_files "posthog.replayFolder.uuid")"
+    legacy_queue_count="$(count_storage_files "posthog.replayFolder")"
+    echo $((current_queue_count + legacy_queue_count))
+}
+
 require_positive_count() {
     local description="$1"
     local count="$2"
@@ -159,20 +167,19 @@ require_positive_count "persisted group properties" "$(count_storage_key_files "
 echo "Writer SDK persisted $EVENT_QUEUE_FILE_COUNT analytics event queue file(s)."
 
 if [ "$INCLUDE_CURRENT_STORAGE_WRITES" = "1" ]; then
-    REPLAY_QUEUE_FILE_COUNT="$(count_storage_files "posthog.replayFolder.uuid")"
+    CURRENT_REPLAY_QUEUE_FILE_COUNT="$(count_storage_files "posthog.replayFolder.uuid")"
     LEGACY_REPLAY_QUEUE_FILE_COUNT="$(count_storage_files "posthog.replayFolder")"
+    REPLAY_QUEUE_FILE_COUNT="$(count_replay_queue_files)"
     LOGS_QUEUE_FILE_COUNT="$(count_storage_files "posthog.logsFolder")"
 
     require_positive_count "queued replay snapshot files" "$REPLAY_QUEUE_FILE_COUNT"
     require_positive_count "queued log files" "$LOGS_QUEUE_FILE_COUNT"
 
     if [ "$LEGACY_REPLAY_QUEUE_FILE_COUNT" -ne 0 ]; then
-        echo "Expected current SDK replay snapshots to avoid legacy posthog.replayFolder, but found $LEGACY_REPLAY_QUEUE_FILE_COUNT file(s)." >&2
-        find "$STATE_HOME/Library/Application Support" -maxdepth 8 -print | sort >&2 || true
-        exit 1
+        echo "Warning: current SDK wrote $LEGACY_REPLAY_QUEUE_FILE_COUNT replay snapshot file(s) to legacy posthog.replayFolder." >&2
     fi
 
-    echo "Current SDK also persisted $REPLAY_QUEUE_FILE_COUNT replay snapshot file(s) and $LOGS_QUEUE_FILE_COUNT log file(s)."
+    echo "Current SDK also persisted $REPLAY_QUEUE_FILE_COUNT replay snapshot file(s) ($CURRENT_REPLAY_QUEUE_FILE_COUNT current, $LEGACY_REPLAY_QUEUE_FILE_COUNT legacy) and $LOGS_QUEUE_FILE_COUNT log file(s)."
 fi
 
 echo "Checking out downgraded SDK ref $DOWNGRADE_REF"

--- a/scripts/test-downgrade-compatibility.sh
+++ b/scripts/test-downgrade-compatibility.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+
+# Verifies that state written by the current SDK can be read by an older SDK.
+# Usage: ./scripts/test-downgrade-compatibility.sh <downgrade-ref>
+# Historical validation: WRITE_REF=3.48.1 ./scripts/test-downgrade-compatibility.sh 3.48.0
+
+set -euo pipefail
+
+DOWNGRADE_REF="${1:-${DOWNGRADE_REF:-3.48.0}}"
+WRITE_REF="${WRITE_REF:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/posthog-ios-downgrade-compat.XXXXXX")"
+
+cleanup() {
+    if [ "${KEEP_DOWNGRADE_COMPAT_TMP:-}" = "1" ]; then
+        echo "Keeping temp directory: $TMP_DIR"
+    else
+        rm -rf "$TMP_DIR"
+    fi
+}
+trap cleanup EXIT
+
+STATE_HOME="$TMP_DIR/home"
+CURRENT_SMOKE_DIR="$TMP_DIR/current-smoke"
+DOWNGRADED_SMOKE_DIR="$TMP_DIR/downgraded-smoke"
+WRITER_REPO_DIR="$TMP_DIR/writer/posthog-ios"
+OLD_REPO_DIR="$TMP_DIR/downgraded/posthog-ios"
+TOKEN="downgrade_compatibility_project"
+
+mkdir -p "$STATE_HOME/Library/Application Support"
+
+ensure_ref() {
+    local ref="$1"
+    if ! git -C "$REPO_ROOT" rev-parse --verify --quiet "$ref^{commit}" >/dev/null; then
+        echo "Fetching refs so '$ref' can be resolved..."
+        git -C "$REPO_ROOT" fetch --depth=1 origin "refs/tags/$ref:refs/tags/$ref" \
+            || git -C "$REPO_ROOT" fetch --depth=1 origin "$ref" \
+            || git -C "$REPO_ROOT" fetch --tags origin
+    fi
+}
+
+ensure_ref "$DOWNGRADE_REF"
+if [ -n "$WRITE_REF" ]; then
+    ensure_ref "$WRITE_REF"
+fi
+
+create_smoke_package() {
+    local package_dir="$1"
+    local dependency_path="$2"
+    local config_initializer_label="$3"
+    local escaped_dependency_path="${dependency_path//\\/\\\\}"
+    escaped_dependency_path="${escaped_dependency_path//\"/\\\"}"
+    local package_identity
+    package_identity="$(basename "$dependency_path")"
+    package_identity="${package_identity%.git}"
+    package_identity="$(printf '%s' "$package_identity" | tr '[:upper:]' '[:lower:]')"
+
+    mkdir -p "$package_dir/Sources/DowngradeCompatibilitySmoke"
+
+    cat > "$package_dir/Package.swift" <<EOF
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "DowngradeCompatibilitySmoke",
+    platforms: [.macOS(.v10_15)],
+    products: [
+        .executable(name: "DowngradeCompatibilitySmoke", targets: ["DowngradeCompatibilitySmoke"]),
+    ],
+    dependencies: [
+        .package(path: "$escaped_dependency_path"),
+    ],
+    targets: [
+        .target(
+            name: "DowngradeCompatibilitySmoke",
+            dependencies: [.product(name: "PostHog", package: "$package_identity")]
+        ),
+    ]
+)
+EOF
+
+    cat > "$package_dir/Sources/DowngradeCompatibilitySmoke/main.swift" <<'EOF'
+import Foundation
+import PostHog
+
+let mode = CommandLine.arguments.dropFirst().first ?? "read"
+let token = ProcessInfo.processInfo.environment["POSTHOG_DOWNGRADE_TEST_TOKEN"] ?? "downgrade_compatibility_project"
+
+let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+print("Application Support: \(appSupport.path)")
+
+let config = PostHogConfig(__CONFIG_INITIALIZER_LABEL__: token, host: "http://127.0.0.1:9")
+config.flushAt = 10_000
+config.maxQueueSize = 10_000
+config.preloadFeatureFlags = false
+config.captureApplicationLifecycleEvents = false
+config.captureScreenViews = false
+config.enableSwizzling = false
+
+PostHogSDK.shared.setup(config)
+
+switch mode {
+case "write":
+    PostHogSDK.shared.identify(
+        "downgrade-compatibility-user",
+        userProperties: ["source": "downgrade-compatibility"]
+    )
+    PostHogSDK.shared.group(
+        type: "organization",
+        key: "posthog",
+        groupProperties: ["ci": true]
+    )
+
+    for index in 0 ..< 5 {
+        PostHogSDK.shared.capture(
+            "downgrade compatibility event",
+            properties: ["index": index, "source": "current-sdk"]
+        )
+    }
+
+    print("Wrote current SDK state for token \(token)")
+case "read":
+    PostHogSDK.shared.capture(
+        "downgrade compatibility read smoke",
+        properties: ["source": "downgraded-sdk"]
+    )
+    print("Downgraded SDK started and read latest state for token \(token)")
+default:
+    fatalError("Unknown mode: \(mode)")
+}
+
+// Give any setup-time async work a short chance to start so startup crashes are observable.
+Thread.sleep(forTimeInterval: 0.2)
+EOF
+
+    perl -pi -e "s/__CONFIG_INITIALIZER_LABEL__/$config_initializer_label/g" \
+        "$package_dir/Sources/DowngradeCompatibilitySmoke/main.swift"
+}
+
+run_smoke() {
+    local package_dir="$1"
+    local mode="$2"
+
+    # CFFIXED_USER_HOME makes Foundation's user-domain Application Support
+    # directory point at our temp home on macOS, keeping the smoke state isolated.
+    CFFIXED_USER_HOME="$STATE_HOME" \
+    HOME="$STATE_HOME" \
+    POSTHOG_DOWNGRADE_TEST_TOKEN="$TOKEN" \
+    xcrun swift run --package-path "$package_dir" DowngradeCompatibilitySmoke "$mode"
+}
+
+count_queue_files() {
+    local state_root="$STATE_HOME/Library/Application Support"
+    if [ ! -d "$state_root" ]; then
+        echo 0
+        return
+    fi
+
+    find "$state_root" -type f \
+        \( -path "*/posthog.queueFolder/*" -o -path "*/posthog.queueFolder.uuid/*" \) \
+        | wc -l | tr -d ' '
+}
+
+if [ -n "$WRITE_REF" ]; then
+    echo "Checking out writer SDK ref $WRITE_REF"
+    mkdir -p "$(dirname "$WRITER_REPO_DIR")"
+    git clone --quiet --shared "$REPO_ROOT" "$WRITER_REPO_DIR"
+    git -C "$WRITER_REPO_DIR" checkout --quiet "$WRITE_REF"
+    WRITER_DEPENDENCY_PATH="$WRITER_REPO_DIR"
+    WRITER_CONFIG_LABEL="apiKey"
+    WRITER_DESCRIPTION="$WRITE_REF"
+else
+    WRITER_DEPENDENCY_PATH="$REPO_ROOT"
+    WRITER_CONFIG_LABEL="projectToken"
+    WRITER_DESCRIPTION="current checkout at $REPO_ROOT"
+fi
+
+echo "Writing state with $WRITER_DESCRIPTION"
+create_smoke_package "$CURRENT_SMOKE_DIR" "$WRITER_DEPENDENCY_PATH" "$WRITER_CONFIG_LABEL"
+run_smoke "$CURRENT_SMOKE_DIR" write
+
+QUEUE_FILE_COUNT="$(count_queue_files)"
+if [ "$QUEUE_FILE_COUNT" -eq 0 ]; then
+    echo "Expected the current SDK to write queued event files, but none were found. State tree:" >&2
+    find "$STATE_HOME/Library/Application Support" -maxdepth 8 -print | sort >&2 || true
+    exit 1
+fi
+
+echo "Current SDK wrote $QUEUE_FILE_COUNT queue file(s)."
+
+echo "Checking out downgraded SDK ref $DOWNGRADE_REF"
+mkdir -p "$(dirname "$OLD_REPO_DIR")"
+git clone --quiet --shared "$REPO_ROOT" "$OLD_REPO_DIR"
+git -C "$OLD_REPO_DIR" checkout --quiet "$DOWNGRADE_REF"
+
+create_smoke_package "$DOWNGRADED_SMOKE_DIR" "$OLD_REPO_DIR" "apiKey"
+echo "Starting downgraded SDK ($DOWNGRADE_REF) against current SDK state"
+run_smoke "$DOWNGRADED_SMOKE_DIR" read
+
+echo "Downgrade compatibility smoke test passed for $DOWNGRADE_REF"

--- a/scripts/test-downgrade-compatibility.sh
+++ b/scripts/test-downgrade-compatibility.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-# Verifies that state written by the current SDK can be read by an older SDK.
+# Verifies that persisted state written by the current SDK does not break an older SDK.
+# The current-writer path seeds identity storage plus analytics, replay, and logs queues.
 # Usage: DOWNGRADE_REF=<downgrade-ref> ./scripts/test-downgrade-compatibility.sh
-# Historical validation: WRITE_REF=3.48.1 DOWNGRADE_REF=3.48.0 ./scripts/test-downgrade-compatibility.sh
+# Historical event-queue validation: WRITE_REF=3.48.3 DOWNGRADE_REF=3.48.0 ./scripts/test-downgrade-compatibility.sh
 
 set -euo pipefail
 
@@ -10,6 +11,7 @@ DOWNGRADE_REF="${1:-${DOWNGRADE_REF:-3.48.0}}"
 WRITE_REF="${WRITE_REF:-}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SMOKE_TEMPLATE_DIR="$SCRIPT_DIR/downgrade-compatibility-smoke"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/posthog-ios-downgrade-compat.XXXXXX")"
 
 cleanup() {
@@ -65,94 +67,9 @@ fi
 create_smoke_package() {
     local package_dir="$1"
     local dependency_path="$2"
-    local config_initializer_label="$3"
-    local escaped_dependency_path="${dependency_path//\\/\\\\}"
-    escaped_dependency_path="${escaped_dependency_path//\"/\\\"}"
-    local package_identity
-    package_identity="$(basename "$dependency_path")"
-    package_identity="${package_identity%.git}"
-    package_identity="$(printf '%s' "$package_identity" | tr '[:upper:]' '[:lower:]')"
 
-    mkdir -p "$package_dir/Sources/DowngradeCompatibilitySmoke"
-
-    cat > "$package_dir/Package.swift" <<EOF
-// swift-tools-version:5.3
-import PackageDescription
-
-let package = Package(
-    name: "DowngradeCompatibilitySmoke",
-    platforms: [.macOS(.v10_15)],
-    products: [
-        .executable(name: "DowngradeCompatibilitySmoke", targets: ["DowngradeCompatibilitySmoke"]),
-    ],
-    dependencies: [
-        .package(path: "$escaped_dependency_path"),
-    ],
-    targets: [
-        .target(
-            name: "DowngradeCompatibilitySmoke",
-            dependencies: [.product(name: "PostHog", package: "$package_identity")]
-        ),
-    ]
-)
-EOF
-
-    cat > "$package_dir/Sources/DowngradeCompatibilitySmoke/main.swift" <<'EOF'
-import Foundation
-import PostHog
-
-let mode = CommandLine.arguments.dropFirst().first ?? "read"
-let token = ProcessInfo.processInfo.environment["POSTHOG_DOWNGRADE_TEST_TOKEN"] ?? "downgrade_compatibility_project"
-
-let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-print("Application Support: \(appSupport.path)")
-
-let config = PostHogConfig(__CONFIG_INITIALIZER_LABEL__: token, host: "http://127.0.0.1:9")
-config.flushAt = 10_000
-config.maxQueueSize = 10_000
-config.preloadFeatureFlags = false
-config.captureApplicationLifecycleEvents = false
-config.captureScreenViews = false
-config.enableSwizzling = false
-
-PostHogSDK.shared.setup(config)
-
-switch mode {
-case "write":
-    PostHogSDK.shared.identify(
-        "downgrade-compatibility-user",
-        userProperties: ["source": "downgrade-compatibility"]
-    )
-    PostHogSDK.shared.group(
-        type: "organization",
-        key: "posthog",
-        groupProperties: ["ci": true]
-    )
-
-    for index in 0 ..< 5 {
-        PostHogSDK.shared.capture(
-            "downgrade compatibility event",
-            properties: ["index": index, "source": "current-sdk"]
-        )
-    }
-
-    print("Wrote current SDK state for token \(token)")
-case "read":
-    PostHogSDK.shared.capture(
-        "downgrade compatibility read smoke",
-        properties: ["source": "downgraded-sdk"]
-    )
-    print("Downgraded SDK started and read latest state for token \(token)")
-default:
-    fatalError("Unknown mode: \(mode)")
-}
-
-// Give any setup-time async work a short chance to start so startup crashes are observable.
-Thread.sleep(forTimeInterval: 0.2)
-EOF
-
-    perl -pi -e "s/__CONFIG_INITIALIZER_LABEL__/$config_initializer_label/g" \
-        "$package_dir/Sources/DowngradeCompatibilitySmoke/main.swift"
+    mkdir -p "$package_dir"
+    cp -R "$SMOKE_TEMPLATE_DIR/." "$package_dir"
 
     local dependency_resolved="$dependency_path/Package.resolved"
     if [ -f "$dependency_resolved" ]; then
@@ -163,25 +80,57 @@ EOF
 run_smoke() {
     local package_dir="$1"
     local mode="$2"
+    local dependency_path="$3"
+    local include_current_storage_writes="${4:-0}"
 
     # CFFIXED_USER_HOME makes Foundation's user-domain Application Support
     # directory point at our temp home on macOS, keeping the smoke state isolated.
     CFFIXED_USER_HOME="$STATE_HOME" \
     HOME="$STATE_HOME" \
     POSTHOG_DOWNGRADE_TEST_TOKEN="$TOKEN" \
+    POSTHOG_DOWNGRADE_SMOKE_DEPENDENCY_PATH="$dependency_path" \
+    POSTHOG_DOWNGRADE_SMOKE_CURRENT_WRITER="$include_current_storage_writes" \
     xcrun swift run --package-path "$package_dir" DowngradeCompatibilitySmoke "$mode"
 }
 
-count_queue_files() {
+count_storage_files() {
+    local folder_name="$1"
     local state_root="$STATE_HOME/Library/Application Support"
     if [ ! -d "$state_root" ]; then
         echo 0
         return
     fi
 
-    find "$state_root" -type f \
-        \( -path "*/posthog.queueFolder/*" -o -path "*/posthog.queueFolder.uuid/*" \) \
-        | wc -l | tr -d ' '
+    find "$state_root" -type f -path "*/$folder_name/*" | wc -l | tr -d ' '
+}
+
+count_storage_key_files() {
+    local file_name="$1"
+    local state_root="$STATE_HOME/Library/Application Support"
+    if [ ! -d "$state_root" ]; then
+        echo 0
+        return
+    fi
+
+    find "$state_root" -type f -name "$file_name" | wc -l | tr -d ' '
+}
+
+count_event_queue_files() {
+    local current_queue_count
+    local legacy_queue_count
+    current_queue_count="$(count_storage_files "posthog.queueFolder.uuid")"
+    legacy_queue_count="$(count_storage_files "posthog.queueFolder")"
+    echo $((current_queue_count + legacy_queue_count))
+}
+
+require_positive_count() {
+    local description="$1"
+    local count="$2"
+    if [ "$count" -eq 0 ]; then
+        echo "Expected $description to be persisted, but none were found. State tree:" >&2
+        find "$STATE_HOME/Library/Application Support" -maxdepth 8 -print | sort >&2 || true
+        exit 1
+    fi
 }
 
 if [ -n "$WRITE_REF" ]; then
@@ -190,34 +139,49 @@ if [ -n "$WRITE_REF" ]; then
     git clone --quiet --shared "$REPO_ROOT" "$WRITER_REPO_DIR"
     git -C "$WRITER_REPO_DIR" checkout --quiet "$WRITE_REF"
     WRITER_DEPENDENCY_PATH="$WRITER_REPO_DIR"
-    WRITER_CONFIG_LABEL="apiKey"
     WRITER_DESCRIPTION="$WRITE_REF"
+    INCLUDE_CURRENT_STORAGE_WRITES=0
 else
     WRITER_DEPENDENCY_PATH="$REPO_ROOT"
-    WRITER_CONFIG_LABEL="projectToken"
     WRITER_DESCRIPTION="current checkout at $REPO_ROOT"
+    INCLUDE_CURRENT_STORAGE_WRITES=1
 fi
 
 echo "Writing state with $WRITER_DESCRIPTION"
-create_smoke_package "$CURRENT_SMOKE_DIR" "$WRITER_DEPENDENCY_PATH" "$WRITER_CONFIG_LABEL"
-run_smoke "$CURRENT_SMOKE_DIR" write
+create_smoke_package "$CURRENT_SMOKE_DIR" "$WRITER_DEPENDENCY_PATH"
+run_smoke "$CURRENT_SMOKE_DIR" write "$WRITER_DEPENDENCY_PATH" "$INCLUDE_CURRENT_STORAGE_WRITES"
 
-QUEUE_FILE_COUNT="$(count_queue_files)"
-if [ "$QUEUE_FILE_COUNT" -eq 0 ]; then
-    echo "Expected the current SDK to write queued event files, but none were found. State tree:" >&2
-    find "$STATE_HOME/Library/Application Support" -maxdepth 8 -print | sort >&2 || true
-    exit 1
+EVENT_QUEUE_FILE_COUNT="$(count_event_queue_files)"
+require_positive_count "queued analytics event files" "$EVENT_QUEUE_FILE_COUNT"
+require_positive_count "persisted distinctId" "$(count_storage_key_files "posthog.distinctId")"
+require_positive_count "persisted group properties" "$(count_storage_key_files "posthog.groups")"
+
+echo "Writer SDK persisted $EVENT_QUEUE_FILE_COUNT analytics event queue file(s)."
+
+if [ "$INCLUDE_CURRENT_STORAGE_WRITES" = "1" ]; then
+    REPLAY_QUEUE_FILE_COUNT="$(count_storage_files "posthog.replayFolder.uuid")"
+    LEGACY_REPLAY_QUEUE_FILE_COUNT="$(count_storage_files "posthog.replayFolder")"
+    LOGS_QUEUE_FILE_COUNT="$(count_storage_files "posthog.logsFolder")"
+
+    require_positive_count "queued replay snapshot files" "$REPLAY_QUEUE_FILE_COUNT"
+    require_positive_count "queued log files" "$LOGS_QUEUE_FILE_COUNT"
+
+    if [ "$LEGACY_REPLAY_QUEUE_FILE_COUNT" -ne 0 ]; then
+        echo "Expected current SDK replay snapshots to avoid legacy posthog.replayFolder, but found $LEGACY_REPLAY_QUEUE_FILE_COUNT file(s)." >&2
+        find "$STATE_HOME/Library/Application Support" -maxdepth 8 -print | sort >&2 || true
+        exit 1
+    fi
+
+    echo "Current SDK also persisted $REPLAY_QUEUE_FILE_COUNT replay snapshot file(s) and $LOGS_QUEUE_FILE_COUNT log file(s)."
 fi
-
-echo "Current SDK wrote $QUEUE_FILE_COUNT queue file(s)."
 
 echo "Checking out downgraded SDK ref $DOWNGRADE_REF"
 mkdir -p "$(dirname "$OLD_REPO_DIR")"
 git clone --quiet --shared "$REPO_ROOT" "$OLD_REPO_DIR"
 git -C "$OLD_REPO_DIR" checkout --quiet "$DOWNGRADE_REF"
 
-create_smoke_package "$DOWNGRADED_SMOKE_DIR" "$OLD_REPO_DIR" "apiKey"
+create_smoke_package "$DOWNGRADED_SMOKE_DIR" "$OLD_REPO_DIR"
 echo "Starting downgraded SDK ($DOWNGRADE_REF) against current SDK state"
-run_smoke "$DOWNGRADED_SMOKE_DIR" read
+run_smoke "$DOWNGRADED_SMOKE_DIR" read "$OLD_REPO_DIR" 0
 
 echo "Downgrade compatibility smoke test passed for $DOWNGRADE_REF"

--- a/scripts/test-downgrade-compatibility.sh
+++ b/scripts/test-downgrade-compatibility.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Verifies that state written by the current SDK can be read by an older SDK.
-# Usage: ./scripts/test-downgrade-compatibility.sh <downgrade-ref>
-# Historical validation: WRITE_REF=3.48.1 ./scripts/test-downgrade-compatibility.sh 3.48.0
+# Usage: DOWNGRADE_REF=<downgrade-ref> ./scripts/test-downgrade-compatibility.sh
+# Historical validation: WRITE_REF=3.48.1 DOWNGRADE_REF=3.48.0 ./scripts/test-downgrade-compatibility.sh
 
 set -euo pipefail
 
@@ -153,6 +153,11 @@ EOF
 
     perl -pi -e "s/__CONFIG_INITIALIZER_LABEL__/$config_initializer_label/g" \
         "$package_dir/Sources/DowngradeCompatibilitySmoke/main.swift"
+
+    local dependency_resolved="$dependency_path/Package.resolved"
+    if [ -f "$dependency_resolved" ]; then
+        cp "$dependency_resolved" "$package_dir/Package.resolved"
+    fi
 }
 
 run_smoke() {

--- a/scripts/test-downgrade-compatibility.sh
+++ b/scripts/test-downgrade-compatibility.sh
@@ -30,6 +30,23 @@ TOKEN="downgrade_compatibility_project"
 
 mkdir -p "$STATE_HOME/Library/Application Support"
 
+validate_ref() {
+    local ref="$1"
+    local label="$2"
+
+    # Keep ref inputs safe for git refspecs/options. CI passes static matrix values,
+    # but this script is also useful locally via DOWNGRADE_REF/WRITE_REF.
+    if [[ -z "$ref" || "$ref" == -* || "$ref" == *..* || ! "$ref" =~ ^[A-Za-z0-9._/+%-]+$ ]]; then
+        echo "Invalid $label: $ref" >&2
+        exit 64
+    fi
+}
+
+validate_ref "$DOWNGRADE_REF" "downgrade ref"
+if [ -n "$WRITE_REF" ]; then
+    validate_ref "$WRITE_REF" "writer ref"
+fi
+
 ensure_ref() {
     local ref="$1"
     if ! git -C "$REPO_ROOT" rev-parse --verify --quiet "$ref^{commit}" >/dev/null; then


### PR DESCRIPTION
## :bulb: Motivation and Context

Adds a CI regression guard for https://github.com/PostHog/posthog-ios/issues/537.

The new job writes persisted SDK state with the current checkout, then starts an older SDK version against that same state. This catches downgrade-incompatible state changes like the UUID queue filename issue that caused 3.48.0 startup crashes after running 3.48.1+.


## :green_heart: How did you test it?

- `make testDowngradeCompatibility`
- `WRITE_REF=3.48.1 DOWNGRADE_REF=3.48.0 make testDowngradeCompatibility` fails as expected with the historical crash
- `bash -n scripts/test-downgrade-compatibility.sh`
- `git diff --check`
- Invalid ref hardening check: `DOWNGRADE_REF='--upload-pack=sh' make testDowngradeCompatibility` rejects the ref before git commands run
- Ran pre-PR review loop and addressed kept findings


## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
