### PR TITLE
docs: Clarify message_id legacy compatibility

### DIFF
--- a/PostHog/Models/PostHogEvent.swift
+++ b/PostHog/Models/PostHogEvent.swift
@@ -68,6 +68,7 @@ import Foundation
 
         guard let distinctId = (json["distinct_id"] as? String) ?? (properties["distinct_id"] as? String) else { return nil }
 
+        // `message_id` is deprecated and only accepted for backwards compatibility with legacy persisted events.
         let uuid = ((json["uuid"] as? String) ?? (json["message_id"] as? String)) ?? UUID.v7().uuidString
         let uuidObj = UUID(uuidString: uuid) ?? UUID.v7()
 


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Clarifies that the `message_id` field is deprecated and only accepted when reading legacy persisted events for backwards compatibility. Current event serialization emits `uuid`.


## :green_heart: How did you test it?

Not run (comment-only change).


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Added a targeted inline note after cross-checking that iOS emits `uuid` and only reads `message_id` as a legacy compatibility alias. No runtime behavior was changed.
