### PR TITLE
chore: use getFeatureFlagResult in ObjC example app

### DIFF
--- a/PostHogObjCExample/AppDelegate.m
+++ b/PostHogObjCExample/AppDelegate.m
@@ -91,7 +91,7 @@
     NSLog(@"isOptOut: %d", [[PostHogSDK shared] isOptOut]);
     NSLog(@"isFeatureEnabled: %d", [[PostHogSDK shared] isFeatureEnabled:@"myFlag"]);
     NSLog(@"getFeatureFlag: %@", [[PostHogSDK shared] getFeatureFlag:@"myFlag"]);
-    NSLog(@"getFeatureFlagPayload: %@", [[PostHogSDK shared] getFeatureFlagPayload:@"myFlag"]);
+    NSLog(@"getFeatureFlagResult payload: %@", [[PostHogSDK shared] getFeatureFlagResult:@"myFlag"].payload);
     
     [[PostHogSDK shared] reloadFeatureFlags];
     [[PostHogSDK shared] reloadFeatureFlagsWithCallback:^(){


### PR DESCRIPTION
## :bulb: Motivation and Context

Follow-up to the `getFeatureFlagPayload` → `getFeatureFlagResult` deprecation. `getFeatureFlagPayload(_:)` is already `@available(*, deprecated)` in `PostHogSDK`, but the Objective-C example app still called it — so the sample built against a deprecated API and taught the old pattern.

## :green_heart: How did you test it?

The Obj-C example now logs `[[PostHogSDK shared] getFeatureFlagResult:@"myFlag"].payload` — the non-deprecated path that returns the flag value and payload from a single evaluation. Example-app-only change; no SDK behavior affected. Built locally.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file (not needed — example-app-only, no release)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Part of a cross-SDK sweep migrating client usages off the deprecated `getFeatureFlagPayload`. An org-wide code search surfaced this Obj-C example as the last remaining caller in the iOS repo (the SDK method itself is already deprecated; the test files intentionally still exercise it). Single-line change; verified the Obj-C selector `getFeatureFlagResult:` exists and `.payload` is `@objc`-exposed on `PostHogFeatureFlagResult`.
