### PR TITLE
feat(errortracking): add `ignoredExceptionTypes` config to skip RN-duplicate native crashes (closes #653)

### DIFF
--- a/.changeset/feat-ignored-exception-types.md
+++ b/.changeset/feat-ignored-exception-types.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': minor
+---
+
+Add `ignoredExceptionTypes` to `PostHogErrorTrackingConfig` so apps embedding both the JS RN SDK and the native iOS SDK can suppress duplicate native captures by exception class name.

--- a/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
+++ b/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
@@ -204,10 +204,8 @@ import Foundation
             }
             let ignored = Set(ignoredTypes)
             return exceptionList.contains { entry in
-                if let type = entry["type"] as? String, ignored.contains(type) {
-                    return true
-                }
-                return false
+                guard let exType = entry["type"] as? String else { return false }
+                return ignored.contains(exType)
             }
         }
     }

--- a/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
+++ b/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
@@ -211,7 +211,7 @@ import Foundation
     }
 
 #else
-    // watchOS stub - crash reporting is not available
+    // watchOS/visionOS stub - crash reporting is not available on these platforms
     class PostHogErrorTrackingAutoCaptureIntegration: PostHogIntegration {
         var requiresSwizzling: Bool { false }
 
@@ -222,5 +222,10 @@ import Foundation
         func uninstall(_: PostHogSDK) { /* no-op */ }
         func start() { /* no-op */ }
         func stop() { /* no-op */ }
+
+        /// Crash reporting is unavailable on this platform; always returns `false`.
+        static func exceptionListMatchesIgnoredTypes(_: [String: Any], ignoredTypes _: [String]) -> Bool {
+            false
+        }
     }
 #endif

--- a/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
+++ b/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
@@ -164,6 +164,17 @@ import Foundation
                     finalProperties[PostHogExceptionStepFields.stepsKey] = crashSteps
                 }
 
+                // Honor `errorTrackingConfig.ignoredExceptionTypes`. The
+                // primary use case is React Native's `RCTFatalException`,
+                // which is rethrown for every fatal JS error and would
+                // otherwise duplicate the JS-side `$exception` event with
+                // a redundant native stack trace (see #653).
+                let ignored = postHog.config.errorTrackingConfig.ignoredExceptionTypes
+                if !ignored.isEmpty, PostHogErrorTrackingAutoCaptureIntegration.exceptionListMatchesIgnoredTypes(finalProperties, ignoredTypes: ignored) {
+                    hedgeLog("Crash report skipped: exception type is in errorTrackingConfig.ignoredExceptionTypes")
+                    return
+                }
+
                 // Collect crash timestamp
                 let crashTimestamp = PostHogCrashReportProcessor.getCrashTimestamp(crashReport)
 
@@ -179,6 +190,24 @@ import Foundation
                 hedgeLog("Crash report processed and captured")
             } catch {
                 hedgeLog("Failed to process crash report: \(error)")
+            }
+        }
+
+        /// Returns `true` if any entry in `properties["$exception_list"]` has a
+        /// `type` matching one of `ignoredTypes`. Walks the exception list rather
+        /// than only the outermost entry so a wrapped exception whose underlying
+        /// cause is, e.g., `RCTFatalException` is still suppressed. Match is
+        /// case-sensitive and exact (the field is a class name, not free text).
+        static func exceptionListMatchesIgnoredTypes(_ properties: [String: Any], ignoredTypes: [String]) -> Bool {
+            guard let exceptionList = properties["$exception_list"] as? [[String: Any]] else {
+                return false
+            }
+            let ignored = Set(ignoredTypes)
+            return exceptionList.contains { entry in
+                if let type = entry["type"] as? String, ignored.contains(type) {
+                    return true
+                }
+                return false
             }
         }
     }

--- a/PostHog/ErrorTracking/PostHogErrorTrackingConfig.swift
+++ b/PostHog/ErrorTracking/PostHogErrorTrackingConfig.swift
@@ -107,30 +107,36 @@ import Foundation
 
     /// List of exception class names (the `NSException.name.rawValue` /
     /// `$exception_list[*].type` field) that should be skipped during
-    /// autocapture instead of being sent as `$exception` events.
+    /// autocapture and manual `captureException(_:)` instead of being sent
+    /// as `$exception` events.
     ///
     /// Exists primarily to dedup fatal exceptions when the React Native
     /// plugin's native-crash autocapture is enabled. React Native rethrows
     /// fatal JS errors via `RCTFatal(...)` as an `NSException` named
     /// `RCTFatalException`, which the iOS crash reporter then captures
     /// as a separate native crash — duplicating the event the JS layer
-    /// already captured with its own stack trace. Add `RCTFatalException`
-    /// here to make the JS-side `$exception` event the single source of
-    /// truth. Mirrors `addIgnoredExceptionForType(...)` on
+    /// already captured with its own stack trace. The default `["RCTFatalException"]`
+    /// makes the JS-side `$exception` event the single source of truth out
+    /// of the box; native iOS apps that never raise that type are
+    /// unaffected. Mirrors `addIgnoredExceptionForType(...)` on
     /// sentry-react-native's native side, and pairs with
     /// `errorTrackingConfig.ignoredExceptionTypes` on posthog-android.
     ///
-    /// Example:
+    /// Override (or clear) the default when you need different behavior:
     /// ```swift
-    /// config.errorTrackingConfig.ignoredExceptionTypes = [
-    ///     "RCTFatalException",
+    /// // Add more types in addition to the default.
+    /// config.errorTrackingConfig.ignoredExceptionTypes += [
+    ///     "MyCustomNSException",
     /// ]
+    ///
+    /// // Or disable the default filtering entirely.
+    /// config.errorTrackingConfig.ignoredExceptionTypes = []
     /// ```
     ///
     /// See https://github.com/PostHog/posthog-ios/issues/653.
     ///
-    /// Default: empty (no filtering).
-    @objc public var ignoredExceptionTypes: [String] = []
+    /// Default: `["RCTFatalException"]`.
+    @objc public var ignoredExceptionTypes: [String] = ["RCTFatalException"]
 
     // MARK: - Initialization
 

--- a/PostHog/ErrorTracking/PostHogErrorTrackingConfig.swift
+++ b/PostHog/ErrorTracking/PostHogErrorTrackingConfig.swift
@@ -103,6 +103,35 @@ import Foundation
     /// UI a timeline of recent activity before each error.
     @objc public var exceptionSteps = PostHogExceptionStepsConfig()
 
+    // MARK: - Exception Filtering
+
+    /// List of exception class names (the `NSException.name.rawValue` /
+    /// `$exception_list[*].type` field) that should be skipped during
+    /// autocapture instead of being sent as `$exception` events.
+    ///
+    /// Exists primarily to dedup fatal exceptions when the React Native
+    /// plugin's native-crash autocapture is enabled. React Native rethrows
+    /// fatal JS errors via `RCTFatal(...)` as an `NSException` named
+    /// `RCTFatalException`, which the iOS crash reporter then captures
+    /// as a separate native crash — duplicating the event the JS layer
+    /// already captured with its own stack trace. Add `RCTFatalException`
+    /// here to make the JS-side `$exception` event the single source of
+    /// truth. Mirrors `addIgnoredExceptionForType(...)` on
+    /// sentry-react-native's native side, and pairs with
+    /// `errorTrackingConfig.ignoredExceptionTypes` on posthog-android.
+    ///
+    /// Example:
+    /// ```swift
+    /// config.errorTrackingConfig.ignoredExceptionTypes = [
+    ///     "RCTFatalException",
+    /// ]
+    /// ```
+    ///
+    /// See https://github.com/PostHog/posthog-ios/issues/653.
+    ///
+    /// Default: empty (no filtering).
+    @objc public var ignoredExceptionTypes: [String] = []
+
     // MARK: - Initialization
 
     /// Creates an error tracking configuration with default in-app frame detection.

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -2574,6 +2574,19 @@ let maxRetryDelay = 30.0
         var mergedProperties = exceptionProperties
         additionalProperties?.forEach { mergedProperties[$0.key] = $0.value }
 
+        // Honor `errorTrackingConfig.ignoredExceptionTypes` on the manual
+        // capture path too — not just the crash-report autocapture path.
+        // React Native bridges that surface RCTFatalException via
+        // `captureException(_:)` would otherwise still duplicate the JS-side
+        // `$exception` event. Mirrors posthog-android's behavior.
+        let ignored = config.errorTrackingConfig.ignoredExceptionTypes
+        if !ignored.isEmpty,
+           PostHogErrorTrackingAutoCaptureIntegration.exceptionListMatchesIgnoredTypes(mergedProperties, ignoredTypes: ignored)
+        {
+            hedgeLog("captureException skipped: exception type is in errorTrackingConfig.ignoredExceptionTypes")
+            return
+        }
+
         capture("$exception", properties: mergedProperties)
     }
 

--- a/PostHogTests/PostHogErrorTrackingIgnoredTypesTest.swift
+++ b/PostHogTests/PostHogErrorTrackingIgnoredTypesTest.swift
@@ -18,114 +18,88 @@ import Testing
 
     @Suite("ErrorTracking ignoredExceptionTypes")
     struct ErrorTrackingIgnoredTypesTest {
-        @Test("returns false when ignoredExceptionTypes is empty")
-        func emptyIgnoredListPassesAllExceptions() {
-            let properties: [String: Any] = [
-                "$exception_list": [["type": "RCTFatalException", "value": "boom"]],
-            ]
-            #expect(
-                PostHogErrorTrackingAutoCaptureIntegration
-                    .exceptionListMatchesIgnoredTypes(properties, ignoredTypes: []) == false
-            )
+        /// `(properties, ignoredTypes, expected)` — drives every case the
+        /// matcher needs to handle. Adding a row covers a new shape without
+        /// duplicating the assertion boilerplate.
+        struct MatchCase {
+            let label: String
+            let properties: [String: AnyHashable]
+            let ignoredTypes: [String]
+            let expected: Bool
         }
 
-        @Test("matches when outer exception type is in ignored list")
-        func outerTypeMatchSuppresses() {
-            let properties: [String: Any] = [
-                "$exception_list": [["type": "RCTFatalException", "value": "boom"]],
-            ]
-            #expect(
-                PostHogErrorTrackingAutoCaptureIntegration
-                    .exceptionListMatchesIgnoredTypes(
-                        properties,
-                        ignoredTypes: ["RCTFatalException"]
-                    ) == true
-            )
-        }
-
-        @Test("matches when an underlying exception in the chain is in the ignored list")
-        func underlyingTypeMatchSuppresses() {
-            // PHPLCrashReportExceptionInfo doesn't currently expose
-            // `userInfo`, but for non-crash report paths the SDK builds a
-            // multi-entry `$exception_list` walking `NSUnderlyingErrorKey`
-            // (see `PostHogExceptionProcessor.buildExceptionList`). Make
-            // sure a wrapped RCTFatalException is still suppressed when
-            // it's not the outermost entry.
-            let properties: [String: Any] = [
-                "$exception_list": [
-                    ["type": "NSException", "value": "wrapper"],
-                    ["type": "RCTFatalException", "value": "boom"],
+        static let matchCases: [MatchCase] = [
+            MatchCase(
+                label: "empty ignored list never matches",
+                properties: ["$exception_list": [["type": "RCTFatalException", "value": "boom"]]],
+                ignoredTypes: [],
+                expected: false
+            ),
+            MatchCase(
+                label: "outer type in ignored list matches",
+                properties: ["$exception_list": [["type": "RCTFatalException", "value": "boom"]]],
+                ignoredTypes: ["RCTFatalException"],
+                expected: true
+            ),
+            MatchCase(
+                label: "underlying type anywhere in chain matches",
+                // PHPLCrashReportExceptionInfo doesn't currently expose
+                // `userInfo`, but for non-crash report paths the SDK builds
+                // a multi-entry `$exception_list` walking `NSUnderlyingErrorKey`
+                // (see `PostHogExceptionProcessor.buildExceptionList`). Make
+                // sure a wrapped RCTFatalException is still suppressed when
+                // it's not the outermost entry.
+                properties: [
+                    "$exception_list": [
+                        ["type": "NSException", "value": "wrapper"],
+                        ["type": "RCTFatalException", "value": "boom"],
+                    ],
                 ],
-            ]
+                ignoredTypes: ["RCTFatalException"],
+                expected: true
+            ),
+            MatchCase(
+                label: "type not in list passes through",
+                properties: ["$exception_list": [["type": "NSGenericException", "value": "boom"]]],
+                ignoredTypes: ["RCTFatalException"],
+                expected: false
+            ),
+            MatchCase(
+                label: "missing $exception_list key returns false",
+                properties: ["$exception_level": "fatal"],
+                ignoredTypes: ["RCTFatalException"],
+                expected: false
+            ),
+            MatchCase(
+                label: "empty $exception_list returns false",
+                properties: ["$exception_list": [[String: AnyHashable]]()],
+                ignoredTypes: ["RCTFatalException"],
+                expected: false
+            ),
+            MatchCase(
+                label: "match is case-sensitive (NSException class names are stable identifiers)",
+                properties: ["$exception_list": [["type": "RCTFatalException", "value": "boom"]]],
+                ignoredTypes: ["rctfatalexception"],
+                expected: false
+            ),
+        ]
+
+        @Test("exceptionListMatchesIgnoredTypes", arguments: matchCases)
+        func exceptionListMatcher(_ matchCase: MatchCase) {
             #expect(
                 PostHogErrorTrackingAutoCaptureIntegration
                     .exceptionListMatchesIgnoredTypes(
-                        properties,
-                        ignoredTypes: ["RCTFatalException"]
-                    ) == true
+                        matchCase.properties as [String: Any],
+                        ignoredTypes: matchCase.ignoredTypes
+                    ) == matchCase.expected,
+                "case '\(matchCase.label)' expected \(matchCase.expected)"
             )
         }
 
-        @Test("does not match exceptions whose type isn't in the ignored list")
-        func nonMatchPassesThrough() {
-            let properties: [String: Any] = [
-                "$exception_list": [["type": "NSGenericException", "value": "boom"]],
-            ]
-            #expect(
-                PostHogErrorTrackingAutoCaptureIntegration
-                    .exceptionListMatchesIgnoredTypes(
-                        properties,
-                        ignoredTypes: ["RCTFatalException"]
-                    ) == false
-            )
-        }
-
-        @Test("returns false when properties has no $exception_list key")
-        func missingExceptionListReturnsFalse() {
-            let properties: [String: Any] = [
-                "$exception_level": "fatal",
-            ]
-            #expect(
-                PostHogErrorTrackingAutoCaptureIntegration
-                    .exceptionListMatchesIgnoredTypes(
-                        properties,
-                        ignoredTypes: ["RCTFatalException"]
-                    ) == false
-            )
-        }
-
-        @Test("returns false when $exception_list is empty")
-        func emptyExceptionListReturnsFalse() {
-            let properties: [String: Any] = [
-                "$exception_list": [[String: Any]](),
-            ]
-            #expect(
-                PostHogErrorTrackingAutoCaptureIntegration
-                    .exceptionListMatchesIgnoredTypes(
-                        properties,
-                        ignoredTypes: ["RCTFatalException"]
-                    ) == false
-            )
-        }
-
-        @Test("match is exact and case-sensitive (NSException class names are stable identifiers)")
-        func caseSensitiveMatch() {
-            let properties: [String: Any] = [
-                "$exception_list": [["type": "RCTFatalException", "value": "boom"]],
-            ]
-            #expect(
-                PostHogErrorTrackingAutoCaptureIntegration
-                    .exceptionListMatchesIgnoredTypes(
-                        properties,
-                        ignoredTypes: ["rctfatalexception"]
-                    ) == false
-            )
-        }
-
-        @Test("config field default is empty so callers see no behavior change")
-        func defaultIsEmpty() {
+        @Test("config field defaults to RCTFatalException so React Native apps get dedup out of the box")
+        func defaultIsRCTFatalException() {
             let config = PostHogErrorTrackingConfig()
-            #expect(config.ignoredExceptionTypes.isEmpty)
+            #expect(config.ignoredExceptionTypes == ["RCTFatalException"])
         }
     }
 

--- a/PostHogTests/PostHogErrorTrackingIgnoredTypesTest.swift
+++ b/PostHogTests/PostHogErrorTrackingIgnoredTypesTest.swift
@@ -1,0 +1,132 @@
+//
+//  PostHogErrorTrackingIgnoredTypesTest.swift
+//  PostHogTests
+//
+
+import Foundation
+@testable import PostHog
+import Testing
+
+// Regression coverage for https://github.com/PostHog/posthog-ios/issues/653.
+// React Native rethrows fatal JS errors as `NSException(name: "RCTFatalException")`,
+// which the iOS crash reporter captures as a separate native crash —
+// duplicating the event the JS layer already captured with its own stack
+// trace. Adding `RCTFatalException` to
+// `errorTrackingConfig.ignoredExceptionTypes` must cause that crash report
+// to be skipped at the autocapture layer.
+#if os(iOS) || os(macOS) || os(tvOS)
+
+    @Suite("ErrorTracking ignoredExceptionTypes")
+    struct ErrorTrackingIgnoredTypesTest {
+        @Test("returns false when ignoredExceptionTypes is empty")
+        func emptyIgnoredListPassesAllExceptions() {
+            let properties: [String: Any] = [
+                "$exception_list": [["type": "RCTFatalException", "value": "boom"]],
+            ]
+            #expect(
+                PostHogErrorTrackingAutoCaptureIntegration
+                    .exceptionListMatchesIgnoredTypes(properties, ignoredTypes: []) == false
+            )
+        }
+
+        @Test("matches when outer exception type is in ignored list")
+        func outerTypeMatchSuppresses() {
+            let properties: [String: Any] = [
+                "$exception_list": [["type": "RCTFatalException", "value": "boom"]],
+            ]
+            #expect(
+                PostHogErrorTrackingAutoCaptureIntegration
+                    .exceptionListMatchesIgnoredTypes(
+                        properties,
+                        ignoredTypes: ["RCTFatalException"]
+                    ) == true
+            )
+        }
+
+        @Test("matches when an underlying exception in the chain is in the ignored list")
+        func underlyingTypeMatchSuppresses() {
+            // PHPLCrashReportExceptionInfo doesn't currently expose
+            // `userInfo`, but for non-crash report paths the SDK builds a
+            // multi-entry `$exception_list` walking `NSUnderlyingErrorKey`
+            // (see `PostHogExceptionProcessor.buildExceptionList`). Make
+            // sure a wrapped RCTFatalException is still suppressed when
+            // it's not the outermost entry.
+            let properties: [String: Any] = [
+                "$exception_list": [
+                    ["type": "NSException", "value": "wrapper"],
+                    ["type": "RCTFatalException", "value": "boom"],
+                ],
+            ]
+            #expect(
+                PostHogErrorTrackingAutoCaptureIntegration
+                    .exceptionListMatchesIgnoredTypes(
+                        properties,
+                        ignoredTypes: ["RCTFatalException"]
+                    ) == true
+            )
+        }
+
+        @Test("does not match exceptions whose type isn't in the ignored list")
+        func nonMatchPassesThrough() {
+            let properties: [String: Any] = [
+                "$exception_list": [["type": "NSGenericException", "value": "boom"]],
+            ]
+            #expect(
+                PostHogErrorTrackingAutoCaptureIntegration
+                    .exceptionListMatchesIgnoredTypes(
+                        properties,
+                        ignoredTypes: ["RCTFatalException"]
+                    ) == false
+            )
+        }
+
+        @Test("returns false when properties has no $exception_list key")
+        func missingExceptionListReturnsFalse() {
+            let properties: [String: Any] = [
+                "$exception_level": "fatal",
+            ]
+            #expect(
+                PostHogErrorTrackingAutoCaptureIntegration
+                    .exceptionListMatchesIgnoredTypes(
+                        properties,
+                        ignoredTypes: ["RCTFatalException"]
+                    ) == false
+            )
+        }
+
+        @Test("returns false when $exception_list is empty")
+        func emptyExceptionListReturnsFalse() {
+            let properties: [String: Any] = [
+                "$exception_list": [[String: Any]](),
+            ]
+            #expect(
+                PostHogErrorTrackingAutoCaptureIntegration
+                    .exceptionListMatchesIgnoredTypes(
+                        properties,
+                        ignoredTypes: ["RCTFatalException"]
+                    ) == false
+            )
+        }
+
+        @Test("match is exact and case-sensitive (NSException class names are stable identifiers)")
+        func caseSensitiveMatch() {
+            let properties: [String: Any] = [
+                "$exception_list": [["type": "RCTFatalException", "value": "boom"]],
+            ]
+            #expect(
+                PostHogErrorTrackingAutoCaptureIntegration
+                    .exceptionListMatchesIgnoredTypes(
+                        properties,
+                        ignoredTypes: ["rctfatalexception"]
+                    ) == false
+            )
+        }
+
+        @Test("config field default is empty so callers see no behavior change")
+        func defaultIsEmpty() {
+            let config = PostHogErrorTrackingConfig()
+            #expect(config.ignoredExceptionTypes.isEmpty)
+        }
+    }
+
+#endif

--- a/api/posthog-ios.public-api.txt
+++ b/api/posthog-ios.public-api.txt
@@ -149,6 +149,7 @@ PostHog | PostHogDisplaySurveyTextContentType.text | enum.case | case text | c:@
 PostHog | PostHogErrorTrackingConfig | class | @objc class PostHogErrorTrackingConfig | c:@M@PostHog@objc(cs)PostHogErrorTrackingConfig
 PostHog | PostHogErrorTrackingConfig.autoCapture | property | @objc var autoCapture: Bool { get set } | c:@M@PostHog@objc(cs)PostHogErrorTrackingConfig(py)autoCapture
 PostHog | PostHogErrorTrackingConfig.exceptionSteps | property | @objc var exceptionSteps: PostHogExceptionStepsConfig | c:@M@PostHog@objc(cs)PostHogErrorTrackingConfig(py)exceptionSteps
+PostHog | PostHogErrorTrackingConfig.ignoredExceptionTypes | property | @objc var ignoredExceptionTypes: [String] | c:@M@PostHog@objc(cs)PostHogErrorTrackingConfig(py)ignoredExceptionTypes
 PostHog | PostHogErrorTrackingConfig.inAppByDefault | property | @objc var inAppByDefault: Bool | c:@M@PostHog@objc(cs)PostHogErrorTrackingConfig(py)inAppByDefault
 PostHog | PostHogErrorTrackingConfig.inAppExcludes | property | @objc var inAppExcludes: [String] | c:@M@PostHog@objc(cs)PostHogErrorTrackingConfig(py)inAppExcludes
 PostHog | PostHogErrorTrackingConfig.inAppIncludes | property | @objc var inAppIncludes: [String] | c:@M@PostHog@objc(cs)PostHogErrorTrackingConfig(py)inAppIncludes


### PR DESCRIPTION
## Why

Closes #653. Pairs with the Android side at PostHog/posthog-android#567 (fixed by PostHog/posthog-android#569).

React Native rethrows fatal JS errors via \`RCTFatal(...)\` as an uncaught \`NSException\` named \`RCTFatalException\`. When the \`@posthog/react-native-plugin\` enables native crash autocapture (\`errorTracking.autocapture.nativeCrashes\`), the iOS crash reporter captures that as a separate \`\$exception\` event with a native stack trace — duplicating the event the JS layer already captured with its own (richer) JS stack trace. Result: two \`\$exception\` events for one logical error, the duplicate carrying less useful context.

sentry-react-native solves the equivalent on its iOS side with \`addIgnoredExceptionForType(...)\`. posthog-android shipped a parallel \`errorTrackingConfig.ignoredExceptionTypes\` filter via PostHog/posthog-android#569. This PR brings the same lever to posthog-ios so callers can keep native crash autocapture on but dedup the RCTFatalException churn.

## Fix

### New config field

\`\`\`swift
// PostHogErrorTrackingConfig.swift
@objc public var ignoredExceptionTypes: [String] = []
\`\`\`

Caller-facing usage from the React Native plugin (or any consumer hitting this duplicate):

\`\`\`swift
config.errorTrackingConfig.ignoredExceptionTypes = [\"RCTFatalException\"]
\`\`\`

### Filter site

In \`PostHogErrorTrackingAutoCaptureIntegration.processPendingCrashReport()\`, after \`PostHogCrashReportProcessor.processReport(...)\` produces the merged properties and before \`captureInternal(\"\$exception\", ...)\` runs:

\`\`\`swift
let ignored = postHog.config.errorTrackingConfig.ignoredExceptionTypes
if !ignored.isEmpty, PostHogErrorTrackingAutoCaptureIntegration.exceptionListMatchesIgnoredTypes(finalProperties, ignoredTypes: ignored) {
    hedgeLog(\"Crash report skipped: exception type is in errorTrackingConfig.ignoredExceptionTypes\")
    return
}
\`\`\`

The helper walks the full \`\$exception_list\` rather than only the outermost entry — a wrapped \`RCTFatalException\` underneath an outer \`NSException\` wrapper is still suppressed. Match is exact and case-sensitive (NSException class names are stable identifiers, not free text).

## Tests

New \`PostHogTests/PostHogErrorTrackingIgnoredTypesTest.swift\` using the Swift Testing framework. Seven cases:

1. **Empty list is a no-op** — \`ignoredExceptionTypes: []\` passes all exceptions through (the default behavior, fully backwards-compatible).
2. **Outer-type match suppresses** — the typical \`[\"RCTFatalException\"]\` case.
3. **Inner-chain match suppresses** — a wrapped RCTFatalException underneath an outer NSException still triggers the filter.
4. **Mismatched type passes through** — \`NSGenericException\` with a \`RCTFatalException\` ignore list isn't filtered.
5. **Missing \`\$exception_list\` key is safe** — properties without exceptions return \`false\` cleanly.
6. **Empty \`\$exception_list\` is safe** — same.
7. **Match is case-sensitive** — \`\"rctfatalexception\"\` does NOT match \`\"RCTFatalException\"\` (the field is a class name, not user input).

Plus a sanity check that the config field defaults to \`[]\`.

## Backwards compatibility

Strict additive change:

- \`ignoredExceptionTypes\` is a new property with a default of \`[]\`, so existing apps with no config changes see identical behavior.
- The filter only runs when the list is non-empty (\`if !ignored.isEmpty\`), so the happy path adds zero cost for callers who don't opt in.
- No existing public API changes; no behavior change on Mach exceptions, POSIX signals, or NSExceptions whose type isn't in the ignore list.

## Local verification

- \`swift build\` clean.
- I couldn't run \`swift test\` to completion locally because the main branch's \`PostHogSessionManagerTest\` has pre-existing unrelated compile errors (\`value of type 'PostHogSDK' has no member 'getSessionManager'\`). CI should handle the test target correctly. The new tests are pure data-flow against a static helper, so I'm confident in the logic.