### PR TITLE
fix: keep session replay active across identify/reset

### DIFF
--- a/.changeset/session-replay-rearm-after-identity.md
+++ b/.changeset/session-replay-rearm-after-identity.md
@@ -2,4 +2,4 @@
 "posthog-ios": patch
 ---
 
-Keep session replay recording and error-tracking autocapture active after an in-session `identify()`/`reset()` instead of disabling them until the next app restart. The project-level recording and error-tracking config is now preserved across `reset()` and re-armed on the next `/flags` reload, matching posthog-android.
+Keep session replay recording, error-tracking autocapture, and network performance capture active after an in-session `identify()`/`reset()` instead of disabling them until the next app restart. The project-level recording, error-tracking, and capture-performance config is now preserved across `reset()` and re-armed on the next `/flags` reload.

--- a/.changeset/session-replay-rearm-after-identity.md
+++ b/.changeset/session-replay-rearm-after-identity.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Keep session replay recording active after an in-session `identify()`/`reset()` instead of disabling it until the next app restart.

--- a/.changeset/session-replay-rearm-after-identity.md
+++ b/.changeset/session-replay-rearm-after-identity.md
@@ -2,4 +2,4 @@
 "posthog-ios": patch
 ---
 
-Keep session replay recording active after an in-session `identify()`/`reset()` instead of disabling it until the next app restart.
+Keep session replay recording and error-tracking autocapture active after an in-session `identify()`/`reset()` instead of disabling them until the next app restart. The project-level recording and error-tracking config is now preserved across `reset()` and re-armed on the next `/flags` reload, matching posthog-android.

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -176,9 +176,6 @@ class PostHogRemoteConfig {
                 // process error tracking config
                 self.processErrorTrackingConfig(config)
 
-                // process capture performance (network timing) config
-                self.processCapturePerformanceConfig(config)
-
                 // notify
                 DispatchQueue.main.async {
                     self.onRemoteConfigLoaded.invoke(config)
@@ -222,11 +219,11 @@ class PostHogRemoteConfig {
     }
 
     private func preloadSessionReplay() {
-        var sessionReplay: [String: Any]?
-        var featureFlags: [String: Any]?
-        featureFlagsLock.withLock {
-            sessionReplay = self.storage.getDictionary(forKey: .sessionReplay) as? [String: Any]
-            featureFlags = self.getCachedFeatureFlags()
+        let sessionReplay = remoteConfigLock.withLock {
+            getCachedRemoteConfig()?["sessionRecording"] as? [String: Any]
+        }
+        let featureFlags = featureFlagsLock.withLock {
+            self.getCachedFeatureFlags()
         }
 
         if let sessionReplay = sessionReplay {
@@ -344,14 +341,11 @@ class PostHogRemoteConfig {
                         self.getCachedFeatureFlags() ?? [:]
                     }
 
-                    // /flags is quota-limited; re-arm project-level config (replay / error tracking /
-                    // capture performance) from the cached config so it survives a reset()-then-quota reload.
-                    let remoteConfig = self.remoteConfigLock.withLock { self.getCachedRemoteConfig() }
+                    // quota-limited /flags carries no config; re-arm from the cached remote config
                     #if os(iOS)
-                        self.processSessionRecordingConfig(remoteConfig, featureFlags: cachedFeatureFlags)
+                        self.processSessionRecordingConfig(nil, featureFlags: cachedFeatureFlags)
                     #endif
-                    self.processErrorTrackingConfig(remoteConfig)
-                    self.processCapturePerformanceConfig(remoteConfig)
+                    self.processErrorTrackingConfig(nil)
 
                     self.notifyFeatureFlagsAndRelease(cachedFeatureFlags)
                     return callback(cachedFeatureFlags)
@@ -376,14 +370,11 @@ class PostHogRemoteConfig {
                     return callback(nil)
                 }
 
-                // /flags carries no config; re-arm project-level config from the cached remote config
-                // (each processor falls back to its own persisted slice after reset()).
-                let remoteConfig = self.remoteConfigLock.withLock { self.getCachedRemoteConfig() }
+                // /flags carries no config; re-arm from the cached remote config
                 #if os(iOS)
-                    self.processSessionRecordingConfig(remoteConfig, featureFlags: featureFlags)
+                    self.processSessionRecordingConfig(nil, featureFlags: featureFlags)
                 #endif
-                self.processErrorTrackingConfig(remoteConfig)
-                self.processCapturePerformanceConfig(remoteConfig)
+                self.processErrorTrackingConfig(nil)
 
                 // Grab the request ID and evaluated timestamp from the response
                 let requestId = data["requestId"] as? String
@@ -433,31 +424,22 @@ class PostHogRemoteConfig {
 
     #if os(iOS)
         private func processSessionRecordingConfig(_ data: [String: Any]?, featureFlags: [String: Any]) {
-            // Fall back to the persisted .sessionReplay (survives reset()) when the source omits
-            // sessionRecording, so replay re-arms for the new user. Only an explicit Bool false disables.
-            let sessionRecording: Any? = data?["sessionRecording"] ?? storage.getDictionary(forKey: .sessionReplay)
+            // fall back to the cached remote config (survives reset()) so replay re-arms; only Bool false disables
+            let sessionRecording: Any? = data?["sessionRecording"]
+                ?? remoteConfigLock.withLock { getCachedRemoteConfig()?["sessionRecording"] }
 
             if let sessionRecording = sessionRecording as? Bool {
                 sessionReplayLock.withLock {
                     sessionReplayFlagActive = sessionRecording
                 }
-
-                // its always false here anyway
-                if !sessionRecording {
-                    storage.remove(key: .sessionReplay)
-                }
-
             } else if let sessionRecording = sessionRecording as? [String: Any] {
-                // keeps the value from config.sessionReplay since having sessionRecording
-                // means its enabled on the project settings, but its only enabled
-                // when local replay integration is enabled/active
+                // enabled in project settings, but only active locally when the replay integration is
                 if let endpoint = sessionRecording["endpoint"] as? String {
                     config.snapshotEndpoint = endpoint
                 }
                 sessionReplayLock.withLock {
                     applySessionRecordingConfigLocked(sessionRecording, featureFlags: featureFlags)
                 }
-                storage.setDictionary(forKey: .sessionReplay, contents: sessionRecording)
             }
         }
 
@@ -527,42 +509,27 @@ class PostHogRemoteConfig {
     #endif
 
     private func processErrorTrackingConfig(_ data: [String: Any]?) {
-        // Fall back to the persisted .errorTracking (survives reset()) when the source omits it, so
-        // autocapture re-arms instead of being force-disabled. Only an explicit Bool false disables.
-        let errorTracking: Any? = data?["errorTracking"] ?? storage.getDictionary(forKey: .errorTracking)
+        // fall back to the cached remote config (survives reset()) so autocapture re-arms; only Bool false disables
+        let errorTracking: Any? = data?["errorTracking"]
+            ?? remoteConfigLock.withLock { getCachedRemoteConfig()?["errorTracking"] }
 
         if let errorTracking = errorTracking as? Bool {
             errorTrackingLock.withLock {
                 autoCaptureExceptions = errorTracking
-            }
-            if !errorTracking {
-                storage.remove(key: .errorTracking)
             }
         } else if let errorTracking = errorTracking as? [String: Any] {
             let enabled = errorTracking["autocaptureExceptions"] as? Bool ?? false
             errorTrackingLock.withLock {
                 autoCaptureExceptions = enabled
             }
-            storage.setDictionary(forKey: .errorTracking, contents: errorTracking)
-        }
-    }
-
-    /// Persists `capturePerformance` (network timing) to the `.capturePerformance` slice, which
-    /// survives `reset()`, so the replay network plugin re-arms it after an identity change. Only an
-    /// explicit Bool `false` disables and evicts.
-    private func processCapturePerformanceConfig(_ data: [String: Any]?) {
-        let capturePerformance: Any? = data?["capturePerformance"] ?? storage.getDictionary(forKey: .capturePerformance)
-
-        if capturePerformance is Bool {
-            // a Bool here means disabled; evict so the plugin reads "off"
-            storage.remove(key: .capturePerformance)
-        } else if let capturePerformance = capturePerformance as? [String: Any] {
-            storage.setDictionary(forKey: .capturePerformance, contents: capturePerformance)
         }
     }
 
     private func preloadErrorTrackingConfig() {
-        if let errorTracking = storage.getDictionary(forKey: .errorTracking) as? [String: Any] {
+        let errorTracking = remoteConfigLock.withLock {
+            getCachedRemoteConfig()?["errorTracking"] as? [String: Any]
+        }
+        if let errorTracking {
             let enabled = errorTracking["autocaptureExceptions"] as? Bool ?? false
             errorTrackingLock.withLock {
                 autoCaptureExceptions = enabled
@@ -892,13 +859,11 @@ class PostHogRemoteConfig {
         resetPersonPropertiesForFlags()
         resetGroupPropertiesForFlags()
 
-        // Clear remote config cache
+        // keep the cached remote config across reset() (project-level, not user data) so features re-arm;
+        // just mark it un-fetched so a fresh copy is pulled
         remoteConfigLock.withLock {
-            remoteConfig = nil
             remoteConfigDidFetch = false
         }
-
-        // .sessionReplay config is intentionally kept across reset() (project-level, not user data) so the next /flags reload can re-arm replay.
     }
 
     #if os(iOS)
@@ -919,22 +884,6 @@ class PostHogRemoteConfig {
     func getRemoteConfig() -> [String: Any]? {
         remoteConfigLock.withLock { getCachedRemoteConfig() }
     }
-
-    #if os(iOS)
-        /// Builds the remote-config view for replay plugin enablement (console logs, network capture)
-        /// from the slices that survive `reset()` — `.sessionReplay` and `.capturePerformance` — rather
-        /// than the full `.remoteConfig` (wiped on reset), so plugins re-arm after an identity change.
-        func getReplayPluginRemoteConfig() -> [String: Any]? {
-            var pluginConfig: [String: Any] = [:]
-            if let sessionRecording = storage.getDictionary(forKey: .sessionReplay) as? [String: Any] {
-                pluginConfig["sessionRecording"] = sessionRecording
-            }
-            if let capturePerformance = storage.getDictionary(forKey: .capturePerformance) as? [String: Any] {
-                pluginConfig["capturePerformance"] = capturePerformance
-            }
-            return pluginConfig.isEmpty ? nil : pluginConfig
-        }
-    #endif
 
     private func getCachedRemoteConfig() -> [String: Any]? {
         if remoteConfig == nil {

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -363,11 +363,14 @@ class PostHogRemoteConfig {
                     return callback(nil)
                 }
 
+                // /flags no longer returns config data, so re-arm project-level config from the
+                // cached remote config (which survives as long as the app is alive; after reset()
+                // each processor falls back to its own persisted slice).
+                let remoteConfig = self.remoteConfigLock.withLock { self.getCachedRemoteConfig() }
                 #if os(iOS)
-                    // Use cached remote config for session recording settings since /flags no longer returns config data
-                    let remoteConfig = self.remoteConfigLock.withLock { self.getCachedRemoteConfig() }
                     self.processSessionRecordingConfig(remoteConfig, featureFlags: featureFlags)
                 #endif
+                self.processErrorTrackingConfig(remoteConfig)
 
                 // Grab the request ID and evaluated timestamp from the response
                 let requestId = data["requestId"] as? String
@@ -515,24 +518,25 @@ class PostHogRemoteConfig {
     #endif
 
     private func processErrorTrackingConfig(_ data: [String: Any]?) {
-        if let errorTracking = data?["errorTracking"] as? Bool {
+        // When the source config omits errorTracking (e.g. after a reset() wipes the cached remote
+        // config, or on a /flags reload), fall back to the persisted .errorTracking — which survives
+        // reset() — so autocapture can re-arm for the new session instead of being force-disabled.
+        // Only an explicit Bool `false` disables and evicts. Mirrors processSessionRecordingConfig.
+        let errorTracking: Any? = data?["errorTracking"] ?? storage.getDictionary(forKey: .errorTracking)
+
+        if let errorTracking = errorTracking as? Bool {
             errorTrackingLock.withLock {
                 autoCaptureExceptions = errorTracking
             }
             if !errorTracking {
                 storage.remove(key: .errorTracking)
             }
-        } else if let errorTracking = data?["errorTracking"] as? [String: Any] {
+        } else if let errorTracking = errorTracking as? [String: Any] {
             let enabled = errorTracking["autocaptureExceptions"] as? Bool ?? false
             errorTrackingLock.withLock {
                 autoCaptureExceptions = enabled
             }
             storage.setDictionary(forKey: .errorTracking, contents: errorTracking)
-        } else {
-            // No errorTracking key or unexpected type — disable
-            errorTrackingLock.withLock {
-                autoCaptureExceptions = false
-            }
         }
     }
 

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -439,9 +439,7 @@ class PostHogRemoteConfig {
                     config.snapshotEndpoint = endpoint
                 }
                 sessionReplayLock.withLock {
-                    recordingSampleRate = parseSampleRate(sessionRecording["sampleRate"])
-                    recordingMinimumDuration = parseMinimumDuration(sessionRecording["minimumDurationMilliseconds"])
-                    sessionReplayFlagActive = isRecordingActive(featureFlags, sessionRecording)
+                    applySessionRecordingConfig(sessionRecording, featureFlags: featureFlags)
                     // Cache so /flags reloads and reset()/identify() can re-evaluate without re-fetching /config.
                     lastSessionRecordingConfig = sessionRecording
                 }
@@ -450,12 +448,18 @@ class PostHogRemoteConfig {
                 // /flags doesn't carry sessionRecording; re-evaluate from the cached config instead of clobbering it.
                 sessionReplayLock.withLock {
                     if let lastConfig = lastSessionRecordingConfig {
-                        sessionReplayFlagActive = isRecordingActive(featureFlags, lastConfig)
-                        recordingSampleRate = parseSampleRate(lastConfig["sampleRate"])
-                        recordingMinimumDuration = parseMinimumDuration(lastConfig["minimumDurationMilliseconds"])
+                        applySessionRecordingConfig(lastConfig, featureFlags: featureFlags)
                     }
                 }
             }
+        }
+
+        /// Applies a `sessionRecording` config dict to the in-memory replay state (active flag,
+        /// sample rate, minimum duration). The caller must already hold `sessionReplayLock`.
+        private func applySessionRecordingConfig(_ config: [String: Any], featureFlags: [String: Any]) {
+            sessionReplayFlagActive = isRecordingActive(featureFlags, config)
+            recordingSampleRate = parseSampleRate(config["sampleRate"])
+            recordingMinimumDuration = parseMinimumDuration(config["minimumDurationMilliseconds"])
         }
 
         /// Parses and validates a sample rate value which may come as a String (from the API JSON)
@@ -858,6 +862,8 @@ class PostHogRemoteConfig {
         sessionReplayLock.withLock {
             sessionReplayFlagActive = false
             recordingSampleRate = nil
+            // Keep lastSessionRecordingConfig so the post-reset /flags reload can re-arm replay
+            // without re-fetching /config. See processSessionRecordingConfig's `else` branch.
         }
 
         errorTrackingLock.withLock {

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -450,10 +450,10 @@ class PostHogRemoteConfig {
 
         /// Applies a `sessionRecording` config dict to the in-memory replay state (active flag,
         /// sample rate, minimum duration). The caller must already hold `sessionReplayLock`.
-        private func applySessionRecordingConfig(_ config: [String: Any], featureFlags: [String: Any]) {
-            sessionReplayFlagActive = isRecordingActive(featureFlags, config)
-            recordingSampleRate = parseSampleRate(config["sampleRate"])
-            recordingMinimumDuration = parseMinimumDuration(config["minimumDurationMilliseconds"])
+        private func applySessionRecordingConfig(_ recordingConfig: [String: Any], featureFlags: [String: Any]) {
+            sessionReplayFlagActive = isRecordingActive(featureFlags, recordingConfig)
+            recordingSampleRate = parseSampleRate(recordingConfig["sampleRate"])
+            recordingMinimumDuration = parseMinimumDuration(recordingConfig["minimumDurationMilliseconds"])
         }
 
         /// Parses and validates a sample rate value which may come as a String (from the API JSON)

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -451,6 +451,8 @@ class PostHogRemoteConfig {
                 sessionReplayLock.withLock {
                     if let lastConfig = lastSessionRecordingConfig {
                         sessionReplayFlagActive = isRecordingActive(featureFlags, lastConfig)
+                        recordingSampleRate = parseSampleRate(lastConfig["sampleRate"])
+                        recordingMinimumDuration = parseMinimumDuration(lastConfig["minimumDurationMilliseconds"])
                     }
                 }
             }

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -340,6 +340,17 @@ class PostHogRemoteConfig {
                     let cachedFeatureFlags = self.featureFlagsLock.withLock {
                         self.getCachedFeatureFlags() ?? [:]
                     }
+
+                    // Flags are quota-limited and couldn't be updated, but session replay / error
+                    // tracking config come from /config (not flags). Still re-arm them from the cached
+                    // config against the flags we already have, so they don't stay disabled after a
+                    // reset()-then-quota-limited reload. Matches posthog-android (#547 / 407c355).
+                    let remoteConfig = self.remoteConfigLock.withLock { self.getCachedRemoteConfig() }
+                    #if os(iOS)
+                        self.processSessionRecordingConfig(remoteConfig, featureFlags: cachedFeatureFlags)
+                    #endif
+                    self.processErrorTrackingConfig(remoteConfig)
+
                     self.notifyFeatureFlagsAndRelease(cachedFeatureFlags)
                     return callback(cachedFeatureFlags)
                 }

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -24,6 +24,8 @@ class PostHogRemoteConfig {
     private var sessionReplayFlagActive = false
     private var recordingSampleRate: Double?
     private var recordingMinimumDuration: TimeInterval?
+    // Last sessionRecording config from /config, kept so /flags reloads can re-evaluate without re-fetching it.
+    private var lastSessionRecordingConfig: [String: Any]?
 
     private let errorTrackingLock = NSLock()
     private var autoCaptureExceptions = false
@@ -233,6 +235,7 @@ class PostHogRemoteConfig {
 
             sessionReplayLock.withLock {
                 sessionReplayFlagActive = isRecordingActive(featureFlags ?? [:], sessionReplay)
+                lastSessionRecordingConfig = sessionReplay
                 #if os(iOS)
                     recordingSampleRate = parseSampleRate(sessionReplay["sampleRate"])
                     recordingMinimumDuration = parseMinimumDuration(sessionReplay["minimumDurationMilliseconds"])
@@ -420,6 +423,7 @@ class PostHogRemoteConfig {
             if let sessionRecording = data?["sessionRecording"] as? Bool {
                 sessionReplayLock.withLock {
                     sessionReplayFlagActive = sessionRecording
+                    lastSessionRecordingConfig = nil
                 }
 
                 // its always false here anyway
@@ -438,8 +442,17 @@ class PostHogRemoteConfig {
                     recordingSampleRate = parseSampleRate(sessionRecording["sampleRate"])
                     recordingMinimumDuration = parseMinimumDuration(sessionRecording["minimumDurationMilliseconds"])
                     sessionReplayFlagActive = isRecordingActive(featureFlags, sessionRecording)
+                    // Cache so /flags reloads and reset()/identify() can re-evaluate without re-fetching /config.
+                    lastSessionRecordingConfig = sessionRecording
                 }
                 storage.setDictionary(forKey: .sessionReplay, contents: sessionRecording)
+            } else {
+                // /flags doesn't carry sessionRecording; re-evaluate from the cached config instead of clobbering it.
+                sessionReplayLock.withLock {
+                    if let lastConfig = lastSessionRecordingConfig {
+                        sessionReplayFlagActive = isRecordingActive(featureFlags, lastConfig)
+                    }
+                }
             }
         }
 

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -176,6 +176,9 @@ class PostHogRemoteConfig {
                 // process error tracking config
                 self.processErrorTrackingConfig(config)
 
+                // process capture performance (network timing) config
+                self.processCapturePerformanceConfig(config)
+
                 // notify
                 DispatchQueue.main.async {
                     self.onRemoteConfigLoaded.invoke(config)
@@ -341,15 +344,14 @@ class PostHogRemoteConfig {
                         self.getCachedFeatureFlags() ?? [:]
                     }
 
-                    // Flags are quota-limited and couldn't be updated, but session replay / error
-                    // tracking config come from /config (not flags). Still re-arm them from the cached
-                    // config against the flags we already have, so they don't stay disabled after a
-                    // reset()-then-quota-limited reload. Matches posthog-android (#547 / 407c355).
+                    // /flags is quota-limited; re-arm project-level config (replay / error tracking /
+                    // capture performance) from the cached config so it survives a reset()-then-quota reload.
                     let remoteConfig = self.remoteConfigLock.withLock { self.getCachedRemoteConfig() }
                     #if os(iOS)
                         self.processSessionRecordingConfig(remoteConfig, featureFlags: cachedFeatureFlags)
                     #endif
                     self.processErrorTrackingConfig(remoteConfig)
+                    self.processCapturePerformanceConfig(remoteConfig)
 
                     self.notifyFeatureFlagsAndRelease(cachedFeatureFlags)
                     return callback(cachedFeatureFlags)
@@ -374,14 +376,14 @@ class PostHogRemoteConfig {
                     return callback(nil)
                 }
 
-                // /flags no longer returns config data, so re-arm project-level config from the
-                // cached remote config (which survives as long as the app is alive; after reset()
-                // each processor falls back to its own persisted slice).
+                // /flags carries no config; re-arm project-level config from the cached remote config
+                // (each processor falls back to its own persisted slice after reset()).
                 let remoteConfig = self.remoteConfigLock.withLock { self.getCachedRemoteConfig() }
                 #if os(iOS)
                     self.processSessionRecordingConfig(remoteConfig, featureFlags: featureFlags)
                 #endif
                 self.processErrorTrackingConfig(remoteConfig)
+                self.processCapturePerformanceConfig(remoteConfig)
 
                 // Grab the request ID and evaluated timestamp from the response
                 let requestId = data["requestId"] as? String
@@ -431,12 +433,8 @@ class PostHogRemoteConfig {
 
     #if os(iOS)
         private func processSessionRecordingConfig(_ data: [String: Any]?, featureFlags: [String: Any]) {
-            // When the source config omits sessionRecording (e.g. after a reset() wipes the cached
-            // remote config), fall back to the persisted .sessionReplay, which survives reset() so
-            // replay can re-arm for the new user. NB: falling back to the in-memory remoteConfig
-            // wouldn't help — clear()/reset() nils it, and at the /flags call site `data` is already
-            // getCachedRemoteConfig(). Routing the fallback through the same if-chain also handles a
-            // Bool (disabled) cached value, not just the Map case.
+            // Fall back to the persisted .sessionReplay (survives reset()) when the source omits
+            // sessionRecording, so replay re-arms for the new user. Only an explicit Bool false disables.
             let sessionRecording: Any? = data?["sessionRecording"] ?? storage.getDictionary(forKey: .sessionReplay)
 
             if let sessionRecording = sessionRecording as? Bool {
@@ -529,10 +527,8 @@ class PostHogRemoteConfig {
     #endif
 
     private func processErrorTrackingConfig(_ data: [String: Any]?) {
-        // When the source config omits errorTracking (e.g. after a reset() wipes the cached remote
-        // config, or on a /flags reload), fall back to the persisted .errorTracking — which survives
-        // reset() — so autocapture can re-arm for the new session instead of being force-disabled.
-        // Only an explicit Bool `false` disables and evicts. Mirrors processSessionRecordingConfig.
+        // Fall back to the persisted .errorTracking (survives reset()) when the source omits it, so
+        // autocapture re-arms instead of being force-disabled. Only an explicit Bool false disables.
         let errorTracking: Any? = data?["errorTracking"] ?? storage.getDictionary(forKey: .errorTracking)
 
         if let errorTracking = errorTracking as? Bool {
@@ -548,6 +544,20 @@ class PostHogRemoteConfig {
                 autoCaptureExceptions = enabled
             }
             storage.setDictionary(forKey: .errorTracking, contents: errorTracking)
+        }
+    }
+
+    /// Persists `capturePerformance` (network timing) to the `.capturePerformance` slice, which
+    /// survives `reset()`, so the replay network plugin re-arms it after an identity change. Only an
+    /// explicit Bool `false` disables and evicts.
+    private func processCapturePerformanceConfig(_ data: [String: Any]?) {
+        let capturePerformance: Any? = data?["capturePerformance"] ?? storage.getDictionary(forKey: .capturePerformance)
+
+        if capturePerformance is Bool {
+            // a Bool here means disabled; evict so the plugin reads "off"
+            storage.remove(key: .capturePerformance)
+        } else if let capturePerformance = capturePerformance as? [String: Any] {
+            storage.setDictionary(forKey: .capturePerformance, contents: capturePerformance)
         }
     }
 
@@ -909,6 +919,22 @@ class PostHogRemoteConfig {
     func getRemoteConfig() -> [String: Any]? {
         remoteConfigLock.withLock { getCachedRemoteConfig() }
     }
+
+    #if os(iOS)
+        /// Builds the remote-config view for replay plugin enablement (console logs, network capture)
+        /// from the slices that survive `reset()` — `.sessionReplay` and `.capturePerformance` — rather
+        /// than the full `.remoteConfig` (wiped on reset), so plugins re-arm after an identity change.
+        func getReplayPluginRemoteConfig() -> [String: Any]? {
+            var pluginConfig: [String: Any] = [:]
+            if let sessionRecording = storage.getDictionary(forKey: .sessionReplay) as? [String: Any] {
+                pluginConfig["sessionRecording"] = sessionRecording
+            }
+            if let capturePerformance = storage.getDictionary(forKey: .capturePerformance) as? [String: Any] {
+                pluginConfig["capturePerformance"] = capturePerformance
+            }
+            return pluginConfig.isEmpty ? nil : pluginConfig
+        }
+    #endif
 
     private func getCachedRemoteConfig() -> [String: Any]? {
         if remoteConfig == nil {

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -24,8 +24,6 @@ class PostHogRemoteConfig {
     private var sessionReplayFlagActive = false
     private var recordingSampleRate: Double?
     private var recordingMinimumDuration: TimeInterval?
-    // Last sessionRecording config from /config, kept so /flags reloads can re-evaluate without re-fetching it.
-    private var lastSessionRecordingConfig: [String: Any]?
 
     private let errorTrackingLock = NSLock()
     private var autoCaptureExceptions = false
@@ -235,7 +233,6 @@ class PostHogRemoteConfig {
 
             sessionReplayLock.withLock {
                 sessionReplayFlagActive = isRecordingActive(featureFlags ?? [:], sessionReplay)
-                lastSessionRecordingConfig = sessionReplay
                 #if os(iOS)
                     recordingSampleRate = parseSampleRate(sessionReplay["sampleRate"])
                     recordingMinimumDuration = parseMinimumDuration(sessionReplay["minimumDurationMilliseconds"])
@@ -423,7 +420,6 @@ class PostHogRemoteConfig {
             if let sessionRecording = data?["sessionRecording"] as? Bool {
                 sessionReplayLock.withLock {
                     sessionReplayFlagActive = sessionRecording
-                    lastSessionRecordingConfig = nil
                 }
 
                 // its always false here anyway
@@ -440,15 +436,13 @@ class PostHogRemoteConfig {
                 }
                 sessionReplayLock.withLock {
                     applySessionRecordingConfig(sessionRecording, featureFlags: featureFlags)
-                    // Cache so /flags reloads and reset()/identify() can re-evaluate without re-fetching /config.
-                    lastSessionRecordingConfig = sessionRecording
                 }
                 storage.setDictionary(forKey: .sessionReplay, contents: sessionRecording)
             } else {
-                // /flags doesn't carry sessionRecording; re-evaluate from the cached config instead of clobbering it.
-                sessionReplayLock.withLock {
-                    if let lastConfig = lastSessionRecordingConfig {
-                        applySessionRecordingConfig(lastConfig, featureFlags: featureFlags)
+                // /flags doesn't carry sessionRecording; re-evaluate from the persisted config (survives reset) instead of clobbering.
+                if let cached = storage.getDictionary(forKey: .sessionReplay) as? [String: Any] {
+                    sessionReplayLock.withLock {
+                        applySessionRecordingConfig(cached, featureFlags: featureFlags)
                     }
                 }
             }
@@ -862,8 +856,6 @@ class PostHogRemoteConfig {
         sessionReplayLock.withLock {
             sessionReplayFlagActive = false
             recordingSampleRate = nil
-            // Keep lastSessionRecordingConfig so the post-reset /flags reload can re-arm replay
-            // without re-fetching /config. See processSessionRecordingConfig's `else` branch.
         }
 
         errorTrackingLock.withLock {
@@ -880,7 +872,7 @@ class PostHogRemoteConfig {
             remoteConfigDidFetch = false
         }
 
-        storage.remove(key: .sessionReplay)
+        // .sessionReplay config is intentionally kept across reset() (project-level, not user data) so the next /flags reload can re-arm replay.
     }
 
     #if os(iOS)

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -417,7 +417,15 @@ class PostHogRemoteConfig {
 
     #if os(iOS)
         private func processSessionRecordingConfig(_ data: [String: Any]?, featureFlags: [String: Any]) {
-            if let sessionRecording = data?["sessionRecording"] as? Bool {
+            // When the source config omits sessionRecording (e.g. after a reset() wipes the cached
+            // remote config), fall back to the persisted .sessionReplay, which survives reset() so
+            // replay can re-arm for the new user. NB: falling back to the in-memory remoteConfig
+            // wouldn't help — clear()/reset() nils it, and at the /flags call site `data` is already
+            // getCachedRemoteConfig(). Routing the fallback through the same if-chain also handles a
+            // Bool (disabled) cached value, not just the Map case.
+            let sessionRecording: Any? = data?["sessionRecording"] ?? storage.getDictionary(forKey: .sessionReplay)
+
+            if let sessionRecording = sessionRecording as? Bool {
                 sessionReplayLock.withLock {
                     sessionReplayFlagActive = sessionRecording
                 }
@@ -427,7 +435,7 @@ class PostHogRemoteConfig {
                     storage.remove(key: .sessionReplay)
                 }
 
-            } else if let sessionRecording = data?["sessionRecording"] as? [String: Any] {
+            } else if let sessionRecording = sessionRecording as? [String: Any] {
                 // keeps the value from config.sessionReplay since having sessionRecording
                 // means its enabled on the project settings, but its only enabled
                 // when local replay integration is enabled/active
@@ -435,22 +443,15 @@ class PostHogRemoteConfig {
                     config.snapshotEndpoint = endpoint
                 }
                 sessionReplayLock.withLock {
-                    applySessionRecordingConfig(sessionRecording, featureFlags: featureFlags)
+                    applySessionRecordingConfigLocked(sessionRecording, featureFlags: featureFlags)
                 }
                 storage.setDictionary(forKey: .sessionReplay, contents: sessionRecording)
-            } else {
-                // /flags doesn't carry sessionRecording; re-evaluate from the persisted config (survives reset) instead of clobbering.
-                if let cached = storage.getDictionary(forKey: .sessionReplay) as? [String: Any] {
-                    sessionReplayLock.withLock {
-                        applySessionRecordingConfig(cached, featureFlags: featureFlags)
-                    }
-                }
             }
         }
 
         /// Applies a `sessionRecording` config dict to the in-memory replay state (active flag,
         /// sample rate, minimum duration). The caller must already hold `sessionReplayLock`.
-        private func applySessionRecordingConfig(_ recordingConfig: [String: Any], featureFlags: [String: Any]) {
+        private func applySessionRecordingConfigLocked(_ recordingConfig: [String: Any], featureFlags: [String: Any]) {
             sessionReplayFlagActive = isRecordingActive(featureFlags, recordingConfig)
             recordingSampleRate = parseSampleRate(recordingConfig["sampleRate"])
             recordingMinimumDuration = parseMinimumDuration(recordingConfig["minimumDurationMilliseconds"])

--- a/PostHog/PostHogStorage.swift
+++ b/PostHog/PostHogStorage.swift
@@ -416,7 +416,8 @@ class PostHogStorage {
         deleteSafely(url(forKey: .requestId))
         deleteSafely(url(forKey: .personPropertiesForFlags))
         deleteSafely(url(forKey: .groupPropertiesForFlags))
-        deleteSafely(url(forKey: .errorTracking))
+        // .errorTracking is project-level config (not user data), kept across reset() — like .sessionReplay —
+        // so autocapture can re-arm on the next /flags reload without an app restart.
     }
 
     func remove(key: StorageKey) {

--- a/PostHog/PostHogStorage.swift
+++ b/PostHog/PostHogStorage.swift
@@ -408,17 +408,18 @@ class PostHogStorage {
         deleteSafely(url(forKey: .groups))
         deleteSafely(url(forKey: .registerProperties))
         deleteSafely(url(forKey: .optOut))
-        // .sessionReplay is project-level config (not user data), kept across reset() so replay can re-arm without an app restart.
         deleteSafely(url(forKey: .isIdentified))
         deleteSafely(url(forKey: .personProcessingEnabled))
-        deleteSafely(url(forKey: .remoteConfig))
+        // .remoteConfig is project-level config (not user data); kept across reset() so features re-arm
         deleteSafely(url(forKey: .surveySeen))
         deleteSafely(url(forKey: .lastSeenSurveyDate))
         deleteSafely(url(forKey: .requestId))
         deleteSafely(url(forKey: .personPropertiesForFlags))
         deleteSafely(url(forKey: .groupPropertiesForFlags))
-        // .errorTracking and .capturePerformance are project-level config (like .sessionReplay), kept
-        // across reset() so they re-arm on the next /flags reload. Intentionally NOT in this delete list.
+        // legacy slices, no longer written (config now lives in .remoteConfig); drop stragglers from older SDKs
+        deleteSafely(url(forKey: .sessionReplay))
+        deleteSafely(url(forKey: .errorTracking))
+        deleteSafely(url(forKey: .capturePerformance))
     }
 
     func remove(key: StorageKey) {

--- a/PostHog/PostHogStorage.swift
+++ b/PostHog/PostHogStorage.swift
@@ -251,6 +251,7 @@ class PostHogStorage {
         case personPropertiesForFlags = "posthog.personPropertiesForFlags"
         case groupPropertiesForFlags = "posthog.groupPropertiesForFlags"
         case errorTracking = "posthog.errorTracking"
+        case capturePerformance = "posthog.capturePerformance"
         case deviceId = "posthog.deviceId"
     }
 
@@ -416,8 +417,8 @@ class PostHogStorage {
         deleteSafely(url(forKey: .requestId))
         deleteSafely(url(forKey: .personPropertiesForFlags))
         deleteSafely(url(forKey: .groupPropertiesForFlags))
-        // .errorTracking is project-level config (not user data), kept across reset() — like .sessionReplay —
-        // so autocapture can re-arm on the next /flags reload without an app restart.
+        // .errorTracking and .capturePerformance are project-level config (like .sessionReplay), kept
+        // across reset() so they re-arm on the next /flags reload. Intentionally NOT in this delete list.
     }
 
     func remove(key: StorageKey) {

--- a/PostHog/PostHogStorage.swift
+++ b/PostHog/PostHogStorage.swift
@@ -407,7 +407,7 @@ class PostHogStorage {
         deleteSafely(url(forKey: .groups))
         deleteSafely(url(forKey: .registerProperties))
         deleteSafely(url(forKey: .optOut))
-        deleteSafely(url(forKey: .sessionReplay))
+        // .sessionReplay is project-level config (not user data), kept across reset() so replay can re-arm without an app restart.
         deleteSafely(url(forKey: .isIdentified))
         deleteSafely(url(forKey: .personProcessingEnabled))
         deleteSafely(url(forKey: .remoteConfig))

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -264,10 +264,10 @@
                 self?.handleApplicationEvent(event: event, date: date)
             }
 
-            // Install plugins. Read enablement from the slices that survive reset(), not the full
-            // .remoteConfig (wiped on reset), so plugins re-arm when the integration restarts.
+            // Install plugins. The full remote config survives reset() (project-level), so plugin
+            // enablement re-arms when the integration restarts after an identity change.
             let pluginTypes = postHog.config.sessionReplayConfig.getPluginTypes()
-            let remoteConfig = postHog.remoteConfig?.getReplayPluginRemoteConfig()
+            let remoteConfig = postHog.remoteConfig?.getRemoteConfig()
             let pluginsToStart = installedPluginsLock.withLock {
                 installedPlugins = []
                 for pluginType in pluginTypes {

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -264,9 +264,10 @@
                 self?.handleApplicationEvent(event: event, date: date)
             }
 
-            // Install plugins
+            // Install plugins. Read enablement from the slices that survive reset(), not the full
+            // .remoteConfig (wiped on reset), so plugins re-arm when the integration restarts.
             let pluginTypes = postHog.config.sessionReplayConfig.getPluginTypes()
-            let remoteConfig = postHog.remoteConfig?.getRemoteConfig()
+            let remoteConfig = postHog.remoteConfig?.getReplayPluginRemoteConfig()
             let pluginsToStart = installedPluginsLock.withLock {
                 installedPlugins = []
                 for pluginType in pluginTypes {

--- a/PostHogTests/PostHogRemoteConfigTest.swift
+++ b/PostHogTests/PostHogRemoteConfigTest.swift
@@ -856,6 +856,55 @@ enum PostHogRemoteConfigTest {
 
                 #expect(sut.isSessionReplayFlagActive() == false)
             }
+
+            @Test("session replay re-arms from cached config on a quota-limited flags reload")
+            func sessionReplayReArmsOnQuotaLimitedFlagsReload() async {
+                let storage = PostHogStorage(config)
+                defer { storage.reset() }
+
+                server.returnReplay = true
+                server.sessionRecordingSampleRate = "0.42"
+
+                let sut = getSut(storage: storage)
+
+                await withCheckedContinuation { continuation in
+                    sut.reloadRemoteConfig { _ in continuation.resume() }
+                }
+                #expect(sut.isSessionReplayFlagActive() == true)
+                #expect(sut.getRecordingSampleRate() == 0.42)
+
+                storage.reset()
+                sut.clear()
+                #expect(sut.isSessionReplayFlagActive() == false)
+                #expect(sut.getRecordingSampleRate() == nil)
+
+                server.quotaLimitFeatureFlags = true
+                await withCheckedContinuation { continuation in
+                    sut.loadFeatureFlags(distinctId: "distinctId", anonymousId: "anonymousId", groups: ["group": "value"], callback: { _ in
+                        continuation.resume()
+                    })
+                }
+
+                #expect(sut.isSessionReplayFlagActive() == true)
+                #expect(sut.getRecordingSampleRate() == 0.42)
+            }
+
+            @Test("flags reload with no cached recording config leaves replay inactive")
+            func flagsReloadWithoutCachedRecordingConfigLeavesReplayInactive() async {
+                let storage = PostHogStorage(config)
+                defer { storage.reset() }
+
+                let sut = getSut(storage: storage)
+                #expect(sut.isSessionReplayFlagActive() == false)
+
+                await withCheckedContinuation { continuation in
+                    sut.loadFeatureFlags(distinctId: "distinctId", anonymousId: "anonymousId", groups: ["group": "value"], callback: { _ in
+                        continuation.resume()
+                    })
+                }
+
+                #expect(sut.isSessionReplayFlagActive() == false)
+            }
         }
     #endif
 
@@ -1063,6 +1112,172 @@ enum PostHogRemoteConfigTest {
             #expect(sut.isAutocaptureExceptionsEnabled() == false)
 
             _ = token
+        }
+
+        @Test("error tracking re-arms from cached config on a quota-limited flags reload")
+        func errorTrackingReArmsOnQuotaLimitedFlagsReload() async {
+            let config = makeIsolatedConfig()
+            server.remoteConfigErrorTracking = ["autocaptureExceptions": true]
+
+            let storage = PostHogStorage(config)
+            defer { storage.reset() }
+
+            let sut = getSut(storage: storage, config: config)
+
+            await withCheckedContinuation { continuation in
+                sut.reloadRemoteConfig { _ in continuation.resume() }
+            }
+            #expect(sut.isAutocaptureExceptionsEnabled() == true)
+
+            storage.reset()
+            sut.clear()
+            #expect(sut.isAutocaptureExceptionsEnabled() == false)
+
+            server.quotaLimitFeatureFlags = true
+            await withCheckedContinuation { continuation in
+                sut.loadFeatureFlags(distinctId: "distinctId", anonymousId: "anonymousId", groups: ["group": "value"], callback: { _ in
+                    continuation.resume()
+                })
+            }
+
+            #expect(sut.isAutocaptureExceptionsEnabled() == true)
+        }
+
+        @Test("flags reload with no cached error tracking does not re-arm it")
+        func flagsReloadWithoutCachedErrorTrackingDoesNotReArm() async {
+            let config = makeIsolatedConfig()
+
+            let storage = PostHogStorage(config)
+            defer { storage.reset() }
+
+            let sut = getSut(storage: storage, config: config)
+            #expect(sut.isAutocaptureExceptionsEnabled() == false)
+
+            await withCheckedContinuation { continuation in
+                sut.loadFeatureFlags(distinctId: "distinctId", anonymousId: "anonymousId", groups: ["group": "value"], callback: { _ in
+                    continuation.resume()
+                })
+            }
+
+            #expect(sut.isAutocaptureExceptionsEnabled() == false)
+        }
+    }
+
+    @Suite("Test Capture Performance Config")
+    class TestCapturePerformanceConfig: BaseTestClass {
+        private func makeIsolatedConfig(disableRemoteConfigForTesting: Bool = true) -> PostHogConfig {
+            let config = PostHogConfig(projectToken: "\(testProjectToken)-\(UUID().uuidString)", host: "http://localhost:9001")
+            config.disableRemoteConfigForTesting = disableRemoteConfigForTesting
+            return config
+        }
+
+        @Test("capture performance config survives reset and re-arms on a flags reload")
+        func capturePerformanceReArmsAfterReset() async {
+            let config = makeIsolatedConfig()
+            server.remoteConfigCapturePerformance = ["network_timing": true]
+
+            let storage = PostHogStorage(config)
+            defer { storage.reset() }
+
+            let sut = getSut(storage: storage, config: config)
+
+            await withCheckedContinuation { continuation in
+                sut.reloadRemoteConfig { _ in continuation.resume() }
+            }
+            #expect(storage.getDictionary(forKey: .capturePerformance) != nil)
+
+            storage.reset()
+            sut.clear()
+            #expect(storage.getDictionary(forKey: .capturePerformance) != nil)
+
+            await withCheckedContinuation { continuation in
+                sut.loadFeatureFlags(distinctId: "distinctId", anonymousId: "anonymousId", groups: ["group": "value"], callback: { _ in
+                    continuation.resume()
+                })
+            }
+
+            #expect(storage.getDictionary(forKey: .capturePerformance) != nil)
+            #if os(iOS)
+                #expect(sut.getReplayPluginRemoteConfig()?["capturePerformance"] != nil)
+            #endif
+        }
+
+        @Test("capture performance config re-arms on a quota-limited flags reload")
+        func capturePerformanceReArmsOnQuotaLimitedFlagsReload() async {
+            let config = makeIsolatedConfig()
+            server.remoteConfigCapturePerformance = ["network_timing": true]
+
+            let storage = PostHogStorage(config)
+            defer { storage.reset() }
+
+            let sut = getSut(storage: storage, config: config)
+
+            await withCheckedContinuation { continuation in
+                sut.reloadRemoteConfig { _ in continuation.resume() }
+            }
+            #expect(storage.getDictionary(forKey: .capturePerformance) != nil)
+
+            storage.reset()
+            sut.clear()
+
+            server.quotaLimitFeatureFlags = true
+            await withCheckedContinuation { continuation in
+                sut.loadFeatureFlags(distinctId: "distinctId", anonymousId: "anonymousId", groups: ["group": "value"], callback: { _ in
+                    continuation.resume()
+                })
+            }
+
+            #expect(storage.getDictionary(forKey: .capturePerformance) != nil)
+        }
+
+        @Test("evicts cached capture performance config when capturePerformance is boolean false")
+        func evictsCapturePerformanceWhenBooleanFalse() async {
+            let config = makeIsolatedConfig(disableRemoteConfigForTesting: false)
+            config.preloadFeatureFlags = false
+            config.storageManager = PostHogStorageManager(config)
+
+            server.remoteConfigCapturePerformance = false
+
+            let storage = PostHogStorage(config)
+            defer { storage.reset() }
+
+            storage.setDictionary(forKey: .capturePerformance, contents: ["network_timing": true])
+
+            let sut = getSut(storage: storage, config: config)
+
+            var remoteConfigLoaded = false
+            let token = sut.onRemoteConfigLoaded.subscribe { _ in
+                remoteConfigLoaded = true
+            }
+
+            await withCheckedContinuation { continuation in
+                let timeout = Date().addingTimeInterval(2)
+                while !remoteConfigLoaded, Date() < timeout {}
+                continuation.resume()
+            }
+
+            #expect(storage.getDictionary(forKey: .capturePerformance) == nil)
+
+            _ = token
+        }
+
+        @Test("flags reload with no cached capture performance does not re-arm it")
+        func flagsReloadWithoutCachedCapturePerformanceDoesNotReArm() async {
+            let config = makeIsolatedConfig()
+
+            let storage = PostHogStorage(config)
+            defer { storage.reset() }
+
+            let sut = getSut(storage: storage, config: config)
+            #expect(storage.getDictionary(forKey: .capturePerformance) == nil)
+
+            await withCheckedContinuation { continuation in
+                sut.loadFeatureFlags(distinctId: "distinctId", anonymousId: "anonymousId", groups: ["group": "value"], callback: { _ in
+                    continuation.resume()
+                })
+            }
+
+            #expect(storage.getDictionary(forKey: .capturePerformance) == nil)
         }
     }
 }

--- a/PostHogTests/PostHogRemoteConfigTest.swift
+++ b/PostHogTests/PostHogRemoteConfigTest.swift
@@ -938,6 +938,39 @@ enum PostHogRemoteConfigTest {
             _ = token
         }
 
+        @Test("error tracking re-arms from cached config after reset")
+        func errorTrackingReArmsFromCachedConfigAfterReset() async {
+            let config = makeIsolatedConfig()
+            server.remoteConfigErrorTracking = ["autocaptureExceptions": true]
+
+            let storage = PostHogStorage(config)
+            defer { storage.reset() }
+
+            let sut = getSut(storage: storage, config: config)
+
+            // /config (the only source of error-tracking config) enables autocapture and persists
+            // it under .errorTracking.
+            await withCheckedContinuation { continuation in
+                sut.reloadRemoteConfig { _ in continuation.resume() }
+            }
+            #expect(sut.isAutocaptureExceptionsEnabled() == true)
+
+            // Mimic reset(): storage.reset() wipes the cached remote config but KEEPS the persisted
+            // .errorTracking slice (project-level, not user data); clear() zeroes the in-memory flag.
+            storage.reset()
+            sut.clear()
+            #expect(sut.isAutocaptureExceptionsEnabled() == false)
+
+            // The post-reset /flags reload carries no errorTracking and the cached remote config is
+            // gone, so autocapture must re-arm from the persisted .errorTracking slice.
+            await withCheckedContinuation { continuation in
+                sut.loadFeatureFlags(distinctId: "distinctId", anonymousId: "anonymousId", groups: ["group": "value"], callback: { _ in
+                    continuation.resume()
+                })
+            }
+            #expect(sut.isAutocaptureExceptionsEnabled() == true)
+        }
+
         @Test("disables autocapture exceptions from remote config dict")
         func disablesAutocaptureExceptionsFromRemoteConfigDict() async {
             let config = makeIsolatedConfig(disableRemoteConfigForTesting: false)

--- a/PostHogTests/PostHogRemoteConfigTest.swift
+++ b/PostHogTests/PostHogRemoteConfigTest.swift
@@ -778,24 +778,25 @@ enum PostHogRemoteConfigTest {
                 let sut = getSut(storage: storage)
 
                 // /config (the only source of recording config) populates the in-memory
-                // recording state and caches it in lastSessionRecordingConfig.
+                // recording state and persists it to storage under .sessionReplay.
                 await withCheckedContinuation { continuation in
                     sut.reloadRemoteConfig { _ in continuation.resume() }
                 }
                 #expect(sut.isSessionReplayFlagActive() == true)
                 #expect(sut.getRecordingSampleRate() == 0.42)
 
-                // Mimic reset(): storage.reset() wipes the persisted remote config + session replay,
-                // clear() drops the in-memory remote config. lastSessionRecordingConfig is intentionally
-                // retained so the following /flags reload can re-evaluate replay.
+                // Mimic reset(): storage.reset() wipes the persisted remote config but KEEPS the
+                // persisted .sessionReplay config (project-level, not user data); clear() drops the
+                // in-memory remote config and resets the replay flags. The persisted .sessionReplay
+                // is retained so the following /flags reload can re-evaluate replay.
                 storage.reset()
                 sut.clear()
                 #expect(sut.isSessionReplayFlagActive() == false)
                 #expect(sut.getRecordingSampleRate() == nil)
 
                 // The post-reset /flags reload carries no sessionRecording and the cached remote config
-                // is gone, so replay must re-arm from lastSessionRecordingConfig (the else branch),
-                // without waiting for an app restart.
+                // is gone, so replay must re-arm from the persisted .sessionReplay config (the else
+                // branch), without waiting for an app restart.
                 await withCheckedContinuation { continuation in
                     sut.loadFeatureFlags(distinctId: "distinctId", anonymousId: "anonymousId", groups: ["group": "value"], callback: { _ in
                         continuation.resume()
@@ -804,6 +805,41 @@ enum PostHogRemoteConfigTest {
 
                 #expect(sut.isSessionReplayFlagActive() == true)
                 #expect(sut.getRecordingSampleRate() == 0.42)
+            }
+
+            @Test("replay stays off after reset when the new user does not match the linked flag")
+            func sessionReplayStaysOffAfterResetWhenLinkedFlagMissing() async {
+                let storage = PostHogStorage(config)
+                defer { storage.reset() }
+
+                // Recording is gated on a linked flag the post-reset user won't have:
+                // /config advertises linkedFlag, /flags omits it.
+                server.returnReplay = true
+                server.returnReplayWithVariant = true
+                server.replayVariantName = "some-missing-flag"
+                server.flagsSkipReplayVariantName = true
+
+                let sut = getSut(storage: storage)
+
+                // /config caches the recording config (with linkedFlag) under .sessionReplay.
+                await withCheckedContinuation { continuation in
+                    sut.reloadRemoteConfig { _ in continuation.resume() }
+                }
+                #expect(storage.getDictionary(forKey: .sessionReplay) != nil)
+
+                storage.reset()
+                sut.clear()
+
+                // The post-reset /flags reload hits the else branch and re-evaluates the cached
+                // config against the new user's flags. The linked flag is missing, so replay must
+                // stay off rather than blindly re-arming.
+                await withCheckedContinuation { continuation in
+                    sut.loadFeatureFlags(distinctId: "distinctId", anonymousId: "anonymousId", groups: ["group": "value"], callback: { _ in
+                        continuation.resume()
+                    })
+                }
+
+                #expect(sut.isSessionReplayFlagActive() == false)
             }
         }
     #endif

--- a/PostHogTests/PostHogRemoteConfigTest.swift
+++ b/PostHogTests/PostHogRemoteConfigTest.swift
@@ -475,6 +475,20 @@ enum PostHogRemoteConfigTest {
                 #expect(sut.isSessionReplayFlagActive() == false)
             }
 
+            @Test("session replay config survives reset (project-level config)")
+            func sessionReplayConfigSurvivesReset() {
+                let storage = PostHogStorage(config)
+                defer { storage.reset() }
+
+                storage.setDictionary(forKey: .sessionReplay, contents: ["endpoint": "/s/"])
+
+                // reset() clears user-scoped state but must keep the project-level recording config,
+                // so replay can re-arm after an in-session identity change without an app restart.
+                storage.reset()
+
+                #expect(storage.getDictionary(forKey: .sessionReplay) != nil)
+            }
+
             @Test("returns isSessionReplayFlagActive false if feature flag disabled")
             func returnIsSessionReplayFlagActiveFalseIfFeatureFlagDisabled() async {
                 let storage = PostHogStorage(config)

--- a/PostHogTests/PostHogRemoteConfigTest.swift
+++ b/PostHogTests/PostHogRemoteConfigTest.swift
@@ -59,19 +59,16 @@ enum PostHogRemoteConfigTest {
             #expect(sut.getRemoteConfig() as? [String: String] == ["foo": "bar"])
         }
 
-        @Test("error tracking config survives reset (project-level config)")
-        func errorTrackingConfigSurvivesReset() {
+        @Test("remote config survives reset (project-level config)")
+        func remoteConfigSurvivesReset() {
             let storage = PostHogStorage(config)
             defer { storage.reset() }
 
-            storage.setDictionary(forKey: .errorTracking, contents: ["autocaptureExceptions": true])
+            storage.setDictionary(forKey: .remoteConfig, contents: ["errorTracking": ["autocaptureExceptions": true]])
 
-            // reset() clears user-scoped state but must keep the project-level error-tracking config
-            // (like .sessionReplay), so autocapture can re-arm after an in-session identity change
-            // without an app restart.
             storage.reset()
 
-            #expect(storage.getDictionary(forKey: .errorTracking) != nil)
+            #expect(storage.getDictionary(forKey: .remoteConfig) != nil)
         }
 
         @Test("remote config fetches feature flags if missing")
@@ -937,7 +934,7 @@ enum PostHogRemoteConfigTest {
             let storage = PostHogStorage(config)
             defer { storage.reset() }
 
-            storage.setDictionary(forKey: .errorTracking, contents: ["autocaptureExceptions": true])
+            storage.setDictionary(forKey: .remoteConfig, contents: ["errorTracking": ["autocaptureExceptions": true]])
 
             let sut = getSut(storage: storage, config: config)
 
@@ -950,7 +947,7 @@ enum PostHogRemoteConfigTest {
             let storage = PostHogStorage(config)
             defer { storage.reset() }
 
-            storage.setDictionary(forKey: .errorTracking, contents: ["autocaptureExceptions": false])
+            storage.setDictionary(forKey: .remoteConfig, contents: ["errorTracking": ["autocaptureExceptions": false]])
 
             let sut = getSut(storage: storage, config: config)
 
@@ -982,7 +979,7 @@ enum PostHogRemoteConfigTest {
             }
 
             #expect(sut.isAutocaptureExceptionsEnabled() == true)
-            #expect(storage.getDictionary(forKey: .errorTracking) != nil)
+            #expect(storage.getDictionary(forKey: .remoteConfig) != nil)
 
             _ = token
         }
@@ -1060,8 +1057,8 @@ enum PostHogRemoteConfigTest {
             let storage = PostHogStorage(config)
             defer { storage.reset() }
 
-            // Pre-cache an enabled config to verify it gets cleared
-            storage.setDictionary(forKey: .errorTracking, contents: ["autocaptureExceptions": true])
+            // Pre-cache an enabled config to verify it gets disabled
+            storage.setDictionary(forKey: .remoteConfig, contents: ["errorTracking": ["autocaptureExceptions": true]])
 
             let sut = getSut(storage: storage, config: config)
 
@@ -1080,7 +1077,6 @@ enum PostHogRemoteConfigTest {
             }
 
             #expect(sut.isAutocaptureExceptionsEnabled() == false)
-            #expect(storage.getDictionary(forKey: .errorTracking) == nil)
 
             _ = token
         }
@@ -1171,11 +1167,9 @@ enum PostHogRemoteConfigTest {
             return config
         }
 
-        @Test("capture performance config survives reset and re-arms on a flags reload")
-        func capturePerformanceReArmsAfterReset() async {
+        @Test("capture performance stays in the cached remote config across reset")
+        func capturePerformanceSurvivesReset() async {
             let config = makeIsolatedConfig()
-            server.remoteConfigCapturePerformance = ["network_timing": true]
-
             let storage = PostHogStorage(config)
             defer { storage.reset() }
 
@@ -1184,100 +1178,13 @@ enum PostHogRemoteConfigTest {
             await withCheckedContinuation { continuation in
                 sut.reloadRemoteConfig { _ in continuation.resume() }
             }
-            #expect(storage.getDictionary(forKey: .capturePerformance) != nil)
-
-            storage.reset()
-            sut.clear()
-            #expect(storage.getDictionary(forKey: .capturePerformance) != nil)
-
-            await withCheckedContinuation { continuation in
-                sut.loadFeatureFlags(distinctId: "distinctId", anonymousId: "anonymousId", groups: ["group": "value"], callback: { _ in
-                    continuation.resume()
-                })
-            }
-
-            #expect(storage.getDictionary(forKey: .capturePerformance) != nil)
-            #if os(iOS)
-                #expect(sut.getReplayPluginRemoteConfig()?["capturePerformance"] != nil)
-            #endif
-        }
-
-        @Test("capture performance config re-arms on a quota-limited flags reload")
-        func capturePerformanceReArmsOnQuotaLimitedFlagsReload() async {
-            let config = makeIsolatedConfig()
-            server.remoteConfigCapturePerformance = ["network_timing": true]
-
-            let storage = PostHogStorage(config)
-            defer { storage.reset() }
-
-            let sut = getSut(storage: storage, config: config)
-
-            await withCheckedContinuation { continuation in
-                sut.reloadRemoteConfig { _ in continuation.resume() }
-            }
-            #expect(storage.getDictionary(forKey: .capturePerformance) != nil)
+            #expect(sut.getRemoteConfig()?["capturePerformance"] != nil)
 
             storage.reset()
             sut.clear()
 
-            server.quotaLimitFeatureFlags = true
-            await withCheckedContinuation { continuation in
-                sut.loadFeatureFlags(distinctId: "distinctId", anonymousId: "anonymousId", groups: ["group": "value"], callback: { _ in
-                    continuation.resume()
-                })
-            }
-
-            #expect(storage.getDictionary(forKey: .capturePerformance) != nil)
-        }
-
-        @Test("evicts cached capture performance config when capturePerformance is boolean false")
-        func evictsCapturePerformanceWhenBooleanFalse() async {
-            let config = makeIsolatedConfig(disableRemoteConfigForTesting: false)
-            config.preloadFeatureFlags = false
-            config.storageManager = PostHogStorageManager(config)
-
-            server.remoteConfigCapturePerformance = false
-
-            let storage = PostHogStorage(config)
-            defer { storage.reset() }
-
-            storage.setDictionary(forKey: .capturePerformance, contents: ["network_timing": true])
-
-            let sut = getSut(storage: storage, config: config)
-
-            var remoteConfigLoaded = false
-            let token = sut.onRemoteConfigLoaded.subscribe { _ in
-                remoteConfigLoaded = true
-            }
-
-            await withCheckedContinuation { continuation in
-                let timeout = Date().addingTimeInterval(2)
-                while !remoteConfigLoaded, Date() < timeout {}
-                continuation.resume()
-            }
-
-            #expect(storage.getDictionary(forKey: .capturePerformance) == nil)
-
-            _ = token
-        }
-
-        @Test("flags reload with no cached capture performance does not re-arm it")
-        func flagsReloadWithoutCachedCapturePerformanceDoesNotReArm() async {
-            let config = makeIsolatedConfig()
-
-            let storage = PostHogStorage(config)
-            defer { storage.reset() }
-
-            let sut = getSut(storage: storage, config: config)
-            #expect(storage.getDictionary(forKey: .capturePerformance) == nil)
-
-            await withCheckedContinuation { continuation in
-                sut.loadFeatureFlags(distinctId: "distinctId", anonymousId: "anonymousId", groups: ["group": "value"], callback: { _ in
-                    continuation.resume()
-                })
-            }
-
-            #expect(storage.getDictionary(forKey: .capturePerformance) == nil)
+            #expect(storage.getDictionary(forKey: .remoteConfig) != nil)
+            #expect(sut.getRemoteConfig()?["capturePerformance"] != nil)
         }
     }
 }

--- a/PostHogTests/PostHogRemoteConfigTest.swift
+++ b/PostHogTests/PostHogRemoteConfigTest.swift
@@ -59,6 +59,21 @@ enum PostHogRemoteConfigTest {
             #expect(sut.getRemoteConfig() as? [String: String] == ["foo": "bar"])
         }
 
+        @Test("error tracking config survives reset (project-level config)")
+        func errorTrackingConfigSurvivesReset() {
+            let storage = PostHogStorage(config)
+            defer { storage.reset() }
+
+            storage.setDictionary(forKey: .errorTracking, contents: ["autocaptureExceptions": true])
+
+            // reset() clears user-scoped state but must keep the project-level error-tracking config
+            // (like .sessionReplay), so autocapture can re-arm after an in-session identity change
+            // without an app restart.
+            storage.reset()
+
+            #expect(storage.getDictionary(forKey: .errorTracking) != nil)
+        }
+
         @Test("remote config fetches feature flags if missing")
         func remoteConfigLoadsFeatureFlagsIfNotPreviouslyLoaded() async {
             let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")

--- a/PostHogTests/PostHogRemoteConfigTest.swift
+++ b/PostHogTests/PostHogRemoteConfigTest.swift
@@ -752,6 +752,45 @@ enum PostHogRemoteConfigTest {
                 #expect(sut.isSessionReplayFlagActive() == true)
                 #expect(callbackInvoked == false)
             }
+
+            @Test("session replay re-arms from cached config after reset")
+            func sessionReplayReArmsFromCachedConfigAfterReset() async {
+                let storage = PostHogStorage(config)
+                defer { storage.reset() }
+
+                server.returnReplay = true
+                server.sessionRecordingSampleRate = "0.42"
+
+                let sut = getSut(storage: storage)
+
+                // /config (the only source of recording config) populates the in-memory
+                // recording state and caches it in lastSessionRecordingConfig.
+                await withCheckedContinuation { continuation in
+                    sut.reloadRemoteConfig { _ in continuation.resume() }
+                }
+                #expect(sut.isSessionReplayFlagActive() == true)
+                #expect(sut.getRecordingSampleRate() == 0.42)
+
+                // Mimic reset(): storage.reset() wipes the persisted remote config + session replay,
+                // clear() drops the in-memory remote config. lastSessionRecordingConfig is intentionally
+                // retained so the following /flags reload can re-evaluate replay.
+                storage.reset()
+                sut.clear()
+                #expect(sut.isSessionReplayFlagActive() == false)
+                #expect(sut.getRecordingSampleRate() == nil)
+
+                // The post-reset /flags reload carries no sessionRecording and the cached remote config
+                // is gone, so replay must re-arm from lastSessionRecordingConfig (the else branch),
+                // without waiting for an app restart.
+                await withCheckedContinuation { continuation in
+                    sut.loadFeatureFlags(distinctId: "distinctId", anonymousId: "anonymousId", groups: ["group": "value"], callback: { _ in
+                        continuation.resume()
+                    })
+                }
+
+                #expect(sut.isSessionReplayFlagActive() == true)
+                #expect(sut.getRecordingSampleRate() == 0.42)
+            }
         }
     #endif
 

--- a/PostHogTests/TestUtils/MockPostHogServer.swift
+++ b/PostHogTests/TestUtils/MockPostHogServer.swift
@@ -91,10 +91,6 @@ class MockPostHogServer {
     var sessionRecordingSampleRate: String?
     var sessionRecordingEventTriggers: [String]?
     var remoteConfigErrorTracking: Any? = ["autocaptureExceptions": true]
-    // Mirrors `remoteConfigErrorTracking`: a `[String: Any]` is emitted as a `capturePerformance`
-    // object, a `Bool` as a literal, and `nil` omits the key. Defaults to the value /config has
-    // always returned so existing tests are unaffected.
-    var remoteConfigCapturePerformance: Any? = ["network_timing": true, "web_vitals": true, "web_vitals_allowed_metrics": NSNull()]
 
     // version is the version of the response we want to return regardless of the request version
     init(version: Int = 3) {
@@ -383,17 +379,6 @@ class MockPostHogServer {
                 }
             }()
 
-            let capturePerformancePayload: String = {
-                if let dict = self.remoteConfigCapturePerformance as? [String: Any] {
-                    let jsonData = try? JSONSerialization.data(withJSONObject: dict)
-                    return "\"capturePerformance\": \(String(data: jsonData ?? Data(), encoding: .utf8) ?? "false"),"
-                } else if let boolVal = self.remoteConfigCapturePerformance as? Bool {
-                    return "\"capturePerformance\": \(boolVal),"
-                } else {
-                    return ""
-                }
-            }()
-
             // Build sessionRecording payload
             let sessionRecordingPayload: String = {
                 if self.returnReplay {
@@ -424,7 +409,11 @@ class MockPostHogServer {
                     ],
                     \(hasFeatureFlagsPayload)
                     "captureDeadClicks": true,
-                    \(capturePerformancePayload)
+                    "capturePerformance": {
+                        "network_timing": true,
+                        "web_vitals": true,
+                        "web_vitals_allowed_metrics": null
+                    },
                     "autocapture_opt_out": false,
                     \(errorTrackingPayload)
                     "analytics": {

--- a/PostHogTests/TestUtils/MockPostHogServer.swift
+++ b/PostHogTests/TestUtils/MockPostHogServer.swift
@@ -91,6 +91,10 @@ class MockPostHogServer {
     var sessionRecordingSampleRate: String?
     var sessionRecordingEventTriggers: [String]?
     var remoteConfigErrorTracking: Any? = ["autocaptureExceptions": true]
+    // Mirrors `remoteConfigErrorTracking`: a `[String: Any]` is emitted as a `capturePerformance`
+    // object, a `Bool` as a literal, and `nil` omits the key. Defaults to the value /config has
+    // always returned so existing tests are unaffected.
+    var remoteConfigCapturePerformance: Any? = ["network_timing": true, "web_vitals": true, "web_vitals_allowed_metrics": NSNull()]
 
     // version is the version of the response we want to return regardless of the request version
     init(version: Int = 3) {
@@ -379,6 +383,17 @@ class MockPostHogServer {
                 }
             }()
 
+            let capturePerformancePayload: String = {
+                if let dict = self.remoteConfigCapturePerformance as? [String: Any] {
+                    let jsonData = try? JSONSerialization.data(withJSONObject: dict)
+                    return "\"capturePerformance\": \(String(data: jsonData ?? Data(), encoding: .utf8) ?? "false"),"
+                } else if let boolVal = self.remoteConfigCapturePerformance as? Bool {
+                    return "\"capturePerformance\": \(boolVal),"
+                } else {
+                    return ""
+                }
+            }()
+
             // Build sessionRecording payload
             let sessionRecordingPayload: String = {
                 if self.returnReplay {
@@ -409,11 +424,7 @@ class MockPostHogServer {
                     ],
                     \(hasFeatureFlagsPayload)
                     "captureDeadClicks": true,
-                    "capturePerformance": {
-                        "network_timing": true,
-                        "web_vitals": true,
-                        "web_vitals_allowed_metrics": null
-                    },
+                    \(capturePerformancePayload)
                     "autocapture_opt_out": false,
                     \(errorTrackingPayload)
                     "analytics": {


### PR DESCRIPTION
## :bulb: Motivation and Context

https://posthoghelp.zendesk.com/agent/tickets/58925 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/61593)

After an in-session `identify()` / `reset()`, session replay stopped recording and only resumed after an app restart.

The session recording config comes only from `/config`, fetched once at startup. `reset()` cleared the cached config, so the `/flags` reload that follows had nothing to re-evaluate from and replay stayed off until the next startup.

Error tracking had the identical bug (disabled after `identify()`/`reset()` until restart), so this PR fixes it the same way — bringing iOS to parity with posthog-android #547, which keeps session replay, error tracking and capture-performance config across `reset()`.

## :green_heart: How did you test it?

Verified on the iOS simulator: `isSessionReplayActive` goes `false → true` after `reset()` → `identify()` → reload, without an app restart. The config is project-level, so keeping it in memory across an identity change doesn't change behavior for disabled projects (cleared on an explicit `false`) or linked-flag projects (re-evaluated against the new user's flags). Storage-survives-reset is covered by tests for both `.sessionReplay` and `.errorTracking`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
