### PR TITLE
chore: use macOS 26 runners

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/sdk-compliance.yml
+++ b/.github/workflows/sdk-compliance.yml
@@ -3,7 +3,7 @@ name: SDK Compliance Tests
 # NOTE: This workflow is adapted from PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml
 # Key difference: Uses HYBRID RUNNER architecture because iOS SDK requires macOS (Darwin frameworks)
 # - Standard action: Runs everything in Docker on ubuntu-latest
-# - This workflow: Runs adapter natively on macos-latest, test harness in Docker
+# - This workflow: Runs adapter natively on a macOS runner, test harness in Docker
 #
 # Why: iOS SDK depends on SystemConfiguration, Foundation, UIKit which don't exist on Linux
 
@@ -18,7 +18,7 @@ on:
 
 jobs:
   compliance-tests:
-    # NOTE: Using macos-15-intel (Intel) instead of macos-latest (Apple Silicon)
+    # NOTE: Using macos-15-intel (Intel) instead of macos-26 (Apple Silicon)
     # Reason: Apple Silicon runners don't support nested virtualization needed for Docker
     # See: https://github.com/actions/runner-images/issues/9460
     runs-on: macos-15-intel


### PR DESCRIPTION
## :bulb: Motivation and Context
in a month `macos-latest` will be migrated to what `macos-26` is today, so changing to `macos-26` already and we can monitor any hiccups CI may have before they do the final change, so we can fix things with more patience if any

## :green_heart: How did you test it?

- Ran `git diff --check`
- Confirmed no `macos-latest` references remain under `.github/workflows`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
