### PR TITLE
chore: improve CI workflow linting

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-platforms:

--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-platforms:
     runs-on: macos-15

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: macos-15-xlarge

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   swiftformat:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,15 +10,25 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  lint:
+  swiftformat:
+    name: SwiftFormat
     runs-on: macos-26
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - name: Install linting tools
-        run: |
-          brew install swiftlint swiftformat
+      - name: Check formatting
+        run: make swiftFormatCheck
 
-      - name: Run lints
-        run: make lint
+  swiftlint:
+    name: SwiftLint
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Run SwiftLint
+        run: make swiftLintCheck

--- a/.github/workflows/sdk-compliance.yml
+++ b/.github/workflows/sdk-compliance.yml
@@ -18,7 +18,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   compliance-tests:

--- a/.github/workflows/sdk-compliance.yml
+++ b/.github/workflows/sdk-compliance.yml
@@ -16,6 +16,10 @@ on:
       - 'sdk_compliance_adapter/**'
       - '.github/workflows/sdk-compliance.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   compliance-tests:
     # NOTE: Using macos-15-intel (Intel) instead of macos-26 (Apple Silicon)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: macos-15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build buildSdk buildExamples format swiftLint swiftFormat test testDowngradeCompatibility testOniOSSimulator testOnMacSimulator lint bootstrap releaseCocoaPods api buildIOS
+.PHONY: build buildSdk buildExamples format swiftLint swiftFormat swiftLintCheck swiftFormatCheck installSwiftLint installSwiftFormat test testDowngradeCompatibility testOniOSSimulator testOnMacSimulator lint bootstrap releaseCocoaPods api buildIOS
 
 build: buildSdk buildExamples
 
@@ -67,11 +67,27 @@ buildExampleXCFramework:
 
 format: swiftLint swiftFormat
 
-swiftLint:
+installSwiftLint:
+	@if ! command -v swiftlint >/dev/null 2>&1; then \
+		brew install swiftlint; \
+	fi
+
+installSwiftFormat:
+	@if ! command -v swiftformat >/dev/null 2>&1; then \
+		brew install swiftformat; \
+	fi
+
+swiftLint: installSwiftLint
 	swiftlint --fix
 
-swiftFormat:
+swiftFormat: installSwiftFormat
 	swiftformat . --swiftversion 5.3
+
+swiftLintCheck: installSwiftLint
+	swiftlint
+
+swiftFormatCheck: installSwiftFormat
+	swiftformat . --lint --swiftversion 5.3
 
 # use -only-testing:PostHogTests/PostHogQueueTest to run only a specific test
 # -retry-tests-on-failure -test-iterations 3: a few tests assert real-time behaviour (autocapture
@@ -100,8 +116,7 @@ testDowngradeCompatibility:
 	DOWNGRADE_REF="$${DOWNGRADE_REF:-3.48.0}" ./scripts/test-downgrade-compatibility.sh
 
 
-lint:
-	swiftformat . --lint --swiftversion 5.3 && swiftlint
+lint: swiftFormatCheck swiftLintCheck
 
 # periphery scan --setup
 # TODO: add periphery to the CI/commit prehooks


### PR DESCRIPTION
## :bulb: Motivation and Context
CI workflow runs should cancel outdated jobs for the same PR without canceling completed coverage for merged commits on `main`, and lint workflow commands should stay centralized in the Makefile instead of being duplicated in GitHub Actions.

## :green_heart: How did you test it?

- `make -n swiftFormatCheck`
- `make -n swiftLintCheck`
- `make lint`
- `git diff --check`
- `rg -n "cancel-in-progress" .github/workflows/build-examples.yml .github/workflows/build.yml .github/workflows/lint.yml .github/workflows/sdk-compliance.yml .github/workflows/test.yml`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
