### PR TITLE
chore: update Sentry license attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -22,10 +22,10 @@ SOFTWARE.
 
 ---
 
-Some files in this codebase contain code from getsentry/sentry-cocoa by Sentry.
+Some files in this codebase contain code from getsentry/sentry-cocoa.
 In such cases it is explicitly stated in the file header. This license only applies to the relevant code in such cases.
 
-MIT License
+The MIT License (MIT)
 
 Copyright (c) 2015 Sentry
 

--- a/PostHog/Replay/PostHogGraphicsImageRenderer.swift
+++ b/PostHog/Replay/PostHogGraphicsImageRenderer.swift
@@ -1,5 +1,6 @@
-// Portions of this file are derived from getsentry/sentry-cocoa by Sentry
-// Licensed under the MIT License
+// Portions of this file are derived from getsentry/sentry-cocoa
+// Copyright (c) 2015 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-cocoa/blob/main/LICENSE.md
 
 #if os(iOS)
 


### PR DESCRIPTION
## :bulb: Motivation and Context
Clarify the Sentry license attribution for code derived from getsentry/sentry-cocoa.

Changes:
- Updated the Sentry attribution language in `LICENSE`.
- Added explicit copyright and source license URL details to `PostHogGraphicsImageRenderer.swift`.

## :green_heart: How did you test it?
Not run (license/comment-only change).

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
