### PR TITLE
feat(identity): bootstrap anonymousId via config and runtime setter

### DIFF
--- a/PostHog/PostHogBootstrap.swift
+++ b/PostHog/PostHogBootstrap.swift
@@ -1,0 +1,45 @@
+//
+//  PostHogBootstrap.swift
+//  PostHog
+//
+
+import Foundation
+
+/// Pre-seeded values applied on the very first SDK launch when no per-device state has
+/// been persisted yet.
+///
+/// Set ``PostHogConfig/bootstrap`` before calling `setup(_:)` to ensure events captured
+/// synchronously during initialization (`Application Installed` / `Application Updated`,
+/// pre-identify lifecycle events) carry a caller-controlled `$distinct_id` rather than
+/// the SDK-generated UUID. Mirrors the [`bootstrap` option in `posthog-js`](https://posthog.com/docs/feature-flags/bootstrapping).
+///
+/// Bootstrap only seeds the very first session. Once an anonymous ID is persisted on
+/// disk, or `identify(...)` has been called, the bootstrap values are ignored — they
+/// never override an already-identified user or re-link traffic across a previous
+/// anon→identified merge.
+@objc(PostHogBootstrap) public class PostHogBootstrap: NSObject {
+    /// The distinct ID to seed on first launch.
+    ///
+    /// When ``isIdentifiedID`` is `false` (the default), this becomes the anonymous ID —
+    /// the `$distinct_id` on pre-identify events. When `true`, it is treated as an
+    /// already-identified user's distinct ID and the SDK skips the `$identify` merge
+    /// for it.
+    @objc public var distinctID: String?
+
+    /// Whether ``distinctID`` represents an already-identified user.
+    ///
+    /// Defaults to `false`. Set to `true` when the host application has resolved the
+    /// user's identity outside the SDK (for example from a backend session token) and
+    /// wants the iOS SDK to treat them as identified from the first event onward.
+    @objc public var isIdentifiedID: Bool = false
+
+    @objc public override init() {
+        super.init()
+    }
+
+    @objc public init(distinctID: String?, isIdentifiedID: Bool = false) {
+        self.distinctID = distinctID
+        self.isIdentifiedID = isIdentifiedID
+        super.init()
+    }
+}

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -187,6 +187,16 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
     /// - Returns: The UUID to persist as the anonymous ID.
     @objc public var getAnonymousId: ((UUID) -> UUID) = { uuid in uuid }
 
+    /// Pre-seeded anonymous ID used on the first call to `getAnonymousId()` when no
+    /// persisted value exists.
+    ///
+    /// Set this before `setup()` to ensure events captured synchronously during initialization
+    /// (such as `Application Installed` / `Application Updated`) use your own ID rather than
+    /// the SDK's auto-generated UUID. Ignored when an anonymous ID is already persisted.
+    ///
+    /// Defaults to `nil` (use the SDK-generated UUID).
+    @objc public var anonymousId: String?
+
     /// Flag to reuse the anonymous Id between `reset()` and next `identify()` calls
     ///
     /// If enabled, the anonymous Id will be reused for all anonymous users on this device,

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -187,15 +187,21 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
     /// - Returns: The UUID to persist as the anonymous ID.
     @objc public var getAnonymousId: ((UUID) -> UUID) = { uuid in uuid }
 
-    /// Pre-seeded anonymous ID used on the first call to `getAnonymousId()` when no
-    /// persisted value exists.
+    /// Pre-seeded identity applied on the very first SDK launch when no per-device state
+    /// has been persisted yet.
     ///
-    /// Set this before `setup()` to ensure events captured synchronously during initialization
-    /// (such as `Application Installed` / `Application Updated`) use your own ID rather than
-    /// the SDK's auto-generated UUID. Ignored when an anonymous ID is already persisted.
+    /// Set this before calling `setup(_:)` to ensure events captured synchronously during
+    /// initialization (`Application Installed` / `Application Updated`, pre-identify
+    /// lifecycle events) carry a caller-controlled `$distinct_id` rather than the
+    /// SDK-generated UUID. Mirrors the [`bootstrap` option in `posthog-js`](https://posthog.com/docs/feature-flags/bootstrapping).
+    ///
+    /// Bootstrap only seeds the very first session. Once an anonymous ID is persisted
+    /// on disk, or `identify(...)` has been called, the bootstrap values are ignored —
+    /// they never override an already-identified user or re-link traffic across a
+    /// previous anon→identified merge.
     ///
     /// Defaults to `nil` (use the SDK-generated UUID).
-    @objc public var anonymousId: String?
+    @objc public var bootstrap: PostHogBootstrap?
 
     /// Flag to reuse the anonymous Id between `reset()` and next `identify()` calls
     ///

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -241,6 +241,20 @@ let maxRetryDelay = 30.0
         getStorageManagerValue { $0.getAnonymousId() }
     }
 
+    /// Overrides the persisted anonymous ID at runtime.
+    ///
+    /// Useful after `reset()` to seed the next anonymous session with a caller-controlled ID
+    /// (mirroring `posthog-js`'s `posthog.reset({ bootstrap: { distinctID } })`). No-op when
+    /// the SDK is not set up or when `anonymousId` is empty.
+    ///
+    /// - Parameter anonymousId: The anonymous ID to persist.
+    @objc public func setAnonymousId(_ anonymousId: String) {
+        guard isEnabled(), !anonymousId.isEmpty, let storageManager = config.storageManager else {
+            return
+        }
+        storageManager.setAnonymousId(anonymousId)
+    }
+
     /// Returns the stable device identifier used for device-level feature flag bucketing.
     ///
     /// This ID persists across `identify()` and `reset()` calls, only changing on a fresh

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -241,20 +241,6 @@ let maxRetryDelay = 30.0
         getStorageManagerValue { $0.getAnonymousId() }
     }
 
-    /// Overrides the persisted anonymous ID at runtime.
-    ///
-    /// Useful after `reset()` to seed the next anonymous session with a caller-controlled ID
-    /// (mirroring `posthog-js`'s `posthog.reset({ bootstrap: { distinctID } })`). No-op when
-    /// the SDK is not set up or when `anonymousId` is empty.
-    ///
-    /// - Parameter anonymousId: The anonymous ID to persist.
-    @objc public func setAnonymousId(_ anonymousId: String) {
-        guard isEnabled(), !anonymousId.isEmpty, let storageManager = config.storageManager else {
-            return
-        }
-        storageManager.setAnonymousId(anonymousId)
-    }
-
     /// Returns the stable device identifier used for device-level feature flag bucketing.
     ///
     /// This ID persists across `identify()` and `reset()` calls, only changing on a fresh

--- a/PostHog/PostHogStorageManager.swift
+++ b/PostHog/PostHogStorageManager.swift
@@ -21,7 +21,7 @@ public class PostHogStorageManager {
     private let identifiedLock = NSLock()
     private let personProcessingLock = NSLock()
     private let idGen: (UUID) -> UUID
-    private let bootstrapAnonymousId: String?
+    private let bootstrap: PostHogBootstrap?
 
     private var distinctId: String?
     private var cachedDistinctId = false
@@ -33,7 +33,33 @@ public class PostHogStorageManager {
     init(_ config: PostHogConfig) {
         storage = PostHogStorage(config)
         idGen = config.getAnonymousId
-        bootstrapAnonymousId = config.anonymousId
+        bootstrap = config.bootstrap
+        applyBootstrapIfNeeded()
+    }
+
+    /// Persists the bootstrap distinct ID exactly once, on the very first launch with no
+    /// per-device state. Skipped when the device already has an anonymous ID on disk,
+    /// when the user is already identified, or when the caller did not supply one.
+    ///
+    /// When `bootstrap.isIdentifiedID` is `true`, the value is treated as the
+    /// already-identified distinct ID — both `.anonymousId` and `.distinctId` are seeded
+    /// to the same value and `isIdentified` is set, so subsequent events are emitted on
+    /// the identified person without an `$identify` merge.
+    private func applyBootstrapIfNeeded() {
+        guard let bootstrap, let bootstrapId = bootstrap.distinctID, !bootstrapId.isEmpty else {
+            return
+        }
+        // Persisted state wins — never override an existing anonymous ID, and never
+        // re-link traffic across a previous anon→identified merge.
+        if storage.getString(forKey: .anonymousId) != nil { return }
+        if storage.getBool(forKey: .isIdentified) == true { return }
+
+        setAnonymousId(bootstrapId)
+
+        if bootstrap.isIdentifiedID {
+            setDistinctId(bootstrapId)
+            setIdentified(true)
+        }
     }
 
     /// Returns the persisted anonymous ID, creating one if needed.
@@ -45,12 +71,8 @@ public class PostHogStorageManager {
                 var anonymousId = storage.getString(forKey: .anonymousId)
 
                 if anonymousId == nil {
-                    if let bootstrap = bootstrapAnonymousId, !bootstrap.isEmpty {
-                        anonymousId = bootstrap
-                    } else {
-                        let uuid = UUID.v7()
-                        anonymousId = idGen(uuid).uuidString
-                    }
+                    let uuid = UUID.v7()
+                    anonymousId = idGen(uuid).uuidString
                     setAnonId(anonymousId ?? "")
                 } else {
                     // update the memory value

--- a/PostHog/PostHogStorageManager.swift
+++ b/PostHog/PostHogStorageManager.swift
@@ -21,6 +21,7 @@ public class PostHogStorageManager {
     private let identifiedLock = NSLock()
     private let personProcessingLock = NSLock()
     private let idGen: (UUID) -> UUID
+    private let bootstrapAnonymousId: String?
 
     private var distinctId: String?
     private var cachedDistinctId = false
@@ -32,6 +33,7 @@ public class PostHogStorageManager {
     init(_ config: PostHogConfig) {
         storage = PostHogStorage(config)
         idGen = config.getAnonymousId
+        bootstrapAnonymousId = config.anonymousId
     }
 
     /// Returns the persisted anonymous ID, creating one if needed.
@@ -43,8 +45,12 @@ public class PostHogStorageManager {
                 var anonymousId = storage.getString(forKey: .anonymousId)
 
                 if anonymousId == nil {
-                    let uuid = UUID.v7()
-                    anonymousId = idGen(uuid).uuidString
+                    if let bootstrap = bootstrapAnonymousId, !bootstrap.isEmpty {
+                        anonymousId = bootstrap
+                    } else {
+                        let uuid = UUID.v7()
+                        anonymousId = idGen(uuid).uuidString
+                    }
                     setAnonId(anonymousId ?? "")
                 } else {
                     // update the memory value

--- a/PostHogTests/PostHogStorageManagerTest.swift
+++ b/PostHogTests/PostHogStorageManagerTest.swift
@@ -59,9 +59,9 @@ class PostHogStorageManagerTest: QuickSpec {
             sut.reset(true)
         }
 
-        it("Uses bootstrap anonymousId from config on fresh install") {
+        it("Seeds the anonymous ID from bootstrap.distinctID on fresh install") {
             let config = PostHogConfig(projectToken: "test_project_token")
-            config.anonymousId = "A-bootstrap-id-123"
+            config.bootstrap = PostHogBootstrap(distinctID: "A-bootstrap-id-123")
             let sut = self.getSut(config)
 
             let anonymousId = sut.getAnonymousId()
@@ -69,13 +69,15 @@ class PostHogStorageManagerTest: QuickSpec {
 
             // Subsequent calls return the same persisted value.
             expect(sut.getAnonymousId()) == "A-bootstrap-id-123"
+            // Not flagged as identified — anonymous-only seed.
+            expect(sut.isIdentified()) == false
 
             sut.reset(true)
         }
 
-        it("Ignores empty bootstrap anonymousId and falls back to UUID") {
+        it("Ignores empty bootstrap.distinctID and falls back to UUID") {
             let config = PostHogConfig(projectToken: "test_project_token")
-            config.anonymousId = ""
+            config.bootstrap = PostHogBootstrap(distinctID: "")
             let sut = self.getSut(config)
 
             let anonymousId = sut.getAnonymousId()
@@ -86,18 +88,54 @@ class PostHogStorageManagerTest: QuickSpec {
             sut.reset(true)
         }
 
-        it("Uses bootstrap anonymousId after reset clears the persisted value") {
+        it("Seeds both anonymous and distinct IDs when bootstrap.isIdentifiedID is true") {
             let config = PostHogConfig(projectToken: "test_project_token")
-            config.anonymousId = "A-bootstrap-id-after-reset"
+            config.bootstrap = PostHogBootstrap(distinctID: "user-42", isIdentifiedID: true)
             let sut = self.getSut(config)
 
-            _ = sut.getAnonymousId()
-            sut.reset(false, true) // clear persisted + memory
-
-            // Next read should pick the bootstrap value again, not generate a UUID.
-            expect(sut.getAnonymousId()) == "A-bootstrap-id-after-reset"
+            expect(sut.getAnonymousId()) == "user-42"
+            expect(sut.getDistinctId()) == "user-42"
+            expect(sut.isIdentified()) == true
 
             sut.reset(true)
+        }
+
+        it("Does not re-apply bootstrap once an anonymous ID is persisted") {
+            let firstConfig = PostHogConfig(projectToken: "test_project_token")
+            firstConfig.bootstrap = PostHogBootstrap(distinctID: "A-original")
+            let firstSut = self.getSut(firstConfig)
+            _ = firstSut.getAnonymousId()
+
+            // Simulate a second SDK init in the same install: storage already has
+            // the original anonymous ID. The new config supplies a different
+            // bootstrap value, which must NOT override the persisted one.
+            let secondConfig = PostHogConfig(projectToken: "test_project_token")
+            secondConfig.bootstrap = PostHogBootstrap(distinctID: "A-different")
+            let secondSut = PostHogStorageManager(secondConfig)
+
+            expect(secondSut.getAnonymousId()) == "A-original"
+
+            firstSut.reset(true)
+        }
+
+        it("Does not re-apply bootstrap after the user has been identified") {
+            let firstConfig = PostHogConfig(projectToken: "test_project_token")
+            let firstSut = self.getSut(firstConfig)
+            firstSut.setIdentified(true)
+            firstSut.setDistinctId("identified-user")
+            let originalAnon = firstSut.getAnonymousId()
+
+            // A subsequent SDK init that supplies a bootstrap must not re-seed
+            // either the anonymous ID or the distinct ID — that would silently
+            // re-link traffic across the prior anon→identified merge.
+            let secondConfig = PostHogConfig(projectToken: "test_project_token")
+            secondConfig.bootstrap = PostHogBootstrap(distinctID: "A-new", isIdentifiedID: true)
+            let secondSut = PostHogStorageManager(secondConfig)
+
+            expect(secondSut.getAnonymousId()) == originalAnon
+            expect(secondSut.getDistinctId()) == "identified-user"
+
+            firstSut.reset(true)
         }
 
         it("Uses the correct fallback value for isIdentified") {

--- a/PostHogTests/PostHogStorageManagerTest.swift
+++ b/PostHogTests/PostHogStorageManagerTest.swift
@@ -59,6 +59,47 @@ class PostHogStorageManagerTest: QuickSpec {
             sut.reset(true)
         }
 
+        it("Uses bootstrap anonymousId from config on fresh install") {
+            let config = PostHogConfig(projectToken: "test_project_token")
+            config.anonymousId = "A-bootstrap-id-123"
+            let sut = self.getSut(config)
+
+            let anonymousId = sut.getAnonymousId()
+            expect(anonymousId) == "A-bootstrap-id-123"
+
+            // Subsequent calls return the same persisted value.
+            expect(sut.getAnonymousId()) == "A-bootstrap-id-123"
+
+            sut.reset(true)
+        }
+
+        it("Ignores empty bootstrap anonymousId and falls back to UUID") {
+            let config = PostHogConfig(projectToken: "test_project_token")
+            config.anonymousId = ""
+            let sut = self.getSut(config)
+
+            let anonymousId = sut.getAnonymousId()
+            expect(anonymousId.isEmpty) == false
+            // Should be a UUID, not an empty string.
+            expect(UUID(uuidString: anonymousId)) != nil
+
+            sut.reset(true)
+        }
+
+        it("Uses bootstrap anonymousId after reset clears the persisted value") {
+            let config = PostHogConfig(projectToken: "test_project_token")
+            config.anonymousId = "A-bootstrap-id-after-reset"
+            let sut = self.getSut(config)
+
+            _ = sut.getAnonymousId()
+            sut.reset(false, true) // clear persisted + memory
+
+            // Next read should pick the bootstrap value again, not generate a UUID.
+            expect(sut.getAnonymousId()) == "A-bootstrap-id-after-reset"
+
+            sut.reset(true)
+        }
+
         it("Uses the correct fallback value for isIdentified") {
             let anonymousIdToSet = UUID.v7()
             let distinctIdToSet = UUID.v7().uuidString


### PR DESCRIPTION
## Why

Closes #471 (and mirrors what \`posthog-js#862\` is asking for on the JS side).

Two real users on #471 hit the same wall: \`Application Installed\` and \`Application Updated\` are captured synchronously during \`setup()\`, before there's any chance to call \`identify()\` or to mutate \`PostHogStorageManager\` (which is public for backwards compatibility but not really intended for app code). Those lifecycle events end up tied to the SDK's auto-generated UUID instead of the caller's account ID.

## What

Two additive surfaces. Both honour empty-string as a no-op so a sentinel can't accidentally clobber the stored value.

**1. \`PostHogConfig.anonymousId: String?\`** — set before \`setup()\`. On the first call to \`getAnonymousId()\`, if nothing is persisted, the SDK uses this value instead of generating a UUID v7. Pre-existing \`PostHogConfig.getAnonymousId\` (UUID → UUID hook) is unaffected.

\`\`\`swift
let config = PostHogConfig(apiKey: \"phc_...\")
config.anonymousId = \"A-\\(myUserId)\"
PostHogSDK.shared.setup(config)
// \"Application Installed\" now reports anonymousId = \"A-...\"
\`\`\`

**2. \`PostHogSDK.setAnonymousId(_:)\`** — runtime override, intended to seed the next anonymous session after \`reset()\`:

\`\`\`swift
PostHogSDK.shared.reset()
PostHogSDK.shared.setAnonymousId(\"A-guest-\\(UUID().uuidString)\")
\`\`\`

This is the iOS equivalent of \`posthog.reset({ bootstrap: { distinctID } })\` from the JS proposal in posthog-js#862.

## Tests

Three new specs in \`PostHogStorageManagerTest\`:
- bootstrap value picked up on fresh install
- empty bootstrap falls back to UUID
- bootstrap re-applies after a \`reset()\` that clears persisted storage

Note: \`swift test\` is currently broken on \`main\` (pre-existing test target rot, see commit 853e71679 — \"ci: run the iOS test target on a simulator and fix the rot it surfaced\"). The SDK target builds clean; the new tests follow the existing Quick/Nimble pattern and should pass on the iOS-simulator CI path.

## Compatibility

- No public API removals, no signature changes.
- Existing call sites compile unchanged (both new surfaces have defaults / are additive).
- \`@objc\` annotations preserved on both new members.