### PR TITLE
fix: respect remote session replay sampling

### DIFF
--- a/.changeset/quiet-owls-record.md
+++ b/.changeset/quiet-owls-record.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': patch
+---
+
+Respect remote session replay sample rates after config loads.

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -433,9 +433,13 @@
         }
 
         func applyRemoteConfig(remoteConfig: [String: Any]?) {
+            let wasEnabled = isEnabled
             updatePlugins(from: remoteConfig)
             updateEventTriggers(from: remoteConfig)
             updateCachedMinimumDuration()
+            if wasEnabled {
+                reevaluateSampling()
+            }
         }
 
         private func updateCachedMinimumDuration() {

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -433,13 +433,10 @@
         }
 
         func applyRemoteConfig(remoteConfig: [String: Any]?) {
-            let wasEnabled = isEnabled
             updatePlugins(from: remoteConfig)
             updateEventTriggers(from: remoteConfig)
             updateCachedMinimumDuration()
-            if wasEnabled {
-                reevaluateSampling()
-            }
+            reevaluateSampling()
         }
 
         private func updateCachedMinimumDuration() {

--- a/PostHogTests/PostHogSamplingTest.swift
+++ b/PostHogTests/PostHogSamplingTest.swift
@@ -271,6 +271,57 @@ class PostHogSamplingTests {
         }
     }
 
+    // MARK: - Replay integration remote sample rate Tests
+
+    @Suite("Replay integration remote sample rate Tests", .serialized)
+    class ReplayIntegrationRemoteSampleRateTests {
+        let server: MockPostHogServer
+
+        init() {
+            server = MockPostHogServer()
+            server.start()
+            PostHogReplayIntegration.clearInstalls()
+        }
+
+        deinit {
+            server.stop()
+            PostHogReplayIntegration.clearInstalls()
+        }
+
+        @Test("remote sample rate is applied after config loads")
+        func remoteSampleRateIsAppliedAfterConfigLoads() async {
+            let config = PostHogConfig(projectToken: "remote_sample_rate_test", host: "http://localhost:9001")
+            config.sessionReplay = true
+            config.preloadFeatureFlags = false
+            config.disableReachabilityForTesting = true
+            config.disableQueueTimerForTesting = true
+            config.disableFlushOnBackgroundForTesting = true
+            config.storageManager = PostHogStorageManager(config)
+
+            let storage = PostHogStorage(config)
+            storage.reset()
+            storage.remove(key: .remoteConfig)
+
+            server.returnReplay = true
+            server.sessionRecordingSampleRate = "0"
+
+            let sut = PostHogSDK.with(config)
+            defer { sut.close() }
+
+            await waitUntil {
+                sut.remoteConfig?.getRecordingSampleRate() == 0.0
+            }
+
+            await waitUntil {
+                sut.getReplayIntegration()?.isActive() == false
+            }
+
+            #expect(sut.remoteConfig?.getRecordingSampleRate() == 0.0)
+            #expect(sut.getReplayIntegration()?.isActive() == false)
+            #expect(sut.isSessionReplayActive() == false)
+        }
+    }
+
     // MARK: - PostHogSessionReplayConfig sampleRate Tests
 
     @Suite("PostHogSessionReplayConfig sampleRate Tests")


### PR DESCRIPTION
## :bulb: Motivation and Context
Remote session replay sample rates can arrive after the replay integration has already started. In that case, the SDK defaulted to recording the session and did not re-check sampling once remote config loaded, so dashboard-configured sampling could be ignored for the current session.

This updates replay to re-evaluate sampling after remote config is applied when replay is already running.

## :green_heart: How did you test it?

- Added an iOS regression test covering remote sample rate `0` stopping an already-started replay integration after config loads.
- Ran `make testOniOSSimulator`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
