### PR TITLE
refactor(compliance): replace 2s flush-sleep 

### DIFF
--- a/sdk_compliance_adapter/Sources/RequestInterceptor.swift
+++ b/sdk_compliance_adapter/Sources/RequestInterceptor.swift
@@ -29,6 +29,75 @@ class RequestInterceptor: URLProtocol {
     static var trackedRequests: [TrackedRequest] = []
     static var totalEventsSent: Int = 0
 
+    private static let condition = NSCondition()
+    private static var _inFlightCount = 0
+
+    static var inFlightCount: Int {
+        condition.lock()
+        defer { condition.unlock() }
+        return _inFlightCount
+    }
+
+    private static func incrementInFlight() {
+        condition.lock()
+        _inFlightCount += 1
+        condition.broadcast()
+        condition.unlock()
+    }
+
+    private static func decrementInFlight() {
+        condition.lock()
+        _inFlightCount = max(0, _inFlightCount - 1)
+        condition.broadcast()
+        condition.unlock()
+    }
+
+    /// Returns once the in-flight count has been 0 for `stabilityWindow` after seeing at least
+    /// one request, or after `gracePeriod` if nothing flew. Times out after `timeout`.
+    static func waitForFlushSettle(
+        timeout: TimeInterval = 30.0,
+        gracePeriod: TimeInterval = 0.1,
+        stabilityWindow: TimeInterval = 2.5
+    ) async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global().async {
+                let absoluteDeadline = Date().addingTimeInterval(timeout)
+                var sawRequest = false
+                var idleSince: Date?
+
+                condition.lock()
+                defer { condition.unlock() }
+
+                while Date() < absoluteDeadline {
+                    if _inFlightCount > 0 {
+                        sawRequest = true
+                        idleSince = nil
+                    } else if idleSince == nil {
+                        idleSince = Date()
+                    }
+
+                    let wakeBy: Date = {
+                        guard let since = idleSince else { return absoluteDeadline }
+                        let window = sawRequest ? stabilityWindow : gracePeriod
+                        return min(since.addingTimeInterval(window), absoluteDeadline)
+                    }()
+
+                    if Date() >= wakeBy {
+                        if _inFlightCount == 0 {
+                            continuation.resume()
+                            return
+                        }
+                        continue
+                    }
+
+                    condition.wait(until: wakeBy)
+                }
+                print("[INTERCEPTOR] waitForFlushSettle timed out after \(timeout)s with \(_inFlightCount) in flight")
+                continuation.resume()
+            }
+        }
+    }
+
     override class func canInit(with request: URLRequest) -> Bool {
         // Only intercept requests to the mock server (not to real PostHog endpoints)
         guard let url = request.url else { return false }
@@ -61,6 +130,7 @@ class RequestInterceptor: URLProtocol {
         // IMPORTANT: Use .default to avoid recursion (our custom config is only for PostHog SDK)
         let session = URLSession(configuration: .default)
         let task = session.dataTask(with: request) { [weak self] data, response, error in
+            Self.decrementInFlight()
             print("[INTERCEPTOR] Task completed for: \(request.url?.absoluteString ?? "nil"), error: \(error?.localizedDescription ?? "none")")
             guard let self = self else { return }
 
@@ -84,6 +154,7 @@ class RequestInterceptor: URLProtocol {
             self.client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
             self.client?.urlProtocolDidFinishLoading(self)
         }
+        Self.incrementInFlight()
         task.resume()
     }
 
@@ -170,6 +241,10 @@ class RequestInterceptor: URLProtocol {
     static func reset() {
         trackedRequests = []
         totalEventsSent = 0
+        condition.lock()
+        _inFlightCount = 0
+        condition.broadcast()
+        condition.unlock()
         print("[INTERCEPTOR] Reset state")
     }
 }

--- a/sdk_compliance_adapter/Sources/RequestInterceptor.swift
+++ b/sdk_compliance_adapter/Sources/RequestInterceptor.swift
@@ -130,7 +130,10 @@ class RequestInterceptor: URLProtocol {
         // IMPORTANT: Use .default to avoid recursion (our custom config is only for PostHog SDK)
         let session = URLSession(configuration: .default)
         let task = session.dataTask(with: request) { [weak self] data, response, error in
-            Self.decrementInFlight()
+            // Decrement only after every URLProtocol client callback has fired, so the SDK
+            // has fully processed the response (including any sync retry/queue hand-off)
+            // before waitForFlushSettle can see in-flight = 0.
+            defer { Self.decrementInFlight() }
             print("[INTERCEPTOR] Task completed for: \(request.url?.absoluteString ?? "nil"), error: \(error?.localizedDescription ?? "none")")
             guard let self = self else { return }
 

--- a/sdk_compliance_adapter/Sources/main.swift
+++ b/sdk_compliance_adapter/Sources/main.swift
@@ -12,11 +12,6 @@ let adapterStorageHome = (NSTemporaryDirectory() as NSString).appendingPathCompo
 setenv("CFFIXED_USER_HOME", adapterStorageHome, 1)
 setenv("HOME", adapterStorageHome, 1)
 
-// How long to wait after sdk.flush() for the SDK's async upload to land before returning.
-// Shared by /flush and get_feature_flag so an event flushed in one test can't spill into the
-// next test's mock window (the side-effect timing failure). Based on browser-SDK experience.
-let flushSettleNanoseconds: UInt64 = 2_000_000_000 // 2 seconds
-
 // Global state for the adapter
 class AdapterState {
     var posthogSDK: PostHogSDK?
@@ -259,9 +254,8 @@ app.post("get_feature_flag") { req async throws -> Response in
     // Flush that $feature_flag_called event now and wait for it to land. With flushAt=1
     // it would otherwise auto-flush asynchronously and could arrive in the *next* test's
     // mock window, inflating $feature_flag_called counts (the side_effect test failure).
-    // Uses the same settle window as /flush so the wait can't be the weak link.
     sdk.flush()
-    try await Task.sleep(nanoseconds: flushSettleNanoseconds)
+    await RequestInterceptor.waitForFlushSettle()
 
     var result: [String: Any] = ["success": true]
     result["value"] = value ?? NSNull()
@@ -277,12 +271,8 @@ app.post("flush") { req async throws -> Response in
         throw Abort(.badRequest, reason: "SDK not initialized. Call /init first.")
     }
 
-    // Flush the SDK
     sdk.flush()
-
-    // CRITICAL: Wait for the flush to complete. The SDK uses async network requests, so
-    // we need to wait for them to finish before returning.
-    try await Task.sleep(nanoseconds: flushSettleNanoseconds)
+    await RequestInterceptor.waitForFlushSettle()
 
     print("[ADAPTER] Flush complete, waited for network requests")
 


### PR DESCRIPTION
Drops the blanket 2s Task.sleep in /flush and get_feature_flag in favor of RequestInterceptor.waitForFlushSettle(): polls the in-flight URLProtocol count and returns once it's been 0 for a 2.5s stability window (after at least one request) or after a 100ms grace period if nothing flew. Catches async retries that would otherwise restart the idle timer.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
