### PR TITLE
fix: always invoke reloadFeatureFlags callback

### DIFF
--- a/.changeset/reload-flags-callback-contract.md
+++ b/.changeset/reload-flags-callback-contract.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+`reloadFeatureFlags(_:)` now always invokes its completion callback, including when the SDK is disabled/opted-out or when no remote config is available. Previously these early-returns skipped the callback, which could leave callers that await it (e.g. the Flutter SDK's `reloadFeatureFlags`) hanging indefinitely.

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -1849,10 +1849,17 @@ let maxRetryDelay = 30.0
     @objc(reloadFeatureFlagsWithCallback:)
     public func reloadFeatureFlags(_ callback: @escaping () -> Void) {
         if !isEnabled() {
+            // Still invoke the callback so awaiting callers aren't left hanging.
+            callback()
             return
         }
 
-        remoteConfig?.reloadFeatureFlags { _ in
+        guard let remoteConfig else {
+            callback()
+            return
+        }
+
+        remoteConfig.reloadFeatureFlags { _ in
             callback()
         }
     }

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -1843,9 +1843,10 @@ let maxRetryDelay = 30.0
         }
     }
 
-    /// Reloads feature flags and invokes a callback when the request finishes.
+    /// Reloads feature flags and invokes a callback when finished.
     ///
-    /// - Parameter callback: Called after the reload request completes.
+    /// - Parameter callback: Invoked when the reload finishes, or immediately if the reload
+    ///   is skipped (SDK disabled/opted-out, or no remote config available).
     @objc(reloadFeatureFlagsWithCallback:)
     public func reloadFeatureFlags(_ callback: @escaping () -> Void) {
         if !isEnabled() {

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -1850,7 +1850,6 @@ let maxRetryDelay = 30.0
     @objc(reloadFeatureFlagsWithCallback:)
     public func reloadFeatureFlags(_ callback: @escaping () -> Void) {
         if !isEnabled() {
-            // Still invoke the callback so awaiting callers aren't left hanging.
             callback()
             return
         }

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -165,6 +165,20 @@ class PostHogSDKTest: QuickSpec {
             sut.close()
         }
 
+        it("invokes reloadFeatureFlags callback when not enabled") {
+            let sut = self.getSut()
+            sut.close()
+
+            var called = false
+            sut.reloadFeatureFlags {
+                called = true
+            }
+
+            // isEnabled() is false after close(), so reloadFeatureFlags early-returns;
+            // the callback must still fire instead of leaving awaiting callers hanging.
+            expect(called).to(beTrue())
+        }
+
         it("captures a screen event") {
             let sut = self.getSut()
 

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -174,8 +174,6 @@ class PostHogSDKTest: QuickSpec {
                 called = true
             }
 
-            // isEnabled() is false after close(), so reloadFeatureFlags early-returns;
-            // the callback must still fire instead of leaving awaiting callers hanging.
             expect(called).to(beTrue())
         }
 


### PR DESCRIPTION
## :bulb: Motivation and Context

https://posthoghelp.zendesk.com/agent/tickets/58925 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/61593)

`reloadFeatureFlags(_:)` promises to invoke its callback when the reload finishes, but two early-returns skipped it:

- `if !isEnabled()` — SDK disabled or opted-out
- `remoteConfig?` being nil

When the callback is never invoked, any caller awaiting it stalls. This surfaced via the Flutter SDK, whose `reloadFeatureFlags()` returns a `Future` that completes from this callback — `await Posthog().reloadFeatureFlags()` would hang forever in those states. (Once execution reaches `remoteConfig.reloadFeatureFlags`, the callback already fires on every network outcome, so only the front-door guards were affected.)

## :green_heart: How did you test it?

The change only adds the callback invocation to the two guard returns (and makes the nil-`remoteConfig` case explicit); the normal path is unchanged. Happy to add a unit test asserting the callback fires when `!isEnabled()` if preferred.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
