### PR TITLE
test: Add public API snapshot canary

### DIFF
--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -171,6 +171,9 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
     /// Default: `false`.
     @objc public var debug: Bool = false
 
+    /// Temporary public API canary used to verify the API snapshot CI check fails.
+    @objc public var apiSnapshotCheckCanary: Bool = false
+
     /// Starts the SDK in an opted-out state when set before setup.
     ///
     /// While opted out, capture calls are ignored and integrations are not installed.


### PR DESCRIPTION
## :bulb: Motivation and Context

This is a temporary draft PR to verify the public API snapshot CI check added in #658 fails when a public API is added without updating the checked-in baseline.


## :green_heart: How did you test it?

- [x] `make apiCheck` (failed as expected because the baseline was intentionally not updated)


## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
