### PR TITLE
fix: skip session replay event-trigger gating when running under React Native

### DIFF
--- a/.changeset/rn-skip-event-trigger-gating.md
+++ b/.changeset/rn-skip-event-trigger-gating.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Session replay: skip native event-trigger gating when running under React Native (`postHogSdkName == "posthog-react-native"`). React Native evaluates `sessionRecording.eventTriggers` in its JS layer and drives recording via explicit `startSessionRecording` calls; the native gate could never be satisfied because JS-captured events never reach the native capture pipeline, so event-triggered replay never recorded on RN. The linked-flag and sampling gates are unchanged, and non-RN behavior is unaffected.

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -143,6 +143,11 @@
             postHogSdkName != "posthog-flutter"
         }
 
+        private func isNotReactNative() -> Bool {
+            // for the React Native SDK, event-trigger evaluation is owned by the JS layer
+            postHogSdkName != "posthog-react-native"
+        }
+
         func install(_ postHog: PostHogSDK) -> PostHogIntegrationInstallResult {
             installIfNeeded(using: Self.integrationInstallState) {
                 self.postHog = postHog
@@ -1252,6 +1257,10 @@
             // Parse event triggers from remote config
             // Path: sessionRecording.eventTriggers ([String])
             let remoteEventTriggers: [String]? = {
+                // React Native evaluates event triggers in its JS layer; RN-captured events never reach
+                // the native capture() pipeline, so the native gate can't be satisfied. Don't store
+                // triggers for RN — the JS layer owns them (linkedFlag and sampling gates still apply).
+                guard isNotReactNative() else { return nil }
                 guard let sessionRecording = remoteConfig?["sessionRecording"] as? [String: Any],
                       let triggers = sessionRecording["eventTriggers"] as? [String]
                 else {

--- a/PostHogTests/PostHogSessionReplayEventTriggersTest.swift
+++ b/PostHogTests/PostHogSessionReplayEventTriggersTest.swift
@@ -205,5 +205,24 @@
 
             sut.close()
         }
+
+        // MARK: - React Native Opt-Out Tests
+
+        @Test("React Native opts out of native event-trigger gating")
+        func reactNativeOptsOutOfTriggerGating() async throws {
+            let original = postHogSdkName
+            postHogSdkName = "posthog-react-native"
+            defer { postHogSdkName = original }
+
+            // Triggers are configured, but React Native evaluates them in its JS layer, so the native
+            // integration must not gate — recording is active immediately without a trigger firing.
+            // (The non-RN path that waits for a trigger is covered by isActiveWhileWaitingForTrigger.)
+            let sut = getSut(eventTriggers: ["purchase_completed"])
+            let integration = sut.getReplayIntegration()
+            #expect(integration != nil)
+            #expect(integration?.isActive() == true)
+
+            sut.close()
+        }
     }
 #endif


### PR DESCRIPTION
## :bulb: Motivation and Context

**This is groundwork, not a feature.** It *enables* React Native session-replay event triggers but does not implement them. The RN feature lives entirely in the JS layer — [PostHog/posthog-js#3932](https://github.com/PostHog/posthog-js/pull/3932), shipped to apps via `@posthog/react-native-plugin` — where event triggers are evaluated and recording is started/stopped explicitly. On its own, this PR adds **no behavior change for native iOS consumers**; it only takes effect when the SDK is run under React Native.

Why it's required for the RN feature to work: posthog-ios fetches its own remote config and applies its **own** session-replay event-trigger gate inside `PostHogReplayIntegration`. That gate only opens for events captured through the native `PostHogSDK.capture()` pipeline (`onEventCaptured` → `handleEventCaptured` → `triggerActivatedSessionId`). React Native captures events in its JS layer and sends them over its own network path, so they never reach native `onEventCaptured` — the native gate can **never** be satisfied, and RN event-triggered replay would never record.

This change makes posthog-ios defer event-trigger gating to the host when driven by React Native (`postHogSdkName == "posthog-react-native"`): triggers aren't stored natively, so the JS layer is the single source of truth. Non-RN behavior is unchanged; the linked-flag / master recording flag and sampling gates still apply.

Part of a cross-repo change — see **Merge order**.

## :green_heart: How did you test it?

- **Manual, end-to-end:** built the posthog-js Expo example against this branch via a CocoaPods `:path` override on an iPhone 16 Pro (iOS 18.0) simulator, against a project configured with an `open_replay_screen_tapped` event trigger.
  - Before this change: `isSessionReplayActive()` stayed `false` after the trigger fired — the integration logged "Integration will not start until any of these events are captured".
  - With this change: firing the configured event flips `isSessionReplayActive()` `false → true` and recording starts.
- **Non-RN unaffected:** the opt-out is gated on `postHogSdkName`, so native iOS / Flutter behavior is byte-identical.
- **Unit test:** added `React Native opts out of native event-trigger gating` to `PostHogSessionReplayEventTriggersTests` (non-RN gating already covered by `isActiveWhileWaitingForTrigger`). Whole suite: 11/11 pass on iPhone 16 Pro (iOS 18.0).

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change (additive, gated on the RN SDK name) — changelog entry to be added.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file <!-- .changeset/rn-skip-event-trigger-gating.md (posthog-ios: patch) -->

## Merge order

**Wave 1 (no dependencies).** Merge + release first as **posthog-ios 3.61.1** (branch is rebased on `origin/main`; the exception-steps changeset is already released, so our `patch` changeset is the only one pending). Consumed by the `@posthog/react-native-plugin` pin-bump PR, which raises `posthog_ios_version` to `~> 3.61.1`.

Cross-repo chain: this PR **+** posthog-android (Wave 1) → `@posthog/react-native-plugin` pin bump (Wave 2) → posthog-react-native implementation (Wave 3). Links: `PostHog/posthog-android#584`, `PostHog/posthog-js#3931`, `PostHog/posthog-js#3932`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — assignee/DRI: @ioannisj
