### PR TITLE
ci: anchor pod trunk info version match to start of line

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,7 +295,7 @@ jobs:
           fi
 
           echo "::warning::pod trunk push failed. Verifying via pod trunk info..."
-          if pod trunk info PostHog --no-ansi | grep -F -- "- $RELEASE_VERSION ("; then
+          if pod trunk info PostHog --no-ansi | grep -E -- "^[[:space:]]*- ${RELEASE_VERSION//./\\.} \("; then
             echo "PostHog $RELEASE_VERSION is on trunk despite the failed push. Treating as success."
             exit 0
           fi


### PR DESCRIPTION
## :bulb: Motivation and Context

Follow-up to #612, applying @turnipdabeets's suggestion from [#588](https://github.com/PostHog/posthog-ios/pull/588#discussion_r3189901145) per @ioannisj's [request here](https://github.com/PostHog/posthog-ios/pull/612#discussion_r3306726614).

```diff
- if pod trunk info PostHog --no-ansi | grep -F -- "- $RELEASE_VERSION ("; then
+ if pod trunk info PostHog --no-ansi | grep -E -- "^[[:space:]]*- ${RELEASE_VERSION//./\\.} \("; then
```

The change is worth landing for two narrower reasons:

1. **Intent is explicit.** Anchored regex says "this is the version-listing bullet at line start," instead of relying on the reader to convince themselves no substring can collide.
2. **Resilience to format changes.** If `pod trunk info` ever changes output (e.g. adds a `Subspecs:` section with similar `- X (` lines), the anchored pattern keeps working.

That is the entire justification. No correctness bug is being fixed.

## :green_heart: How did you test it?

Verifiable success criteria — all confirmed locally against real `pod trunk info PostHog --no-ansi` output:

| Input | Expected | Actual |
|---|---|---|
| Real published `3.59.0` line | match (exit 0) | ✓ exit 0 |
| Fake `99.99.99` line | no match (exit 1) | ✓ exit 1 |
| Synthetic `13.59.0` line, searching `3.59.0` | no match (exit 1) | ✓ exit 1 |
| `3X59X0` line, searching `3.59.0` | no match (period must be literal) | ✓ exit 1 |

YAML parses cleanly.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes. _(N/A — workflow change)_
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file _(intentionally skipped — CI-only change, should not trigger a release)_
