### PR TITLE
ci: treat CocoaPods publish as success if version is on trunk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,7 +285,23 @@ jobs:
           xcode-version: '16.2'
 
       - name: Publish to CocoaPods
-        run: make releaseCocoaPods
+        env:
+          RELEASE_VERSION: ${{ needs.create-github-release.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          if make releaseCocoaPods; then
+            exit 0
+          fi
+
+          echo "::warning::pod trunk push failed. Verifying via pod trunk info..."
+          if pod trunk info PostHog --no-ansi | grep -F -- "- $RELEASE_VERSION ("; then
+            echo "PostHog $RELEASE_VERSION is on trunk despite the failed push. Treating as success."
+            exit 0
+          fi
+
+          echo "::error::PostHog $RELEASE_VERSION is not on trunk after failed push."
+          exit 1
 
       # Notify in case of failure
       - name: Send failure event to PostHog


### PR DESCRIPTION
## :bulb: Motivation and Context

`pod trunk push` sometimes returns a non-zero exit even when the publish actually succeeded on CocoaPods trunk — e.g. v3.59.0 today (published at `2026-05-26 14:50:19 UTC`, the exact minute CI reported failure). The release job then fails loudly with a ❌ Slack message, even though the pod is available to end users.

When the failed job is rerun, `pod trunk push` errors with a duplicate-version error and the job fails again. Today we work around it by manually noticing in Slack and ignoring the failure.

This makes the publish step idempotent and tolerant of false failures by re-checking trunk after a failed push:

- If `pod trunk push` succeeds → done (unchanged).
- If `pod trunk push` fails but `pod trunk info PostHog` shows the version is on trunk → log a warning and treat the step as successful.
- If `pod trunk push` fails and the version is not on trunk → real failure, exit non-zero as before.

`pod trunk info` queries `trunk.cocoapods.org` directly (not the CDN), so it reflects the publish state immediately — no eventual-consistency window.

Replaces #588 with a simpler approach: post-check only, no pre-check step. Same coverage, ~1/3 the diff size.

## :green_heart: How did you test it?

Verified the grep pattern locally against trunk:

- `pod trunk info PostHog --no-ansi | grep -F -- "- 3.59.0 ("` → matched `- 3.59.0 (2026-05-26 14:50:19 UTC)`, exit 0
- Same grep with `- 99.99.99 (` → exit 1

YAML parses cleanly. Will be exercised on the next real release; if it ever rejects a legitimate publish, the failure mode is identical to today (CI fails loudly, Slack ❌).

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes. _(N/A — workflow change)_
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file _(intentionally skipped — CI-only change, should not trigger a release)_
