### PR TITLE
fix: silence vendored libtool empty-object warnings

### DIFF
--- a/vendor/PHPLCrashReporter/Source/CrashReporterFramework.m
+++ b/vendor/PHPLCrashReporter/Source/CrashReporterFramework.m
@@ -2,3 +2,4 @@
  * This empty file is required to correctly resolve
  * all build settings and dependencies in the framework targets.
  */
+__attribute__((used, visibility("hidden"))) const int PHPLCrashReporterFrameworkTranslationUnitAnchor = 0;

--- a/vendor/PHPLCrashReporter/Source/PLCrashAsyncThread_x86.c
+++ b/vendor/PHPLCrashReporter/Source/PLCrashAsyncThread_x86.c
@@ -701,4 +701,6 @@ static const char *plcrash_async_thread_state_get_regname_64 (plcrash_regnum_t r
     abort();
 }
 
+#else
+__attribute__((used, visibility("hidden"))) const int PLCrashAsyncThreadX86TranslationUnitAnchor = 0;
 #endif /* defined(__i386__) || defined(__x86_64__) */

--- a/vendor/libwebp/huffman_utils.c
+++ b/vendor/libwebp/huffman_utils.c
@@ -27,3 +27,5 @@
   ((1 << MAX_CACHE_BITS) + NUM_LITERAL_CODES + NUM_LENGTH_CODES)
 // Cut-off value for switching between heap and stack allocation.
 #define SORTED_SIZE_CUTOFF 512
+
+__attribute__((used, visibility("hidden"))) const int phlibwebp_huffman_utils_translation_unit_anchor = 0;

--- a/vendor/libwebp/muxread.c
+++ b/vendor/libwebp/muxread.c
@@ -35,3 +35,5 @@
   } while (0)
 
 #undef SWITCH_ID_LIST
+
+__attribute__((used, visibility("hidden"))) const int phlibwebp_muxread_translation_unit_anchor = 0;


### PR DESCRIPTION
## :bulb: Motivation and Context

Fixes noisy Xcode `libtool` warnings from vendored empty translation units when PostHog is built through a Tuist-generated SwiftPM dependency project:

```text
libtool: warning: 'huffman_utils.o' has no symbols
libtool: warning: 'muxread.o' has no symbols
libtool: warning: 'CrashReporterFramework.o' has no symbols
libtool: warning: 'PLCrashAsyncThread_x86.o' has no symbols
```

This keeps the existing dependency graph and platform behavior unchanged. It only adds hidden retained anchor symbols to the four translation units that otherwise compile to empty object files.

This is intentionally narrower than earlier CrashReporter-related fixes: it does not remove `PHPLCrashReporter`, change Swift import guards, change product types, or disable error tracking on any platform.

## :green_heart: How did you test it?

- Created a minimal Tuist repro app that depends on this checkout through SwiftPM.
- Confirmed `main` reproduces the four `libtool: warning: '<object>.o' has no symbols` warnings.
- Confirmed this branch builds the same `phlibwebp.framework` and `PHPLCrashReporter.framework` targets with `0` matching `libtool: warning` lines.
- Ran `git diff --check`.
- Confirmed the new anchors are hidden with `nm -m` (`private external [no dead strip]`).
- Ran `make test`; the package compiled, including the touched vendored files, but the full run exited with existing unrelated `PostHogContextTest` nil-context failures.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex CLI helped reproduce the warning in a clean Tuist app, test package/product-type alternatives, and narrow the patch to hidden source-level anchors after consumer-side settings proved insufficient.
