### PR TITLE
fix: clear queue after repeated failed restore attempts

### DIFF
--- a/.changeset/wild-lands-unite.md
+++ b/.changeset/wild-lands-unite.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+fix: clear queue after repeated failed restore attempts to recover from disk queue corruption

--- a/PostHog/PostHogFileBackedQueue.swift
+++ b/PostHog/PostHogFileBackedQueue.swift
@@ -7,21 +7,37 @@
 
 import Foundation
 
+private let maxRestoreAttempts = 3
+
 class PostHogFileBackedQueue {
     let queue: URL
     private var items = [String]()
     private let itemsLock = NSLock()
+    private let restoreAttemptsKey: String?
 
     var depth: Int {
         itemsLock.withLock { items.count }
     }
 
-    init(queue: URL, oldQueues: [URL] = []) {
+    init(queue: URL, oldQueues: [URL] = [], restoreAttemptsKey: String? = nil) {
         self.queue = queue
-        setup(oldQueues: oldQueues)
+        self.restoreAttemptsKey = restoreAttemptsKey
+        setup(oldQueues: oldQueues, trackAttempts: true)
     }
 
-    private func setup(oldQueues: [URL]) {
+    private func setup(oldQueues: [URL], trackAttempts: Bool) {
+        if trackAttempts, let key = restoreAttemptsKey {
+            let previousAttempts = UserDefaults.standard.integer(forKey: key)
+
+            if previousAttempts >= maxRestoreAttempts {
+                hedgeLog("Queue restore failed \(previousAttempts) consecutive time(s), clearing queue directory")
+                deleteSafely(queue)
+                UserDefaults.standard.set(0, forKey: key)
+            }
+
+            UserDefaults.standard.set(UserDefaults.standard.integer(forKey: key) + 1, forKey: key)
+        }
+
         do {
             try FileManager.default.createDirectory(atPath: queue.path, withIntermediateDirectories: true)
         } catch {
@@ -48,6 +64,11 @@ class PostHogFileBackedQueue {
         } catch {
             hedgeLog("Failed to load files for queue \(error)")
             // failed to read directory – bad permissions, perhaps?
+            return
+        }
+
+        if trackAttempts, let key = restoreAttemptsKey {
+            UserDefaults.standard.set(0, forKey: key)
         }
     }
 
@@ -83,7 +104,7 @@ class PostHogFileBackedQueue {
     /// Internal, used for testing
     func clear() {
         deleteSafely(queue)
-        setup(oldQueues: [])
+        setup(oldQueues: [], trackAttempts: false)
     }
 
     /// Reloads items from disk and sorts by creation date.

--- a/PostHog/PostHogQueue.swift
+++ b/PostHog/PostHogQueue.swift
@@ -118,7 +118,8 @@ class PostHogQueue<Record> {
             rateCapWindowSeconds = endpoint.rateCapWindowSeconds(config)
             fileQueue = PostHogFileBackedQueue(
                 queue: storage.url(forKey: endpoint.storageKey),
-                oldQueues: endpoint.oldStorageKeys.map { storage.url(forKey: $0) }
+                oldQueues: endpoint.oldStorageKeys.map { storage.url(forKey: $0) },
+                restoreAttemptsKey: "restore_attempt_\(endpoint.storageKey.rawValue)"
             )
             dispatchQueue = DispatchQueue(label: endpoint.dispatchQueueLabel, target: .global(qos: .utility))
         }
@@ -133,7 +134,8 @@ class PostHogQueue<Record> {
             rateCapWindowSeconds = endpoint.rateCapWindowSeconds(config)
             fileQueue = PostHogFileBackedQueue(
                 queue: storage.url(forKey: endpoint.storageKey),
-                oldQueues: endpoint.oldStorageKeys.map { storage.url(forKey: $0) }
+                oldQueues: endpoint.oldStorageKeys.map { storage.url(forKey: $0) },
+                restoreAttemptsKey: "restore_attempt_\(endpoint.storageKey.rawValue)"
             )
             dispatchQueue = DispatchQueue(label: endpoint.dispatchQueueLabel, target: .global(qos: .utility))
         }

--- a/PostHogTests/PostHogFileBackedQueueTest.swift
+++ b/PostHogTests/PostHogFileBackedQueueTest.swift
@@ -263,5 +263,52 @@ class PostHogFileBackedQueueTest: QuickSpec {
 
             sut.clear()
         }
+
+        it("clears queue after maxRestoreAttempts consecutive failed setups") {
+            let attemptsKey = "test.queueRestoreAttempts"
+            let queueURL = applicationSupportDirectoryURL().appendingPathComponent("recoverQueue")
+
+            // Seed the queue with a file so we can verify it gets cleared
+            try FileManager.default.createDirectory(atPath: queueURL.path, withIntermediateDirectories: true)
+            let seedFile = queueURL.appendingPathComponent("seed.dat")
+            try "data".data(using: .utf8)!.write(to: seedFile)
+
+            // Simulate failed setups by pre-setting the counter to maxRestoreAttempts
+            UserDefaults.standard.set(3, forKey: attemptsKey)
+
+            let sut = PostHogFileBackedQueue(queue: queueURL, restoreAttemptsKey: attemptsKey)
+
+            // Queue should be empty — the directory was cleared before setup ran
+            expect(sut.depth) == 0
+            expect(FileManager.default.fileExists(atPath: seedFile.path)) == false
+
+            // Counter resets to 0 after clearing — the clean directory setup will succeed
+            expect(UserDefaults.standard.integer(forKey: attemptsKey)) == 0
+
+            // Successful setup resets counter to 0
+            _ = PostHogFileBackedQueue(queue: queueURL, restoreAttemptsKey: attemptsKey)
+            expect(UserDefaults.standard.integer(forKey: attemptsKey)) == 0
+
+            sut.clear()
+            UserDefaults.standard.removeObject(forKey: attemptsKey)
+        }
+
+        it("does not increment setup attempt counter when clear() reinitialises the queue") {
+            let attemptsKey = "test.queueRestoreAttemptsClear"
+            let queueURL = applicationSupportDirectoryURL().appendingPathComponent("clearQueue")
+
+            UserDefaults.standard.set(0, forKey: attemptsKey)
+
+            let sut = PostHogFileBackedQueue(queue: queueURL, restoreAttemptsKey: attemptsKey)
+            // Counter is 0 after a successful init
+            expect(UserDefaults.standard.integer(forKey: attemptsKey)) == 0
+
+            sut.clear()
+
+            // clear() must not touch the counter
+            expect(UserDefaults.standard.integer(forKey: attemptsKey)) == 0
+
+            UserDefaults.standard.removeObject(forKey: attemptsKey)
+        }
     }
 }


### PR DESCRIPTION
…om disk queue corruption

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

After 3 consecutive failures to load a disk queue, the queue directory is cleared before the next attempt, giving the SDK a clean slate to recover from. This is done at the expense of dropping events. 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
