### PR TITLE
test: stabilize remote config cache clearing assertion

### DIFF
--- a/PostHogTests/PostHogRemoteConfigTest.swift
+++ b/PostHogTests/PostHogRemoteConfigTest.swift
@@ -207,7 +207,11 @@ enum PostHogRemoteConfigTest {
             // The cache clearing runs asynchronously after onRemoteConfigLoaded fires and isn't tied to
             // any callback we can await, so poll the end state — returns the instant it clears rather
             // than blocking on a fixed delay.
-            await waitUntil { storage.getDictionary(forKey: .enabledFeatureFlags).isNilOrEmpty }
+            await waitUntil {
+                storage.getDictionary(forKey: .flags).isNilOrEmpty &&
+                    storage.getDictionary(forKey: .enabledFeatureFlags).isNilOrEmpty &&
+                    storage.getDictionary(forKey: .enabledFeatureFlagPayloads).isNilOrEmpty
+            }
 
             // test for empty cache
             #expect(storage.getDictionary(forKey: .flags).isNilOrEmpty == true)


### PR DESCRIPTION
## :bulb: Motivation and Context

The remote config cache-clearing test can be flaky because it waits for only the enabled feature flags cache to clear, then immediately asserts the flags and payload caches are also empty. The SDK clears those cache slices sequentially, so CI can observe the small window between clears.


## :green_heart: How did you test it?

- [x] `make test filter=PostHogRemoteConfigTest`


## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
