### PR TITLE
chore: Bump flags-project-board workflow pin to latest

### DIFF
--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
     call-flags-project:
-        uses: PostHog/.github/.github/workflows/flags-project-board.yml@5fc4680761e8ac29a61b212756230eba0e276d8c
+        uses: PostHog/.github/.github/workflows/flags-project-board.yml@d8b55d05dc5150f05c24542a6397ff3ecfbfb56d
         with:
             pr_number: ${{ github.event.pull_request.number }}
             pr_node_id: ${{ github.event.pull_request.node_id }}


### PR DESCRIPTION
Re-pins the reusable `flags-project-board.yml` workflow to the latest `main` (`d8b55d0`).

This pulls in:
- The team→board mapping moving to a runtime config file (`.github/flags-boards.json`), so future board-list edits no longer require callers to re-pin.
- Removal of the dead direct `pull_request_review` trigger in the `.github` repo (no behavior change for callers).

No input contract changes — `pr_number`, `pr_node_id`, `is_draft`, and `secrets: inherit` are unchanged.