### PR TITLE
feat: auto-attach $screen_name to all events

### DIFF
--- a/.changeset/screen-name-on-all-events.md
+++ b/.changeset/screen-name-on-all-events.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": minor
+---
+
+Auto-attach `$screen_name` to every captured event after `PostHogSDK.shared.screen()` has been called, or whenever screen auto-capture is on (default). Cached value is cleared by `reset()` and `close()`. To opt out, set `PostHogConfig.captureScreenViews = false` and avoid calling `screen()` manually. Behavior change: existing events from `captureException`, `identify`, etc. will start carrying `$screen_name` for users who hadn't disabled screen capture. Closes posthog-android#119.

--- a/.changeset/screen-name-on-all-events.md
+++ b/.changeset/screen-name-on-all-events.md
@@ -2,18 +2,6 @@
 "posthog-ios": minor
 ---
 
-Auto-attach `$screen_name` to every captured event after `PostHogSDK.shared.screen()` has been called (manually or via screen-view auto-capture). Cached value is cleared by `reset()` and `close()`. Closes posthog-android#119.
+Auto-attach `$screen_name` to every captured event after `PostHogSDK.shared.screen()` has been called (manually or via screen-view auto-capture). Cached value is cleared by `reset()` and `close()`.
 
 **To opt out of `$screen_name` stamping entirely**, set `PostHogConfig.captureScreenViews = false` **and** stop calling `screen()` manually. Disabling `captureScreenViews` alone is not sufficient — a single manual `screen("Home")` call will re-enable stamping.
-
-## Behavior changes
-
-These all affect what your events carry on the wire. Review your dashboards/insights/HogQL queries:
-
-- **Cross-event stamping.** `$exception`, `$identify`, `$autocapture`, `$create_alias`, `$groupidentify`, custom events, etc. will start carrying `$screen_name` whenever a screen has been recorded in the session. Previously only `$screen` events carried it. `$snapshot` events are excluded.
-- **SwiftUI `$screen` event payloads change shape.** Names are now sanitized: `$screen_name = "UIHostingController<MyView>"` → `$screen_name = "MyView"`. **Hard cutover for HogQL filters** like `properties.$screen_name LIKE 'UIHostingController%'` or `properties.$screen_name LIKE 'ModifiedContent%'` — they will start returning zero matches. Customers will need to rewrite those filters using the bare type name.
-- **Type-erased SwiftUI roots stop emitting `$screen`.** Apps whose `body: some View` resolves to `AnyView` (e.g. mixed-type branches returning `AnyView(...)`) will see `$screen` event counts **drop to zero** for those screens — the swizzle still fires, but sanitize returns nil and the event is suppressed. To restore: expose a real type via `.postHogScreenView("MyScreen")` modifier, or call `screen("MyScreen")` manually.
-- **`$screen` event override semantics flipped.** `screen("Home", properties: ["$screen_name": "Override"])` now ships `$screen_name = "Override"` on the `$screen` event. Previously the `screenTitle` arg won (`{ prop, _ in prop }`). This aligns iOS with Android. Customers who passed `$screen_name` defensively in `properties` will see their override take effect.
-- **`screen("")` is silently dropped.** Previously an empty `screenTitle` emitted a `$screen` event with `$screen_name = ""`; now nothing is emitted and the cache is untouched. Customers using empty-string as a sentinel in dashboards will see those rows disappear.
-- **`screen("AnyView")` (literal manual call) is honored.** Only `AnyView` that surfaced from stripping `UIHostingController<...>` / `ModifiedContent<...>` wrappers is dropped (auto-capture noise from `body: some View` type erasure). A caller who literally typed `screen("AnyView")` gets that event through.
-- **Out-of-process crash reports carry `$screen_name` too.** `screen()` now refreshes the crash-replay context snapshot, so an `$exception` event reconstructed from a crash that happened on a given screen will ship with that screen name — matching the behavior of live `captureException(_:)` calls.

--- a/.changeset/screen-name-on-all-events.md
+++ b/.changeset/screen-name-on-all-events.md
@@ -2,11 +2,21 @@
 "posthog-ios": minor
 ---
 
-Auto-attach `$screen_name` to every captured event after `PostHogSDK.shared.screen()` has been called, or whenever screen auto-capture is on (default). Cached value is cleared by `reset()` and `close()`. To opt out, set `PostHogConfig.captureScreenViews = false` and avoid calling `screen()` manually. Closes posthog-android#119.
+Auto-attach `$screen_name` to every captured event after `PostHogSDK.shared.screen()` has been called (manually or via screen-view auto-capture). Cached value is cleared by `reset()` and `close()`. Closes posthog-android#119.
 
-Additional behavior changes:
+**To opt out of `$screen_name` stamping entirely**, set `PostHogConfig.captureScreenViews = false` **and** stop calling `screen()` manually. Disabling `captureScreenViews` alone is not sufficient — a single manual `screen("Home")` call will re-enable stamping.
 
-- `screen()` now sanitizes SwiftUI wrappers before emitting: `$screen` events on SwiftUI apps will carry `"MyView"` instead of `"UIHostingController<MyView>"`. Same applies to the `$screen_name` cached on subsequent events.
-- `screen("")` and auto-captured `UIHostingController<…AnyView…>` chains (anything that sanitizes to empty, or to `AnyView` after wrapper-stripping) are silently dropped — no `$screen` event, cache untouched. A manual `screen("AnyView")` call is honored as-is.
-- Caller-supplied `$screen_name` in `properties` now wins on the `$screen` event itself (previously the `screenTitle` arg won), matching the cross-event override on `capture()` and aligning with Android.
-- Existing events from `captureException`, `identify`, etc. will start carrying `$screen_name` for users who hadn't disabled screen capture.
+## Behavior changes
+
+These all affect what your events carry on the wire. Review your dashboards/insights/HogQL queries:
+
+- **Cross-event stamping.** `$exception`, `$identify`, `$autocapture`, `$create_alias`, `$groupidentify`, custom events, etc. will start carrying `$screen_name` whenever a screen has been recorded in the session. Previously only `$screen` events carried it. `$snapshot` events are excluded.
+- **SwiftUI `$screen` event payloads change shape.** Names are now sanitized: `$screen_name = "UIHostingController<MyView>"` → `$screen_name = "MyView"`. **Hard cutover for HogQL filters** like `properties.$screen_name LIKE 'UIHostingController%'` or `properties.$screen_name LIKE 'ModifiedContent%'` — they will start returning zero matches. Customers will need to rewrite those filters using the bare type name.
+- **Type-erased SwiftUI roots stop emitting `$screen`.** Apps whose `body: some View` resolves to `AnyView` (e.g. mixed-type branches returning `AnyView(...)`) will see `$screen` event counts **drop to zero** for those screens — the swizzle still fires, but sanitize returns nil and the event is suppressed. To restore: expose a real type via `.postHogScreenView("MyScreen")` modifier, or call `screen("MyScreen")` manually.
+- **`$screen` event override semantics flipped.** `screen("Home", properties: ["$screen_name": "Override"])` now ships `$screen_name = "Override"` on the `$screen` event. Previously the `screenTitle` arg won (`{ prop, _ in prop }`). This aligns iOS with Android. Customers who passed `$screen_name` defensively in `properties` will see their override take effect.
+- **`screen("")` is silently dropped.** Previously an empty `screenTitle` emitted a `$screen` event with `$screen_name = ""`; now nothing is emitted and the cache is untouched. Customers using empty-string as a sentinel in dashboards will see those rows disappear.
+- **`screen("AnyView")` (literal manual call) is honored.** Only `AnyView` that surfaced from stripping `UIHostingController<...>` / `ModifiedContent<...>` wrappers is dropped (auto-capture noise from `body: some View` type erasure). A caller who literally typed `screen("AnyView")` gets that event through.
+
+## Known asymmetry
+
+Live `captureException(_:)` calls (caught and rethrown by your code) **will** carry `$screen_name`. Crash-replay `$exception` events fired from the error-tracking auto-capture integration (out-of-process crashes) **will not** — that path bypasses `buildProperties` via `skipBuildProperties: true` to preserve the snapshot taken at crash time. If you segment exception analytics by `$screen_name`, expect a gap on the crash-replay rows.

--- a/.changeset/screen-name-on-all-events.md
+++ b/.changeset/screen-name-on-all-events.md
@@ -16,7 +16,4 @@ These all affect what your events carry on the wire. Review your dashboards/insi
 - **`$screen` event override semantics flipped.** `screen("Home", properties: ["$screen_name": "Override"])` now ships `$screen_name = "Override"` on the `$screen` event. Previously the `screenTitle` arg won (`{ prop, _ in prop }`). This aligns iOS with Android. Customers who passed `$screen_name` defensively in `properties` will see their override take effect.
 - **`screen("")` is silently dropped.** Previously an empty `screenTitle` emitted a `$screen` event with `$screen_name = ""`; now nothing is emitted and the cache is untouched. Customers using empty-string as a sentinel in dashboards will see those rows disappear.
 - **`screen("AnyView")` (literal manual call) is honored.** Only `AnyView` that surfaced from stripping `UIHostingController<...>` / `ModifiedContent<...>` wrappers is dropped (auto-capture noise from `body: some View` type erasure). A caller who literally typed `screen("AnyView")` gets that event through.
-
-## Known asymmetry
-
-Live `captureException(_:)` calls (caught and rethrown by your code) **will** carry `$screen_name`. Crash-replay `$exception` events fired from the error-tracking auto-capture integration (out-of-process crashes) **will not** — that path bypasses `buildProperties` via `skipBuildProperties: true` to preserve the snapshot taken at crash time. If you segment exception analytics by `$screen_name`, expect a gap on the crash-replay rows.
+- **Out-of-process crash reports carry `$screen_name` too.** `screen()` now refreshes the crash-replay context snapshot, so an `$exception` event reconstructed from a crash that happened on a given screen will ship with that screen name — matching the behavior of live `captureException(_:)` calls.

--- a/.changeset/screen-name-on-all-events.md
+++ b/.changeset/screen-name-on-all-events.md
@@ -7,6 +7,6 @@ Auto-attach `$screen_name` to every captured event after `PostHogSDK.shared.scre
 Additional behavior changes:
 
 - `screen()` now sanitizes SwiftUI wrappers before emitting: `$screen` events on SwiftUI apps will carry `"MyView"` instead of `"UIHostingController<MyView>"`. Same applies to the `$screen_name` cached on subsequent events.
-- `screen("")` and `screen("AnyView")` (and anything that sanitizes to an empty/`AnyView`-only name) are silently dropped — no `$screen` event, cache untouched.
+- `screen("")` and auto-captured `UIHostingController<…AnyView…>` chains (anything that sanitizes to empty, or to `AnyView` after wrapper-stripping) are silently dropped — no `$screen` event, cache untouched. A manual `screen("AnyView")` call is honored as-is.
 - Caller-supplied `$screen_name` in `properties` now wins on the `$screen` event itself (previously the `screenTitle` arg won), matching the cross-event override on `capture()` and aligning with Android.
 - Existing events from `captureException`, `identify`, etc. will start carrying `$screen_name` for users who hadn't disabled screen capture.

--- a/.changeset/screen-name-on-all-events.md
+++ b/.changeset/screen-name-on-all-events.md
@@ -2,4 +2,11 @@
 "posthog-ios": minor
 ---
 
-Auto-attach `$screen_name` to every captured event after `PostHogSDK.shared.screen()` has been called, or whenever screen auto-capture is on (default). Cached value is cleared by `reset()` and `close()`. To opt out, set `PostHogConfig.captureScreenViews = false` and avoid calling `screen()` manually. Behavior change: existing events from `captureException`, `identify`, etc. will start carrying `$screen_name` for users who hadn't disabled screen capture. Closes posthog-android#119.
+Auto-attach `$screen_name` to every captured event after `PostHogSDK.shared.screen()` has been called, or whenever screen auto-capture is on (default). Cached value is cleared by `reset()` and `close()`. To opt out, set `PostHogConfig.captureScreenViews = false` and avoid calling `screen()` manually. Closes posthog-android#119.
+
+Additional behavior changes:
+
+- `screen()` now sanitizes SwiftUI wrappers before emitting: `$screen` events on SwiftUI apps will carry `"MyView"` instead of `"UIHostingController<MyView>"`. Same applies to the `$screen_name` cached on subsequent events.
+- `screen("")` and `screen("AnyView")` (and anything that sanitizes to an empty/`AnyView`-only name) are silently dropped — no `$screen` event, cache untouched.
+- Caller-supplied `$screen_name` in `properties` now wins on the `$screen` event itself (previously the `screenTitle` arg won), matching the cross-event override on `capture()` and aligning with Android.
+- Existing events from `captureException`, `identify`, etc. will start carrying `$screen_name` for users who hadn't disabled screen capture.

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -259,6 +259,7 @@
 		DA5063C92EF585AB00C51DA0 /* PostHogErrorTrackingUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5063C82EF585AB00C51DA0 /* PostHogErrorTrackingUtils.swift */; };
 		DA5063D22EF5918200C51DA0 /* PostHogCrashReportProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5063D12EF5918200C51DA0 /* PostHogCrashReportProcessor.swift */; };
 		DA5064412EF5E40300C51DA0 /* ApplicationScreenViewPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA578E992D676AE700B3A56C /* ApplicationScreenViewPublisher.swift */; };
+		5CA51F0E2B5C9A0100000003 /* PostHogScreenNameSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA51F0E2B5C9A0100000004 /* PostHogScreenNameSanitizer.swift */; };
 		DA5064432EF5E58D00C51DA0 /* PostHogErrorTrackingAutoCaptureIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5064422EF5E58D00C51DA0 /* PostHogErrorTrackingAutoCaptureIntegration.swift */; };
 		DA5064572EF6171900C51DA0 /* SwiftCrashTriggers.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5064562EF6171900C51DA0 /* SwiftCrashTriggers.swift */; };
 		DA5175B32F6C4CEA00F0E00A /* PostHogReplayBufferDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5175B12F6C4CEA00F0E00A /* PostHogReplayBufferDelegate.swift */; };
@@ -1007,6 +1008,7 @@
 		DA53DE7D2D3E66A300C38DCA /* PostHogRemoteConfigTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogRemoteConfigTest.swift; sourceTree = "<group>"; };
 		DA578E972D6768B400B3A56C /* PostHogScreenViewIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogScreenViewIntegration.swift; sourceTree = "<group>"; };
 		DA578E992D676AE700B3A56C /* ApplicationScreenViewPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationScreenViewPublisher.swift; sourceTree = "<group>"; };
+		5CA51F0E2B5C9A0100000004 /* PostHogScreenNameSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogScreenNameSanitizer.swift; sourceTree = "<group>"; };
 		DA578E9B2D68578500B3A56C /* MockApplicationLifecyclePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockApplicationLifecyclePublisher.swift; sourceTree = "<group>"; };
 		DA578E9D2D6858B200B3A56C /* PostHogScreenViewIntegrationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogScreenViewIntegrationTest.swift; sourceTree = "<group>"; };
 		DA578E9F2D6858C900B3A56C /* MockScreenViewPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockScreenViewPublisher.swift; sourceTree = "<group>"; };
@@ -1888,6 +1890,7 @@
 			isa = PBXGroup;
 			children = (
 				DA578E992D676AE700B3A56C /* ApplicationScreenViewPublisher.swift */,
+				5CA51F0E2B5C9A0100000004 /* PostHogScreenNameSanitizer.swift */,
 				DA578E972D6768B400B3A56C /* PostHogScreenViewIntegration.swift */,
 			);
 			path = ScreenViews;
@@ -3206,6 +3209,7 @@
 				69B7F60C2CF7703400A48BCC /* UIImage+Util.swift in Sources */,
 				DA703C1C2D6616FD0069097B /* PostHogAppLifeCycleIntegration.swift in Sources */,
 				DA5064412EF5E40300C51DA0 /* ApplicationScreenViewPublisher.swift in Sources */,
+				5CA51F0E2B5C9A0100000003 /* PostHogScreenNameSanitizer.swift in Sources */,
 				DAB565CA2D142F8F0088F720 /* PostHogNoMaskViewModifier.swift in Sources */,
 				69261D132AD5685B00232EC7 /* PostHogRemoteConfig.swift in Sources */,
 				DA9AE8F42D89AFD7002F1B44 /* BottomSection.swift in Sources */,

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		690FF0EF2AEFF23D00A0B06B /* OHHTTPStubsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 690FF0EE2AEFF23D00A0B06B /* OHHTTPStubsSwift */; };
 		690FF0F12AEFF24200A0B06B /* OHHTTPStubs in Frameworks */ = {isa = PBXBuildFile; productRef = 690FF0F02AEFF24200A0B06B /* OHHTTPStubs */; };
 		690FF0F52AF0F06100A0B06B /* PostHogSDKTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690FF0F42AF0F06100A0B06B /* PostHogSDKTest.swift */; };
+		5CA51F0E2B5C9A0100000001 /* PostHogScreenNameTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA51F0E2B5C9A0100000002 /* PostHogScreenNameTest.swift */; };
 		69261D132AD5685B00232EC7 /* PostHogRemoteConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69261D122AD5685B00232EC7 /* PostHogRemoteConfig.swift */; };
 		69261D192AD9673500232EC7 /* PostHogUploadInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69261D182AD9673500232EC7 /* PostHogUploadInfo.swift */; };
 		69261D1B2AD9678C00232EC7 /* PostHogEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69261D1A2AD9678C00232EC7 /* PostHogEvent.swift */; };
@@ -810,6 +811,7 @@
 		690FF0E22AEFD12900A0B06B /* PostHogConfigTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogConfigTest.swift; sourceTree = "<group>"; };
 		690FF0E82AEFD3BD00A0B06B /* PostHogQueueTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogQueueTest.swift; sourceTree = "<group>"; };
 		690FF0F42AF0F06100A0B06B /* PostHogSDKTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSDKTest.swift; sourceTree = "<group>"; };
+		5CA51F0E2B5C9A0100000002 /* PostHogScreenNameTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogScreenNameTest.swift; sourceTree = "<group>"; };
 		690FF1732AF3CE8A00A0B06B /* PostHogExampleWatchOS.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = PostHogExampleWatchOS.xcodeproj; path = PostHogExampleWatchOS/PostHogExampleWatchOS.xcodeproj; sourceTree = "<group>"; };
 		69261D122AD5685B00232EC7 /* PostHogRemoteConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogRemoteConfig.swift; sourceTree = "<group>"; };
 		69261D182AD9673500232EC7 /* PostHogUploadInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogUploadInfo.swift; sourceTree = "<group>"; };
@@ -1603,6 +1605,7 @@
 				690FF0E22AEFD12900A0B06B /* PostHogConfigTest.swift */,
 				690FF0E82AEFD3BD00A0B06B /* PostHogQueueTest.swift */,
 				690FF0F42AF0F06100A0B06B /* PostHogSDKTest.swift */,
+				5CA51F0E2B5C9A0100000002 /* PostHogScreenNameTest.swift */,
 				DA6F24812D4A6CA100CA2777 /* PostHogApiTest.swift */,
 				DA578E9D2D6858B200B3A56C /* PostHogScreenViewIntegrationTest.swift */,
 				DACF6D5C2CD2F5BC00F14133 /* PostHogAutocaptureIntegrationSpec.swift */,
@@ -3288,6 +3291,7 @@
 				DA979D7B2CD370B700F56BAE /* PostHogAutocaptureEventTrackerSpec.swift in Sources */,
 				DA0C944B2D54CDD000BFD9FB /* PostHogStorageMigrationTest.swift in Sources */,
 				690FF0F52AF0F06100A0B06B /* PostHogSDKTest.swift in Sources */,
+				5CA51F0E2B5C9A0100000001 /* PostHogScreenNameTest.swift in Sources */,
 				690FF0E12AEFC59100A0B06B /* PostHogFileBackedQueueTest.swift in Sources */,
 				DA578E9C2D68578500B3A56C /* MockApplicationLifecyclePublisher.swift in Sources */,
 				DA4FFBB52DAD5B01006BAEEA /* PostHogIdentityTests.swift in Sources */,

--- a/PostHog/Logs/PostHogLogger.swift
+++ b/PostHog/Logs/PostHogLogger.swift
@@ -22,20 +22,25 @@ import Foundation
     }
 
     /// Strips SwiftUI's `UIHostingController` / `ModifiedContent` wrappers to
-    /// surface the user's actual view type. Returns `nil` when the inner type
-    /// was erased to `AnyView` (no useful name to surface). UIKit class names
-    /// pass through unchanged.
+    /// surface the user's actual view type. Empty inputs always return `nil`.
+    /// An `AnyView` result is dropped only when it surfaced from stripping
+    /// (auto-capture noise from `body: some View` erasure); a caller who
+    /// manually passes `"AnyView"` is honored as-is.
     static func sanitize(rawScreenName name: String) -> String? {
         var current = name
+        var didStrip = false
         if let inner = stripGeneric(current, wrapper: "UIHostingController") {
             current = inner
+            didStrip = true
         }
         while let inner = stripGeneric(current, wrapper: "ModifiedContent"),
               let firstArg = firstGenericArgument(inner)
         {
             current = firstArg
+            didStrip = true
         }
-        if current.isEmpty || current == "AnyView" { return nil }
+        if current.isEmpty { return nil }
+        if didStrip, current == "AnyView" { return nil }
         return current
     }
 

--- a/PostHog/Logs/PostHogLogger.swift
+++ b/PostHog/Logs/PostHogLogger.swift
@@ -10,67 +10,9 @@ import Foundation
 @objc public final class PostHogLogger: NSObject {
     private weak var sdk: PostHogSDK?
 
-    /// Latest reported screen name. Delegates to `PostHogSDK.lastScreenName`,
-    /// which is sanitized in `screen()` before being cached.
-    var lastScreenName: String? {
-        sdk?.lastScreenName
-    }
-
     init(sdk: PostHogSDK) {
         self.sdk = sdk
         super.init()
-    }
-
-    /// Strips SwiftUI's `UIHostingController` / `ModifiedContent` wrappers to
-    /// surface the user's actual view type. Empty inputs always return `nil`.
-    /// An `AnyView` result is dropped only when it surfaced from stripping
-    /// (auto-capture noise from `body: some View` erasure); a caller who
-    /// manually passes `"AnyView"` is honored as-is.
-    static func sanitize(rawScreenName name: String) -> String? {
-        var current = name
-        var didStrip = false
-        if let inner = stripGeneric(current, wrapper: "UIHostingController") {
-            current = inner
-            didStrip = true
-        }
-        while let inner = stripGeneric(current, wrapper: "ModifiedContent"),
-              let firstArg = firstGenericArgument(inner)
-        {
-            current = firstArg
-            didStrip = true
-        }
-        if current.isEmpty { return nil }
-        if didStrip, current == "AnyView" { return nil }
-        return current
-    }
-
-    /// Returns the body of `wrapper<…>` if `string` matches that exact shape
-    /// (no trailing junk after the closing `>`). nil otherwise.
-    private static func stripGeneric(_ string: String, wrapper: String) -> String? {
-        let prefix = wrapper + "<"
-        guard string.hasPrefix(prefix), string.hasSuffix(">") else { return nil }
-        let start = string.index(string.startIndex, offsetBy: prefix.count)
-        let end = string.index(before: string.endIndex)
-        return String(string[start ..< end])
-    }
-
-    /// Returns the first comma-separated generic argument from a body string,
-    /// respecting nested `<…>` so `ModifiedContent<X, Y>, B` splits at the
-    /// outer comma. Returns the input trimmed if there's no top-level comma.
-    private static func firstGenericArgument(_ string: String) -> String? {
-        var depth = 0
-        for (offset, char) in string.enumerated() {
-            if char == "<" {
-                depth += 1
-            } else if char == ">" {
-                depth -= 1
-            } else if char == ",", depth == 0 {
-                let idx = string.index(string.startIndex, offsetBy: offset)
-                return String(string[..<idx]).trimmingCharacters(in: .whitespaces)
-            }
-        }
-        let trimmed = string.trimmingCharacters(in: .whitespaces)
-        return trimmed.isEmpty ? nil : trimmed
     }
 
     /// Capture a `.trace` record. Finest-grained detail; usually only enabled

--- a/PostHog/Logs/PostHogLogger.swift
+++ b/PostHog/Logs/PostHogLogger.swift
@@ -9,34 +9,16 @@ import Foundation
 /// to call `trace`, `debug`, `info`, `warn`, `error`, or `fatal`.
 @objc public final class PostHogLogger: NSObject {
     private weak var sdk: PostHogSDK?
-    private let lastScreenLock = NSLock()
-    private var _lastScreenName: String?
-    private var screenViewToken: RegistrationToken?
 
-    /// Latest reported screen name, populated by the screen-view publisher.
-    /// `nil` until the first navigation after SDK setup.
+    /// Latest reported screen name. Delegates to `PostHogSDK.lastScreenName`,
+    /// which is sanitized in `screen()` before being cached.
     var lastScreenName: String? {
-        lastScreenLock.withLock { _lastScreenName }
+        sdk?.lastScreenName
     }
 
     init(sdk: PostHogSDK) {
         self.sdk = sdk
         super.init()
-        screenViewToken = DI.main.screenViewPublisher.onScreenView.subscribe { [weak self] name in
-            guard let self else { return }
-            // Only overwrite when the sanitizer recovers something meaningful;
-            // preserves the last useful name across noisy intermediate
-            // viewDidAppears (e.g. the AnyView-wrapped HostingControllers
-            // SwiftUI emits during initial layout).
-            guard let cleaned = Self.sanitize(rawScreenName: name) else { return }
-            self.lastScreenLock.withLock { self._lastScreenName = cleaned }
-        }
-    }
-
-    /// Releases the screen-view subscription and clears the cache.
-    func detach() {
-        screenViewToken = nil
-        lastScreenLock.withLock { _lastScreenName = nil }
     }
 
     /// Strips SwiftUI's `UIHostingController` / `ModifiedContent` wrappers to

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -73,11 +73,14 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
 
     @objc public var captureApplicationLifecycleEvents: Bool = true
     /// Automatically captures a `$screen` event whenever a `UIViewController` appears
-    /// (via `viewDidAppear` swizzling). When enabled, the most recent screen name is
-    /// also attached as `$screen_name` to every subsequent event captured by the SDK.
+    /// (via `viewDidAppear` swizzling).
     ///
-    /// To opt out of `$screen_name` stamping entirely, set to `false` **and** avoid
-    /// calling `PostHogSDK.shared.screen(...)` manually.
+    /// `$screen_name` stamping on subsequent events is a related effect: any
+    /// successful `screen()` call — whether fired by this auto-capture path **or
+    /// invoked manually** via `PostHogSDK.shared.screen(...)` — caches the screen
+    /// name so it lands as `$screen_name` on every later event the SDK captures.
+    /// To opt out of `$screen_name` stamping entirely, set this to `false` **and**
+    /// avoid calling `screen(...)` manually.
     ///
     /// Default: `true`
     @objc public var captureScreenViews: Bool = true

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -72,6 +72,9 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
     }
 
     @objc public var captureApplicationLifecycleEvents: Bool = true
+    /// When enabled, `$screen_name` is also automatically attached to subsequent
+    /// events. Disable this and avoid calling `PostHogSDK.shared.screen()` to opt
+    /// out of `$screen_name` stamping entirely.
     @objc public var captureScreenViews: Bool = true
 
     /// Enable method swizzling for SDK functionality that depends on it

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -72,9 +72,14 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
     }
 
     @objc public var captureApplicationLifecycleEvents: Bool = true
-    /// When enabled, `$screen_name` is also automatically attached to subsequent
-    /// events. Disable this and avoid calling `PostHogSDK.shared.screen()` to opt
-    /// out of `$screen_name` stamping entirely.
+    /// Automatically captures a `$screen` event whenever a `UIViewController` appears
+    /// (via `viewDidAppear` swizzling). When enabled, the most recent screen name is
+    /// also attached as `$screen_name` to every subsequent event captured by the SDK.
+    ///
+    /// To opt out of `$screen_name` stamping entirely, set to `false` **and** avoid
+    /// calling `PostHogSDK.shared.screen(...)` manually.
+    ///
+    /// Default: `true`
     @objc public var captureScreenViews: Bool = true
 
     /// Enable method swizzling for SDK functionality that depends on it

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -1180,7 +1180,7 @@ let maxRetryDelay = 30.0
         // Strip SwiftUI wrappers (UIHostingController<X> → X). Drops degenerate
         // inputs (empty, stripped-AnyView) — for those we skip the $screen event
         // and leave the cache untouched so the last useful name survives.
-        guard let cleaned = PostHogLogger.sanitize(rawScreenName: screenTitle) else {
+        guard let cleaned = PostHogScreenNameSanitizer.sanitize(rawScreenName: screenTitle) else {
             return
         }
 

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -40,7 +40,7 @@ let maxRetryDelay = 30.0
 
     private let lastScreenLock = NSLock()
     private var _lastScreenName: String?
-    var lastScreenName: String? {
+    private var lastScreenName: String? {
         lastScreenLock.withLock { _lastScreenName }
     }
 
@@ -440,10 +440,12 @@ let maxRetryDelay = 30.0
 
             props["$process_person_profile"] = hasPersonProcessing()
 
-            // Only stamp if the caller didn't supply one — `merging(properties)`
-            // below keeps the existing value on conflict, so seeding would
-            // shadow a caller-supplied override.
-            if let name = lastScreenName, properties?["$screen_name"] == nil {
+            // Only stamp if the caller didn't supply a non-empty value —
+            // `merging(properties)` below keeps the existing value on conflict,
+            // so seeding would shadow a caller-supplied override. Treat caller
+            // empty/whitespace as absent (likely accidental).
+            let callerScreenName = properties?["$screen_name"] as? String
+            if let name = lastScreenName, !name.isEmpty, callerScreenName.isNilOrEmpty {
                 props["$screen_name"] = name
             }
         }
@@ -1986,11 +1988,13 @@ let maxRetryDelay = 30.0
             didEnterBackgroundToken = nil
             logger?.detach()
             logger = nil
-            lastScreenLock.withLock { _lastScreenName = nil }
             toggleHedgeLog(false)
 
             uninstallIntegrations()
         }
+        // Outside setupLock to avoid lock-ordering coupling between
+        // setupLock and lastScreenLock.
+        lastScreenLock.withLock { _lastScreenName = nil }
     }
 
     #if os(iOS)

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -38,6 +38,12 @@ let maxRetryDelay = 30.0
     private let cachedPersonPropertiesLock = NSLock()
     private var cachedPersonPropertiesHash: String?
 
+    private let lastScreenLock = NSLock()
+    private var _lastScreenName: String?
+    var lastScreenName: String? {
+        lastScreenLock.withLock { _lastScreenName }
+    }
+
     private var queue: PostHogQueue<PostHogEvent>?
     private(set) var replayQueue: PostHogReplayQueue?
     private(set) var logsQueue: PostHogQueue<PostHogLogRecord>?
@@ -433,6 +439,13 @@ let maxRetryDelay = 30.0
             }
 
             props["$process_person_profile"] = hasPersonProcessing()
+
+            // Only stamp if the caller didn't supply one — `merging(properties)`
+            // below keeps the existing value on conflict, so seeding would
+            // shadow a caller-supplied override.
+            if let name = lastScreenName, properties?["$screen_name"] == nil {
+                props["$screen_name"] = name
+            }
         }
 
         let sdkInfo = context?.sdkInfo()
@@ -500,6 +513,8 @@ let maxRetryDelay = 30.0
 
         // Clear all in-memory caches (feature flags, session replay state, etc.)
         remoteConfig?.clear()
+
+        lastScreenLock.withLock { _lastScreenName = nil }
 
         // reload flags as anon user
         remoteConfig?.reloadFeatureFlags()
@@ -1138,6 +1153,10 @@ let maxRetryDelay = 30.0
         screen(screenTitle, properties: nil)
     }
 
+    /// Captures a `$screen` event and caches `screenTitle` so it is automatically
+    /// attached as `$screen_name` to every subsequent event (until `reset()` or
+    /// `close()`). Callers can override per-event by passing `$screen_name` in
+    /// `properties` on the next `capture(_:properties:)` call.
     @objc(screenWithTitle:properties:)
     public func screen(_ screenTitle: String, properties: [String: Any]? = nil) {
         if !isEnabled() {
@@ -1151,6 +1170,8 @@ let maxRetryDelay = 30.0
         guard let queue else {
             return
         }
+
+        lastScreenLock.withLock { _lastScreenName = screenTitle }
 
         let props = [
             "$screen_name": screenTitle,
@@ -1958,6 +1979,7 @@ let maxRetryDelay = 30.0
             didEnterBackgroundToken = nil
             logger?.detach()
             logger = nil
+            lastScreenLock.withLock { _lastScreenName = nil }
             toggleHedgeLog(false)
 
             uninstallIntegrations()

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -1186,7 +1186,13 @@ let maxRetryDelay = 30.0
 
         // Cache the name before the queue check so a screen() call during init
         // (queue not yet assigned) still seeds the cache for subsequent events.
-        lastScreenLock.withLock { _lastScreenName = cleaned }
+        // Track whether the value actually changed so we can skip the crash-
+        // replay snapshot refresh on duplicate viewDidAppears for the same VC.
+        let screenNameChanged = lastScreenLock.withLock { () -> Bool in
+            let changed = _lastScreenName != cleaned
+            _lastScreenName = cleaned
+            return changed
+        }
 
         guard let queue else {
             return
@@ -1207,12 +1213,19 @@ let maxRetryDelay = 30.0
         queueEvent(event, queue: queue)
 
         // Fanout to subscribers (sanitized; downstream listeners no longer
-        // need to re-apply sanitize). Subscribers must not re-enter screen().
+        // need to re-apply sanitize). Currently no in-tree subscribers — kept
+        // as an extension point for external consumers. Subscribers must not
+        // re-enter screen().
         DI.main.screenViewPublisher.onNewScreenName(cleaned)
 
-        // Refresh the crash-replay snapshot so an out-of-process crash on this
-        // screen carries the right $screen_name on the resulting $exception.
-        notifyContextDidChange()
+        // Refresh the crash-replay snapshot only when the screen actually
+        // changed — `viewDidAppear` re-fires for the same VC on every tab
+        // switch / sheet dismiss, and the snapshot includes a full event-
+        // properties build + JSON serialize + customData write that we don't
+        // want to repeat on the main thread for no behavior change.
+        if screenNameChanged {
+            notifyContextDidChange()
+        }
     }
 
     func autocapture(

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -442,10 +442,11 @@ let maxRetryDelay = 30.0
 
             // Only stamp if the caller didn't supply a non-empty value —
             // `merging(properties)` below keeps the existing value on conflict,
-            // so seeding would shadow a caller-supplied override. Treat caller
-            // empty/whitespace as absent (likely accidental).
-            let callerScreenName = properties?["$screen_name"] as? String
-            if let name = lastScreenName, !name.isEmpty, callerScreenName.isNilOrEmpty {
+            // so seeding would shadow a caller-supplied override. Whitespace-only
+            // caller values are treated as absent (almost always accidental).
+            let trimmedCallerScreenName = (properties?["$screen_name"] as? String)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if let name = lastScreenName, !name.isEmpty, trimmedCallerScreenName.isNilOrEmpty {
                 props["$screen_name"] = name
             }
         }
@@ -1176,18 +1177,20 @@ let maxRetryDelay = 30.0
             return
         }
 
-        guard let queue else {
-            return
-        }
-
         // Strip SwiftUI wrappers (UIHostingController<X> → X). Drops degenerate
-        // inputs (empty, AnyView) — for those we skip the $screen event and
-        // leave the cache untouched so the last useful name survives.
+        // inputs (empty, stripped-AnyView) — for those we skip the $screen event
+        // and leave the cache untouched so the last useful name survives.
         guard let cleaned = PostHogLogger.sanitize(rawScreenName: screenTitle) else {
             return
         }
 
+        // Cache the name before the queue check so a screen() call during init
+        // (queue not yet assigned) still seeds the cache for subsequent events.
         lastScreenLock.withLock { _lastScreenName = cleaned }
+
+        guard let queue else {
+            return
+        }
 
         let props = [
             "$screen_name": cleaned,

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -1209,6 +1209,10 @@ let maxRetryDelay = 30.0
         // Fanout to subscribers (sanitized; downstream listeners no longer
         // need to re-apply sanitize). Subscribers must not re-enter screen().
         DI.main.screenViewPublisher.onNewScreenName(cleaned)
+
+        // Refresh the crash-replay snapshot so an out-of-process crash on this
+        // screen carries the right $screen_name on the resulting $exception.
+        notifyContextDidChange()
     }
 
     func autocapture(

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -1153,10 +1153,17 @@ let maxRetryDelay = 30.0
         screen(screenTitle, properties: nil)
     }
 
-    /// Captures a `$screen` event and caches `screenTitle` so it is automatically
-    /// attached as `$screen_name` to every subsequent event (until `reset()` or
-    /// `close()`). Callers can override per-event by passing `$screen_name` in
-    /// `properties` on the next `capture(_:properties:)` call.
+    /// Records a screen view by capturing a `$screen` event with `screenTitle`.
+    ///
+    /// The title is also cached and automatically attached as `$screen_name` to
+    /// every subsequent event (until `reset()` or `close()` clears it).
+    ///
+    /// To override the auto-attached value on a specific event, pass `$screen_name`
+    /// in that event's `properties` dictionary.
+    ///
+    /// - Parameters:
+    ///   - screenTitle: The screen name to record.
+    ///   - properties: Additional properties to attach to this `$screen` event.
     @objc(screenWithTitle:properties:)
     public func screen(_ screenTitle: String, properties: [String: Any]? = nil) {
         if !isEnabled() {

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -40,7 +40,7 @@ let maxRetryDelay = 30.0
 
     private let lastScreenLock = NSLock()
     private var _lastScreenName: String?
-    private var lastScreenName: String? {
+    var lastScreenName: String? {
         lastScreenLock.withLock { _lastScreenName }
     }
 
@@ -1028,7 +1028,7 @@ let maxRetryDelay = 30.0
         // alter the record because the snapshot is frozen here.
         let distinctId = getDistinctId()
         let sessionId = sessionManager.getSessionId(readOnly: true)
-        let screenName = logger?.lastScreenName
+        let screenName = lastScreenName
         let appState: PostHogLogRecord.AppState = sessionManager.isAppInBackgroundSnapshot ? .background : .foreground
         let featureFlagKeys: [String] = (remoteConfig?.getFeatureFlags() as? [String: Any])?.compactMap { key, value in
             // Bool flags are active iff true; multivariant (non-bool) values
@@ -1180,11 +1180,18 @@ let maxRetryDelay = 30.0
             return
         }
 
-        lastScreenLock.withLock { _lastScreenName = screenTitle }
+        // Strip SwiftUI wrappers (UIHostingController<X> → X). Drops degenerate
+        // inputs (empty, AnyView) — for those we skip the $screen event and
+        // leave the cache untouched so the last useful name survives.
+        guard let cleaned = PostHogLogger.sanitize(rawScreenName: screenTitle) else {
+            return
+        }
+
+        lastScreenLock.withLock { _lastScreenName = cleaned }
 
         let props = [
-            "$screen_name": screenTitle,
-        ].merging(sanitizeDictionary(properties) ?? [:]) { prop, _ in prop }
+            "$screen_name": cleaned,
+        ].merging(sanitizeDictionary(properties) ?? [:]) { _, new in new }
 
         let distinctId = getDistinctId()
 
@@ -1196,9 +1203,9 @@ let maxRetryDelay = 30.0
 
         queueEvent(event, queue: queue)
 
-        // Fanout to subscribers (e.g. the logs feature's lastScreenName).
-        // Subscribers must not re-enter screen() from the callback.
-        DI.main.screenViewPublisher.onNewScreenName(screenTitle)
+        // Fanout to subscribers (sanitized; downstream listeners no longer
+        // need to re-apply sanitize). Subscribers must not re-enter screen().
+        DI.main.screenViewPublisher.onNewScreenName(cleaned)
     }
 
     func autocapture(
@@ -1986,7 +1993,6 @@ let maxRetryDelay = 30.0
             context = nil
             sessionManager.endSession()
             didEnterBackgroundToken = nil
-            logger?.detach()
             logger = nil
             toggleHedgeLog(false)
 

--- a/PostHog/ScreenViews/PostHogScreenNameSanitizer.swift
+++ b/PostHog/ScreenViews/PostHogScreenNameSanitizer.swift
@@ -1,0 +1,60 @@
+//
+//  PostHogScreenNameSanitizer.swift
+//  PostHog
+//
+
+import Foundation
+
+enum PostHogScreenNameSanitizer {
+    /// Strips SwiftUI's `UIHostingController` / `ModifiedContent` wrappers to
+    /// surface the user's actual view type. Empty inputs always return `nil`.
+    /// An `AnyView` result is dropped only when it surfaced from stripping
+    /// (auto-capture noise from `body: some View` erasure); a caller who
+    /// manually passes `"AnyView"` is honored as-is.
+    static func sanitize(rawScreenName name: String) -> String? {
+        var current = name
+        var didStrip = false
+        if let inner = stripGeneric(current, wrapper: "UIHostingController") {
+            current = inner
+            didStrip = true
+        }
+        while let inner = stripGeneric(current, wrapper: "ModifiedContent"),
+              let firstArg = firstGenericArgument(inner)
+        {
+            current = firstArg
+            didStrip = true
+        }
+        if current.isEmpty { return nil }
+        if didStrip, current == "AnyView" { return nil }
+        return current
+    }
+
+    /// Returns the body of `wrapper<…>` if `string` matches that exact shape
+    /// (no trailing junk after the closing `>`). nil otherwise.
+    private static func stripGeneric(_ string: String, wrapper: String) -> String? {
+        let prefix = wrapper + "<"
+        guard string.hasPrefix(prefix), string.hasSuffix(">") else { return nil }
+        let start = string.index(string.startIndex, offsetBy: prefix.count)
+        let end = string.index(before: string.endIndex)
+        return String(string[start ..< end])
+    }
+
+    /// Returns the first comma-separated generic argument from a body string,
+    /// respecting nested `<…>` so `ModifiedContent<X, Y>, B` splits at the
+    /// outer comma. Returns the input trimmed if there's no top-level comma.
+    private static func firstGenericArgument(_ string: String) -> String? {
+        var depth = 0
+        for (offset, char) in string.enumerated() {
+            if char == "<" {
+                depth += 1
+            } else if char == ">" {
+                depth -= 1
+            } else if char == ",", depth == 0 {
+                let idx = string.index(string.startIndex, offsetBy: offset)
+                return String(string[..<idx]).trimmingCharacters(in: .whitespaces)
+            }
+        }
+        let trimmed = string.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/PostHogTests/PostHogScreenNameTest.swift
+++ b/PostHogTests/PostHogScreenNameTest.swift
@@ -1,0 +1,120 @@
+//
+//  PostHogScreenNameTest.swift
+//  PostHogTests
+//
+
+import Foundation
+import Nimble
+@testable import PostHog
+import Quick
+
+class PostHogScreenNameTest: QuickSpec {
+    final class CapturedEvents {
+        var events: [PostHogEvent] = []
+    }
+
+    func getSut(captured: CapturedEvents) -> PostHogSDK {
+        let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
+        config.flushAt = 1
+        config.preloadFeatureFlags = false
+        config.sendFeatureFlagEvent = false
+        config.disableReachabilityForTesting = true
+        config.disableQueueTimerForTesting = true
+        config.disableFlushOnBackgroundForTesting = true
+        config.captureApplicationLifecycleEvents = false
+        config.setBeforeSend { event in
+            captured.events.append(event)
+            return nil
+        }
+
+        let storage = PostHogStorage(config)
+        storage.reset()
+
+        return PostHogSDK.with(config)
+    }
+
+    override func spec() {
+        var captured: CapturedEvents!
+
+        beforeEach {
+            captured = CapturedEvents()
+        }
+
+        it("event captured before screen has no screen_name") {
+            let sut = self.getSut(captured: captured)
+
+            sut.capture("event")
+
+            let event = captured.events.first { $0.event == "event" }!
+            expect(event.properties["$screen_name"]).to(beNil())
+
+            sut.reset()
+            sut.close()
+        }
+
+        it("event captured after screen carries screen_name") {
+            let sut = self.getSut(captured: captured)
+
+            sut.screen("Home")
+            sut.capture("event")
+
+            let event = captured.events.first { $0.event == "event" }!
+            expect(event.properties["$screen_name"] as? String) == "Home"
+
+            sut.reset()
+            sut.close()
+        }
+
+        it("caller-supplied screen_name overrides cached value") {
+            let sut = self.getSut(captured: captured)
+
+            sut.screen("Home")
+            sut.capture("event", properties: ["$screen_name": "Override"])
+
+            let event = captured.events.first { $0.event == "event" }!
+            expect(event.properties["$screen_name"] as? String) == "Override"
+
+            sut.reset()
+            sut.close()
+        }
+
+        it("reset clears screen_name from subsequent events") {
+            let sut = self.getSut(captured: captured)
+
+            sut.screen("Home")
+            sut.reset()
+            sut.capture("event")
+
+            let event = captured.events.first { $0.event == "event" }!
+            expect(event.properties["$screen_name"]).to(beNil())
+
+            sut.close()
+        }
+
+        it("exception event carries screen_name") {
+            let sut = self.getSut(captured: captured)
+
+            sut.screen("Home")
+            sut.captureException(NSError(domain: "test", code: 1))
+
+            let event = captured.events.first { $0.event == "$exception" }!
+            expect(event.properties["$screen_name"] as? String) == "Home"
+
+            sut.reset()
+            sut.close()
+        }
+
+        it("snapshot event does not carry screen_name") {
+            let sut = self.getSut(captured: captured)
+
+            sut.screen("Home")
+            sut.capture("$snapshot", properties: ["$session_id": "test-session-id"])
+
+            let event = captured.events.first { $0.event == "$snapshot" }!
+            expect(event.properties["$screen_name"]).to(beNil())
+
+            sut.reset()
+            sut.close()
+        }
+    }
+}

--- a/PostHogTests/PostHogScreenNameTest.swift
+++ b/PostHogTests/PostHogScreenNameTest.swift
@@ -78,6 +78,18 @@ class PostHogScreenNameTest: QuickSpec {
             sut.close()
         }
 
+        it("screen() with screen_name in properties carries the override on the $screen event") {
+            let sut = self.getSut(captured: captured)
+
+            sut.screen("Home", properties: ["$screen_name": "Override"])
+
+            let event = captured.events.first { $0.event == "$screen" }!
+            expect(event.properties["$screen_name"] as? String) == "Override"
+
+            sut.reset()
+            sut.close()
+        }
+
         it("reset clears screen_name from subsequent events") {
             let sut = self.getSut(captured: captured)
 

--- a/PostHogTests/PostHogScreenViewIntegrationTest.swift
+++ b/PostHogTests/PostHogScreenViewIntegrationTest.swift
@@ -148,13 +148,19 @@ final class ScreenViewIntegrationTest {
         #expect(PostHogLogger.sanitize(rawScreenName: raw) == "HomeView")
     }
 
-    @Test("sanitize: AnyView at the inner position returns nil (type was erased)")
-    func sanitizeReturnsNilForAnyView() {
+    @Test("sanitize: AnyView surfaced from stripping returns nil")
+    func sanitizeReturnsNilForAnyViewFromStripping() {
         // The exact shape we observed end-to-end in PostHogExample.
         let raw = "UIHostingController<ModifiedContent<AnyView, RootModifier>>"
         #expect(PostHogLogger.sanitize(rawScreenName: raw) == nil)
         #expect(PostHogLogger.sanitize(rawScreenName: "UIHostingController<AnyView>") == nil)
-        #expect(PostHogLogger.sanitize(rawScreenName: "AnyView") == nil)
+    }
+
+    @Test("sanitize: literal AnyView passes through (caller intent)")
+    func sanitizeKeepsLiteralAnyView() {
+        // A caller who typed `screen("AnyView")` deliberately gets that
+        // name through; only the auto-capture noise case is dropped.
+        #expect(PostHogLogger.sanitize(rawScreenName: "AnyView") == "AnyView")
     }
 
     @Test("sanitize: empty / whitespace-only returns nil")

--- a/PostHogTests/PostHogScreenViewIntegrationTest.swift
+++ b/PostHogTests/PostHogScreenViewIntegrationTest.swift
@@ -162,21 +162,19 @@ final class ScreenViewIntegrationTest {
         #expect(PostHogLogger.sanitize(rawScreenName: "") == nil)
     }
 
-    @Test("logger.lastScreenName preserves the previous useful name when an AnyView fires after it")
-    func loggerKeepsLastUsefulNameWhenSwizzleProducesAnyView() async throws {
+    @Test("screen() with degenerate input preserves the previous useful name")
+    func screenWithDegenerateInputPreservesLastUsefulName() async throws {
         // SwiftUI initial layout often emits multiple viewDidAppears: a
         // useful one (e.g. ContentView) followed by AnyView-wrapped ones
-        // from container chrome. The sanitizer's nil signal must not erase
-        // the good name we already had.
+        // from container chrome. SDK.screen() sanitizes; degenerate inputs
+        // must not erase the good name we already had.
         let sut = getSut(captureScreenViews: false)
         let logger = try #require(sut.logger)
 
         sut.screen("HomeView")
         #expect(logger.lastScreenName == "HomeView")
 
-        // Simulate a noisy intermediate viewDidAppear that the publisher
-        // would fan out (e.g. from auto-capture in a mixed app).
-        mockScreenView.simulateScreenView(screen: "UIHostingController<ModifiedContent<AnyView, RootModifier>>")
+        sut.screen("UIHostingController<ModifiedContent<AnyView, RootModifier>>")
         #expect(logger.lastScreenName == "HomeView")
 
         sut.close()

--- a/PostHogTests/PostHogScreenViewIntegrationTest.swift
+++ b/PostHogTests/PostHogScreenViewIntegrationTest.swift
@@ -120,23 +120,23 @@ final class ScreenViewIntegrationTest {
         sut.close()
     }
 
-    // MARK: - PostHogLogger.sanitize
+    // MARK: - PostHogScreenNameSanitizer
 
     @Test("sanitize: pure UIKit class names pass through unchanged")
     func sanitizePassesUIKitNames() {
-        #expect(PostHogLogger.sanitize(rawScreenName: "MyHomeViewController") == "MyHomeViewController")
-        #expect(PostHogLogger.sanitize(rawScreenName: "SettingsVC") == "SettingsVC")
+        #expect(PostHogScreenNameSanitizer.sanitize(rawScreenName: "MyHomeViewController") == "MyHomeViewController")
+        #expect(PostHogScreenNameSanitizer.sanitize(rawScreenName: "SettingsVC") == "SettingsVC")
     }
 
     @Test("sanitize: UIHostingController<X> → X")
     func sanitizeStripsHostingController() {
-        #expect(PostHogLogger.sanitize(rawScreenName: "UIHostingController<HomeView>") == "HomeView")
+        #expect(PostHogScreenNameSanitizer.sanitize(rawScreenName: "UIHostingController<HomeView>") == "HomeView")
     }
 
     @Test("sanitize: ModifiedContent<X, _> → X (peels one modifier)")
     func sanitizePeelsOneModifier() {
         let raw = "UIHostingController<ModifiedContent<DetailView, EnvironmentValueWriter>>"
-        #expect(PostHogLogger.sanitize(rawScreenName: raw) == "DetailView")
+        #expect(PostHogScreenNameSanitizer.sanitize(rawScreenName: raw) == "DetailView")
     }
 
     @Test("sanitize: nested ModifiedContent recurses to innermost user view")
@@ -145,27 +145,27 @@ final class ScreenViewIntegrationTest {
         // a left-leaning ModifiedContent chain like this — the user's view
         // is at the innermost left.
         let raw = "UIHostingController<ModifiedContent<ModifiedContent<HomeView, A>, B>>"
-        #expect(PostHogLogger.sanitize(rawScreenName: raw) == "HomeView")
+        #expect(PostHogScreenNameSanitizer.sanitize(rawScreenName: raw) == "HomeView")
     }
 
     @Test("sanitize: AnyView surfaced from stripping returns nil")
     func sanitizeReturnsNilForAnyViewFromStripping() {
         // The exact shape we observed end-to-end in PostHogExample.
         let raw = "UIHostingController<ModifiedContent<AnyView, RootModifier>>"
-        #expect(PostHogLogger.sanitize(rawScreenName: raw) == nil)
-        #expect(PostHogLogger.sanitize(rawScreenName: "UIHostingController<AnyView>") == nil)
+        #expect(PostHogScreenNameSanitizer.sanitize(rawScreenName: raw) == nil)
+        #expect(PostHogScreenNameSanitizer.sanitize(rawScreenName: "UIHostingController<AnyView>") == nil)
     }
 
     @Test("sanitize: literal AnyView passes through (caller intent)")
     func sanitizeKeepsLiteralAnyView() {
         // A caller who typed `screen("AnyView")` deliberately gets that
         // name through; only the auto-capture noise case is dropped.
-        #expect(PostHogLogger.sanitize(rawScreenName: "AnyView") == "AnyView")
+        #expect(PostHogScreenNameSanitizer.sanitize(rawScreenName: "AnyView") == "AnyView")
     }
 
     @Test("sanitize: empty / whitespace-only returns nil")
     func sanitizeReturnsNilForEmpty() {
-        #expect(PostHogLogger.sanitize(rawScreenName: "") == nil)
+        #expect(PostHogScreenNameSanitizer.sanitize(rawScreenName: "") == nil)
     }
 
     @Test("screen() with degenerate input preserves the previous useful name")
@@ -175,36 +175,30 @@ final class ScreenViewIntegrationTest {
         // from container chrome. SDK.screen() sanitizes; degenerate inputs
         // must not erase the good name we already had.
         let sut = getSut(captureScreenViews: false)
-        let logger = try #require(sut.logger)
 
         sut.screen("HomeView")
-        #expect(logger.lastScreenName == "HomeView")
+        #expect(sut.lastScreenName == "HomeView")
 
         sut.screen("UIHostingController<ModifiedContent<AnyView, RootModifier>>")
-        #expect(logger.lastScreenName == "HomeView")
+        #expect(sut.lastScreenName == "HomeView")
 
         sut.close()
     }
 
-    @Test("captureScreenViews=false + manual screen() updates the logger's lastScreenName")
-    func loggerLastScreenNamePopulatedFromManualScreen() async throws {
+    @Test("captureScreenViews=false + manual screen() seeds the SDK cache")
+    func screenCachePopulatedFromManualCall() async throws {
         // End-to-end: with auto-capture disabled (no integration installed),
         // a manual screen() call (or the SwiftUI .postHogScreenView modifier
-        // which routes through it) must still feed the logs feature's
-        // screen.name attribute. This is the regression that motivated
-        // option-3 unification.
+        // which routes through it) must still feed the SDK's screen-name
+        // cache so the logs feature and cross-event stamping pick it up.
         let sut = getSut(captureScreenViews: false)
-        let logger = try #require(sut.logger)
 
         sut.screen("HomeScreen")
-
-        // The logger's screen-view subscription updates synchronously inside
-        // the publisher invocation, so it's safe to read immediately.
-        #expect(logger.lastScreenName == "HomeScreen")
+        #expect(sut.lastScreenName == "HomeScreen")
 
         // A second call should overwrite the cache, not append.
         sut.screen("DetailsScreen")
-        #expect(logger.lastScreenName == "DetailsScreen")
+        #expect(sut.lastScreenName == "DetailsScreen")
 
         sut.close()
     }


### PR DESCRIPTION
## :bulb: Motivation and Context

Closes PostHog/posthog-android#119 for iOS. RN and Flutter already attach `$screen_name` to every event once `screen()` has been called; iOS did not. Android equivalent: PostHog/posthog-android#530.

## :green_heart: How did you test it?

Six unit tests in `PostHogScreenNameTest`: before-screen baseline, after-screen attaches, caller override wins, `reset()` clears, `$exception` carries it (Option A cross-event scope), `$snapshot` does not (verifies `appendSharedProps = false` gate).

End-to-end on iPhone 17 simulator across all five customer-visible scenarios — confirmed via Xcode console and by querying the `events` table on `us.posthog.com`:

| Scenario | Event | `$screen_name` |
|---|---|---|
| Auto-capture (`captureScreenViews=true`) | `test_auto_capture` | `UIHostingController<ModifiedContent<AnyView, RootModifier>>` |
| Manual `screen("ManualScreen")` | `test_after_manual` | `ManualScreen` |
| Caller override | `test_override` | `OverrideValue` |
| After `reset()` | `test_after_reset` | _absent_ |
| Exception after `screen("ExceptionScreen")` | `$exception` | `ExceptionScreen` |

**Behavior change** for reviewers: existing customers who have not disabled `captureScreenViews` will start seeing `$screen_name` attached to `$exception`, `$identify`, etc. — not only `$screen` events. Opt-out is `captureScreenViews = false` plus avoiding manual `PostHogSDK.shared.screen()` calls.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file