### PR TITLE
fix(surveys): one malformed survey no longer disables the entire survey list (#611)

### DIFF
--- a/.changeset/surveys-resilient-decoding.md
+++ b/.changeset/surveys-resilient-decoding.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+fix(surveys): a single malformed survey no longer disables every survey on iOS. Surveys are now decoded per-element (a bad entry is logged and skipped instead of dropping the whole list), and rating questions tolerate missing `lowerBoundLabel`/`upperBoundLabel` to match Web/Android behavior. Empty bound labels are also no longer rendered as blank caption rows under the rating control. Fixes #611.

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -526,6 +526,8 @@
 		DAA5EE362D4368A900D437E0 /* fixture_survey_question_multiple_choice.json in Resources */ = {isa = PBXBuildFile; fileRef = DAA5EE312D4368A900D437E0 /* fixture_survey_question_multiple_choice.json */; };
 		DAA5EE372D4368A900D437E0 /* fixture_survey_question_rating.json in Resources */ = {isa = PBXBuildFile; fileRef = DAA5EE322D4368A900D437E0 /* fixture_survey_question_rating.json */; };
 		DAA5EE382D4368A900D437E0 /* fixture_survey_question_single_choice.json in Resources */ = {isa = PBXBuildFile; fileRef = DAA5EE332D4368A900D437E0 /* fixture_survey_question_single_choice.json */; };
+		F22413BB1C82340F203271A4 /* fixture_survey_question_rating_no_bounds.json in Resources */ = {isa = PBXBuildFile; fileRef = 45D65956292974AA707263FA /* fixture_survey_question_rating_no_bounds.json */; };
+		867168FF2DB362371B6ACBA2 /* fixture_surveys_array_with_malformed.json in Resources */ = {isa = PBXBuildFile; fileRef = 0C73719F6590EB6B34D3EF2C /* fixture_surveys_array_with_malformed.json */; };
 		DAAD96982F7EF3DC002A8379 /* PostHog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AC745B5296D6FE60025C109 /* PostHog.framework */; };
 		DAAD96992F7EF3DC002A8379 /* PostHog.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3AC745B5296D6FE60025C109 /* PostHog.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DAB565CA2D142F8F0088F720 /* PostHogNoMaskViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB565C92D142F8F0088F720 /* PostHogNoMaskViewModifier.swift */; };
@@ -1327,6 +1329,8 @@
 		DAA5EE312D4368A900D437E0 /* fixture_survey_question_multiple_choice.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = fixture_survey_question_multiple_choice.json; sourceTree = "<group>"; };
 		DAA5EE322D4368A900D437E0 /* fixture_survey_question_rating.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = fixture_survey_question_rating.json; sourceTree = "<group>"; };
 		DAA5EE332D4368A900D437E0 /* fixture_survey_question_single_choice.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = fixture_survey_question_single_choice.json; sourceTree = "<group>"; };
+		45D65956292974AA707263FA /* fixture_survey_question_rating_no_bounds.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = fixture_survey_question_rating_no_bounds.json; sourceTree = "<group>"; };
+		0C73719F6590EB6B34D3EF2C /* fixture_surveys_array_with_malformed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = fixture_surveys_array_with_malformed.json; sourceTree = "<group>"; };
 		DAB06F9C2D09A744005B1C9B /* PostHog.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = PostHog.modulemap; sourceTree = "<group>"; };
 		DAB565C92D142F8F0088F720 /* PostHogNoMaskViewModifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostHogNoMaskViewModifier.swift; sourceTree = "<group>"; };
 		DAB565DE2D14C55C0088F720 /* PostHogTagViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogTagViewModifier.swift; sourceTree = "<group>"; };
@@ -2446,6 +2450,8 @@
 				DAA5EE312D4368A900D437E0 /* fixture_survey_question_multiple_choice.json */,
 				DAA5EE322D4368A900D437E0 /* fixture_survey_question_rating.json */,
 				DAA5EE332D4368A900D437E0 /* fixture_survey_question_single_choice.json */,
+				45D65956292974AA707263FA /* fixture_survey_question_rating_no_bounds.json */,
+				0C73719F6590EB6B34D3EF2C /* fixture_surveys_array_with_malformed.json */,
 				DA5E52E02E09930600159D20 /* fixture_survey_unknown_question_type.json */,
 				DA5E52E12E09930600159D20 /* fixture_survey_unknown_type.json */,
 				DAA0222F2D78158600197660 /* fixture_survey_conditions_event_repeated.json */,
@@ -2947,6 +2953,8 @@
 				DA5E52E32E09930600159D20 /* fixture_survey_unknown_question_type.json in Resources */,
 				DAA5EE372D4368A900D437E0 /* fixture_survey_question_rating.json in Resources */,
 				DAA5EE382D4368A900D437E0 /* fixture_survey_question_single_choice.json in Resources */,
+				F22413BB1C82340F203271A4 /* fixture_survey_question_rating_no_bounds.json in Resources */,
+				867168FF2DB362371B6ACBA2 /* fixture_surveys_array_with_malformed.json in Resources */,
 				DAA5EE2D2D43605000D437E0 /* fixture_survey_basic.json in Resources */,
 				DAA5EE2E2D43605000D437E0 /* fixture_survey_branching_response_based.json in Resources */,
 				DA71854D2D07E11200396388 /* input_1.png in Resources */,

--- a/PostHog/Models/Surveys/PostHogSurvey+Display.swift
+++ b/PostHog/Models/Surveys/PostHogSurvey+Display.swift
@@ -56,8 +56,8 @@
                     ratingType: question.display.toDisplayRatingType(),
                     scaleLowerBound: question.scale.range.lowerBound,
                     scaleUpperBound: question.scale.range.upperBound,
-                    lowerBoundLabel: translation?.lowerBoundLabel ?? question.lowerBoundLabel,
-                    upperBoundLabel: translation?.upperBoundLabel ?? question.upperBoundLabel
+                    lowerBoundLabel: translation?.lowerBoundLabel ?? question.lowerBoundLabel ?? "",
+                    upperBoundLabel: translation?.upperBoundLabel ?? question.upperBoundLabel ?? ""
                 )
 
             case let .singleChoice(question), let .multipleChoice(question):

--- a/PostHog/Models/Surveys/PostHogSurveyQuestion.swift
+++ b/PostHog/Models/Surveys/PostHogSurveyQuestion.swift
@@ -154,8 +154,8 @@ struct PostHogRatingSurveyQuestion: PostHogSurveyQuestionProperties, Decodable {
     let display: PostHogSurveyRatingDisplayType
     /// Scale of the rating (3, 5, 7, or 10)
     let scale: PostHogSurveyRatingScale
-    let lowerBoundLabel: String
-    let upperBoundLabel: String
+    let lowerBoundLabel: String?
+    let upperBoundLabel: String?
 }
 
 /// Represents a multiple-choice or single-choice survey question

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -258,12 +258,15 @@
                 return []
             }
 
-            do {
-                let jsonData = try JSONSerialization.data(withJSONObject: surveysJSON)
-                return try PostHogApi.jsonDecoder.decode([PostHogSurvey].self, from: jsonData)
-            } catch {
-                hedgeLog("Error decoding Surveys: \(error)")
-                return []
+            // Decode each survey individually so one malformed entry doesn't drop the entire list
+            return surveysJSON.compactMap { surveyJSON in
+                do {
+                    let jsonData = try JSONSerialization.data(withJSONObject: surveyJSON)
+                    return try PostHogApi.jsonDecoder.decode(PostHogSurvey.self, from: jsonData)
+                } catch {
+                    hedgeLog("Error decoding Survey: \(error)")
+                    return nil
+                }
             }
         }
 

--- a/PostHog/Surveys/Utils/EmojiRating.swift
+++ b/PostHog/Surveys/Utils/EmojiRating.swift
@@ -42,7 +42,7 @@
                     }
                 }
 
-                if scale != .twoPoint {
+                if scale != .twoPoint, !lowerBoundLabel.isEmpty || !upperBoundLabel.isEmpty {
                     HStack(spacing: 0) {
                         Text(lowerBoundLabel)
                             .foregroundStyle(appearance.descriptionTextColor)

--- a/PostHog/Surveys/Utils/NumberRating.swift
+++ b/PostHog/Surveys/Utils/NumberRating.swift
@@ -46,16 +46,18 @@
                     RoundedRectangle(cornerRadius: 6)
                         .stroke(appearance.borderColor, lineWidth: 2)
                 )
-                HStack {
-                    Text(lowerBoundLabel)
-                        .font(.callout)
-                        .foregroundColor(appearance.descriptionTextColor)
-                        .frame(alignment: .leading)
-                    Spacer()
-                    Text(upperBoundLabel)
-                        .font(.callout)
-                        .foregroundColor(appearance.descriptionTextColor)
-                        .frame(alignment: .trailing)
+                if !lowerBoundLabel.isEmpty || !upperBoundLabel.isEmpty {
+                    HStack {
+                        Text(lowerBoundLabel)
+                            .font(.callout)
+                            .foregroundColor(appearance.descriptionTextColor)
+                            .frame(alignment: .leading)
+                        Spacer()
+                        Text(upperBoundLabel)
+                            .font(.callout)
+                            .foregroundColor(appearance.descriptionTextColor)
+                            .frame(alignment: .trailing)
+                    }
                 }
             }
 

--- a/PostHogTests/PostHogSurveysTest.swift
+++ b/PostHogTests/PostHogSurveysTest.swift
@@ -1815,8 +1815,20 @@ enum PostHogSurveysTest {
             #expect(displaySurvey.appearance?.surveyPopupDelaySeconds == nil)
         }
 
-        @Test("rating display defaults missing bound labels to empty string")
-        func ratingDisplayDefaultsMissingBoundLabelsToEmptyString() throws {
+        @Test(
+            "rating display nil-coalesces missing bound labels to empty string",
+            arguments: [
+                (lower: String?.none, upper: String?.none, expectedLower: "", expectedUpper: ""),
+                (lower: String?.none, upper: "Very likely", expectedLower: "", expectedUpper: "Very likely"),
+                (lower: "Not likely", upper: String?.none, expectedLower: "Not likely", expectedUpper: ""),
+            ]
+        )
+        func ratingDisplayDefaultsMissingBoundLabelsToEmptyString(
+            lower: String?,
+            upper: String?,
+            expectedLower: String,
+            expectedUpper: String
+        ) throws {
             let ratingQuestion = PostHogRatingSurveyQuestion(
                 id: "r-1",
                 question: "How likely?",
@@ -1829,8 +1841,8 @@ enum PostHogSurveysTest {
                 translations: nil,
                 display: .number,
                 scale: .tenPoint,
-                lowerBoundLabel: nil,
-                upperBoundLabel: nil
+                lowerBoundLabel: lower,
+                upperBoundLabel: upper
             )
             let survey = PostHogSurvey.testInstance(
                 name: "rating-no-bounds",
@@ -1840,8 +1852,8 @@ enum PostHogSurveysTest {
             let displaySurvey = survey.toDisplaySurvey()
             let displayQuestion = try #require(displaySurvey.questions.first as? PostHogDisplayRatingQuestion)
 
-            #expect(displayQuestion.lowerBoundLabel == "")
-            #expect(displayQuestion.upperBoundLabel == "")
+            #expect(displayQuestion.lowerBoundLabel == expectedLower)
+            #expect(displayQuestion.upperBoundLabel == expectedUpper)
         }
     }
 }

--- a/PostHogTests/PostHogSurveysTest.swift
+++ b/PostHogTests/PostHogSurveysTest.swift
@@ -191,6 +191,21 @@ enum PostHogSurveysTest {
                     throw TestError("Expected a rating question")
                 }
             }
+
+            @Test("rating question decodes without bound labels")
+            func ratingQuestionDecodesWithoutBoundLabels() throws {
+                let data = try loadFixture("fixture_survey_question_rating_no_bounds")
+                let sut = try PostHogApi.jsonDecoder.decode(PostHogSurvey.self, from: data)
+
+                if case let .rating(question) = sut.questions[0] {
+                    #expect(question.scale == .tenPoint)
+                    #expect(question.display == .number)
+                    #expect(question.lowerBoundLabel == nil)
+                    #expect(question.upperBoundLabel == nil)
+                } else {
+                    throw TestError("Expected a rating question")
+                }
+            }
         }
 
         @Suite("Question branching decodes correctly")
@@ -1723,6 +1738,40 @@ enum PostHogSurveysTest {
         }
     }
 
+    @Suite("Test resilient survey list decoding")
+    struct TestResilientSurveyListDecoding {
+        @Test("atomic array decode fails when one survey is malformed")
+        func atomicArrayDecodeFailsOnMalformedEntry() throws {
+            let data = try loadFixture("fixture_surveys_array_with_malformed")
+
+            // Documents Swift's atomic [Decodable] behavior: a single malformed
+            // element throws and drops the entire array. This is the root cause
+            // of issue #611 and the reason decodeSurveys decodes per-element.
+            #expect(throws: DecodingError.self) {
+                _ = try PostHogApi.jsonDecoder.decode([PostHogSurvey].self, from: data)
+            }
+        }
+
+        @Test("per-element decoding skips malformed entries and keeps valid ones")
+        func perElementDecodingSkipsMalformedEntries() throws {
+            let data = try loadFixture("fixture_surveys_array_with_malformed")
+            let rawArray = try JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+            let arrayItems = try #require(rawArray)
+
+            // Mirrors PostHogSurveyIntegration.decodeSurveys: decode each entry
+            // individually so a malformed survey can't take down the whole list.
+            let decoded: [PostHogSurvey] = arrayItems.compactMap { item in
+                guard let itemData = try? JSONSerialization.data(withJSONObject: item) else {
+                    return nil
+                }
+                return try? PostHogApi.jsonDecoder.decode(PostHogSurvey.self, from: itemData)
+            }
+
+            #expect(decoded.count == 1)
+            #expect(decoded.first?.id == "valid-survey-id")
+        }
+    }
+
     @Suite("Test survey to display model mapping")
     struct TestSurveyToDisplayMapping {
         private func makeAppearance(delay: TimeInterval?) -> PostHogSurveyAppearance {
@@ -1764,6 +1813,35 @@ enum PostHogSurveysTest {
             let displaySurvey = survey.toDisplaySurvey()
 
             #expect(displaySurvey.appearance?.surveyPopupDelaySeconds == nil)
+        }
+
+        @Test("rating display defaults missing bound labels to empty string")
+        func ratingDisplayDefaultsMissingBoundLabelsToEmptyString() throws {
+            let ratingQuestion = PostHogRatingSurveyQuestion(
+                id: "r-1",
+                question: "How likely?",
+                description: nil,
+                descriptionContentType: nil,
+                optional: nil,
+                buttonText: nil,
+                originalQuestionIndex: 0,
+                branching: nil,
+                translations: nil,
+                display: .number,
+                scale: .tenPoint,
+                lowerBoundLabel: nil,
+                upperBoundLabel: nil
+            )
+            let survey = PostHogSurvey.testInstance(
+                name: "rating-no-bounds",
+                questions: [.rating(ratingQuestion)]
+            )
+
+            let displaySurvey = survey.toDisplaySurvey()
+            let displayQuestion = try #require(displaySurvey.questions.first as? PostHogDisplayRatingQuestion)
+
+            #expect(displayQuestion.lowerBoundLabel == "")
+            #expect(displayQuestion.upperBoundLabel == "")
         }
     }
 }

--- a/PostHogTests/Resources/fixture_survey_question_rating_no_bounds.json
+++ b/PostHogTests/Resources/fixture_survey_question_rating_no_bounds.json
@@ -1,0 +1,16 @@
+{
+    "id": "01947134-8a35-0000-549a-193b86fa2e44",
+    "name": "NPS Survey without bound labels",
+    "type": "popover",
+    "questions": [
+        {
+            "id": "303",
+            "type": "rating",
+            "scale": 10,
+            "display": "number",
+            "question": "How likely are you to recommend us to a friend?",
+            "originalQuestionIndex": 0,
+            "descriptionContentType": "text"
+        }
+    ]
+}

--- a/PostHogTests/Resources/fixture_surveys_array_with_malformed.json
+++ b/PostHogTests/Resources/fixture_surveys_array_with_malformed.json
@@ -1,0 +1,31 @@
+[
+    {
+        "id": "valid-survey-id",
+        "name": "Valid survey",
+        "type": "popover",
+        "questions": [
+            {
+                "id": "300",
+                "type": "open",
+                "question": "What would you like to see?",
+                "originalQuestionIndex": 0,
+                "descriptionContentType": "text"
+            }
+        ]
+    },
+    {
+        "id": "malformed-survey-id",
+        "name": "Malformed rating survey",
+        "type": "popover",
+        "questions": [
+            {
+                "id": "301",
+                "type": "rating",
+                "display": "number",
+                "question": "How likely are you to recommend us?",
+                "originalQuestionIndex": 0,
+                "descriptionContentType": "text"
+            }
+        ]
+    }
+]


### PR DESCRIPTION
## :bulb: Motivation and Context

Fixes [#611](https://github.com/PostHog/posthog-ios/issues/611). On iOS, a single malformed survey could silently disable **every** survey in the project. Two compounding issues are fixed here.

### Root causes

**1. Atomic array decoding.** `decodeSurveys` decoded the whole `[PostHogSurvey]` in one shot. Swift's array `Decodable` conformance is all-or-nothing — a single failing element throws for the entire array, and the `catch` returned `[]`. So one bad survey took down every survey on the platform.

```swift
// before
return try PostHogApi.jsonDecoder.decode([PostHogSurvey].self, from: jsonData) // atomic
```

**2. Mandatory bound labels on rating questions.** `PostHogRatingSurveyQuestion.lowerBoundLabel`/`upperBoundLabel` were non-optional `String`. The Web and Android SDKs treat these as optional, so any rating question created via the Management API (or any survey where the designer left the scale labels blank) failed to decode on iOS — and given root cause #1, took down every other survey too.

### Real-world impact

From the issue: a Flutter app via `posthog-flutter` saw zero `survey shown` events on iOS over 60 days while Android emitted them normally. Two old test surveys with empty rating bound labels were silently disabling every survey for every iOS user.

### Changes

**Resilient per-element decoding** — `PostHog/Surveys/PostHogSurveyIntegration.swift` now decodes each survey individually via `compactMap`. A malformed entry is logged and skipped; valid surveys still load.

```swift
return surveysJSON.compactMap { surveyJSON in
    do {
        let jsonData = try JSONSerialization.data(withJSONObject: surveyJSON)
        return try PostHogApi.jsonDecoder.decode(PostHogSurvey.self, from: jsonData)
    } catch {
        hedgeLog("Error decoding Survey: \(error)")
        return nil
    }
}
```

**Optional bound labels (aligned with Web/Android)**

- `PostHog/Models/Surveys/PostHogSurveyQuestion.swift` — `lowerBoundLabel`/`upperBoundLabel` are now `String?` on the internal `PostHogRatingSurveyQuestion` decode model.
- `PostHog/Models/Surveys/PostHogSurvey+Display.swift` — nil-coalesces to `""` when building the public display model, so `PostHogDisplayRatingQuestion.lowerBoundLabel: String` keeps its existing non-optional public contract.

**UI: don’t render empty label rows**

- `PostHog/Surveys/Utils/NumberRating.swift` — the labels `HStack` is only shown when at least one label is non-empty.
- `PostHog/Surveys/Utils/EmojiRating.swift` — same guard added inside the existing `scale != .twoPoint` block.

This avoids an empty caption row taking up vertical space below the rating control when bound labels are absent.

### Public API impact

**None.** `PostHogRatingSurveyQuestion` is an internal struct, `PostHogDisplayRatingQuestion.lowerBoundLabel: String` (public) is unchanged, `NumberRating` / `EmojiRating` view init signatures are unchanged, and `decodeSurveys` is `private`.

## :green_heart: How did you test it?

Added four new Swift Testing tests to `PostHogTests/PostHogSurveysTest.swift` plus two new JSON fixtures (`fixture_survey_question_rating_no_bounds.json`, `fixture_surveys_array_with_malformed.json`, both wired into the Xcode project across PBXBuildFile / PBXFileReference / group children / Resources build phase):

1. **`rating question decodes without bound labels`** — proves the decode model now tolerates missing labels.
2. **`atomic array decode fails when one survey is malformed`** — documents the underlying Swift behavior that caused the original bug.
3. **`per-element decoding skips malformed entries and keeps valid ones`** — proves the resilient decoder keeps valid surveys.
4. **`rating display defaults missing bound labels to empty string`** — proves the public display model still receives non-optional `String`.

Verified locally:

- `make test filter=PostHogSurveysTest` — **71 tests in 15 suites passed**
- `xcodebuild build -scheme PostHog -destination 'generic/platform=ios'` — succeeds
- `xcodebuild build -scheme PostHog -destination 'generic/platform=macos'` — succeeds
- `make format` / `make lint` — no new violations

The fix is fully backwards-compatible: any existing surveys with bound labels render identically. Only the previously-broken case (missing labels) is changed.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
