### PR TITLE
fix: retry event uploads on HTTP 408 (Request Timeout)

### DIFF
--- a/.changeset/retry-events-on-408.md
+++ b/.changeset/retry-events-on-408.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Retry event uploads on HTTP 408 (Request Timeout), matching the SDK's existing logs-endpoint behavior.

--- a/PostHog/QueueEndpoint+Factories.swift
+++ b/PostHog/QueueEndpoint+Factories.swift
@@ -5,10 +5,11 @@
 
 import Foundation
 
-/// Retry policy shared by `/batch` (events) and `/snapshot` (replay): 429,
+/// Retry policy shared by `/batch` (events) and `/snapshot` (replay): 408, 429,
 /// the listed 5xx, plus 3xx redirects.
 private func isEventsRetriableStatusCode(_ code: Int) -> Bool {
-    code == 429
+    code == 408
+        || code == 429
         || [500, 502, 503, 504].contains(code)
         || (300 ... 399).contains(code)
 }

--- a/PostHog/QueueEndpoint+Factories.swift
+++ b/PostHog/QueueEndpoint+Factories.swift
@@ -8,9 +8,7 @@ import Foundation
 /// Retry policy shared by `/batch` (events) and `/snapshot` (replay): 408, 429,
 /// the listed 5xx, plus 3xx redirects.
 private func isEventsRetriableStatusCode(_ code: Int) -> Bool {
-    code == 408
-        || code == 429
-        || [500, 502, 503, 504].contains(code)
+    [408, 429, 500, 502, 503, 504].contains(code)
         || (300 ... 399).contains(code)
 }
 

--- a/PostHogTests/PostHogQueueTest.swift
+++ b/PostHogTests/PostHogQueueTest.swift
@@ -371,8 +371,8 @@ class PostHogQueueTest: QuickSpec {
 
         it("pops batch on 5xx codes outside the narrow retriable set") {
             // 501/505/etc. are NOT in the narrow 5xx retriable set
-            // {500, 502, 503, 504} (matching posthog-android). Treat as
-            // non-retriable so a poison record can't block the queue.
+            // {500, 502, 503, 504}. Treat as non-retriable so a poison
+            // record can't block the queue.
             let sut = self.getSut(flushAt: 2, maxBatchSize: 4)
             server.batchResponseHandler = { _, _ in
                 HTTPStubsResponse(jsonObject: [], statusCode: 501, headers: nil)

--- a/PostHogTests/PostHogQueueTest.swift
+++ b/PostHogTests/PostHogQueueTest.swift
@@ -320,6 +320,23 @@ class PostHogQueueTest: QuickSpec {
             sut.clear()
         }
 
+        it("retains batch on HTTP 408 (request timeout is retriable) and does not change cap") {
+            let sut = self.getSut(flushAt: 2, maxBatchSize: 4)
+            server.batchResponseHandler = { _, _ in
+                HTTPStubsResponse(jsonObject: [], statusCode: 408, headers: nil)
+            }
+
+            sut.add(PostHogEvent(event: "event1", distinctId: "id1"))
+            sut.add(PostHogEvent(event: "event2", distinctId: "id2"))
+
+            _ = getBatchedEvents(server)
+
+            expect(sut.depth).toEventually(equal(2))
+            expect(sut.currentBatchCapForTesting).toEventually(equal(4))
+
+            sut.clear()
+        }
+
         it("halves cap repeatedly across multiple 413s and drops once cap reaches 1") {
             // flushAt is high so add() doesn't trigger an auto-flush — we drive
             // each flush manually to observe the multi-step halving sequence.
@@ -353,8 +370,8 @@ class PostHogQueueTest: QuickSpec {
         }
 
         it("pops batch on 5xx codes outside the narrow retriable set") {
-            // 501/505/etc. are NOT in {429, 500, 502, 503, 504} — match
-            // posthog-android's RETRYABLE_STATUS_CODES exactly. Treat as
+            // 501/505/etc. are NOT in the narrow 5xx retriable set
+            // {500, 502, 503, 504} (matching posthog-android). Treat as
             // non-retriable so a poison record can't block the queue.
             let sut = self.getSut(flushAt: 2, maxBatchSize: 4)
             server.batchResponseHandler = { _, _ in


### PR DESCRIPTION
## :bulb: Motivation and Context

HTTP 408 (Request Timeout) is transient and retryable, and the SDK already retries it on the logs endpoint — but the events/batch retry set omitted it. This adds 408 there.

Surfaced by the SDK compliance harness (`retries_on_408`). posthog-android has the same gap: PostHog/posthog-android#538.

See compliance check fail #622.

## :green_heart: How did you test it?

New `PostHogQueueTest` case (408 → batch retained, not dropped). Compliance harness capture suite: 24/29 → 25/29.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
