### PR TITLE
chore: Add CocoaPods podspec lint CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,3 +70,16 @@ jobs:
             -scheme PostHogExampleWithPods \
             -destination generic/platform=ios \
             SWIFT_VERSION=5 | xcpretty
+
+  podspec-lint:
+    runs-on: macos-15
+    name: CocoaPods package lint
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+        with:
+          xcode-version: latest-stable
+      - name: Install CocoaPods
+        run: gem install cocoapods
+      - name: Lint podspec
+        run: pod lib lint PostHog.podspec --allow-warnings --skip-tests


### PR DESCRIPTION
## :bulb: Motivation and Context
Add CI coverage for CocoaPods package validation so podspec issues are caught automatically before release.

## :green_heart: How did you test it?
Not run successfully locally; `pod lib lint PostHog.podspec --allow-warnings --skip-tests` is blocked on this machine by missing Xcode 26.5 simulator/platform runtimes.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
