### PR TITLE
feat: expose public getAllFeatureFlags() returning structured results

### DIFF
--- a/.changeset/all-feature-flags-accessor.md
+++ b/.changeset/all-feature-flags-accessor.md
@@ -2,4 +2,4 @@
 'posthog-ios': minor
 ---
 
-Add `PostHogSDK.getFeatureFlags()` to read all currently loaded feature flags. Exposed to Objective-C via `@objc`.
+Add `PostHogSDK.getAllFeatureFlags()` returning all loaded flags as `[PostHogFeatureFlagResult]` (key, enabled, variant, payload). Exposed to Objective-C via `@objc`.

--- a/.changeset/all-feature-flags-accessor.md
+++ b/.changeset/all-feature-flags-accessor.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': minor
+---
+
+Add `PostHogSDK.getFeatureFlags()` to read all currently loaded feature flags. Exposed to Objective-C via `@objc`.

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -749,6 +749,26 @@ class PostHogRemoteConfig {
 
         guard flagValue != nil else { return nil }
 
+        return makeFeatureFlagResult(key: key, flagValue: flagValue, payloadValue: payloadValue)
+    }
+
+    func getAllFeatureFlagResults() -> [PostHogFeatureFlagResult]? {
+        var flags: [String: Any]?
+        var payloads: [String: Any]?
+
+        featureFlagsLock.withLock {
+            flags = getCachedFeatureFlags()
+            payloads = getCachedFeatureFlagPayload()
+        }
+
+        guard let flags else { return nil }
+
+        return flags.map { key, value in
+            makeFeatureFlagResult(key: key, flagValue: value, payloadValue: payloads?[key])
+        }
+    }
+
+    private func makeFeatureFlagResult(key: String, flagValue: Any?, payloadValue: Any?) -> PostHogFeatureFlagResult {
         let payload: Any?
         if let stringValue = payloadValue as? String {
             do {

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -2026,6 +2026,25 @@ let maxRetryDelay = 30.0
         return result is String ? true : (result as? Bool) ?? false
     }
 
+    /// Returns all currently loaded feature flags keyed by flag name.
+    ///
+    /// Each value is the flag's resolved value: `Bool` for boolean flags or `String`
+    /// for multivariate flags. Flags become available after they finish loading from
+    /// the server; before the first load (or when the SDK is disabled) this returns `nil`.
+    /// Reading does not capture `$feature_flag_called` events.
+    ///
+    /// - Returns: A dictionary of flag keys to values, or `nil` if no flags are loaded.
+    ///
+    /// ```swift
+    /// let flags = PostHogSDK.shared.getFeatureFlags()
+    /// ```
+    @objc public func getFeatureFlags() -> [String: Any]? {
+        if !isEnabled() {
+            return nil
+        }
+        return remoteConfig?.getFeatureFlags()
+    }
+
     /// Returns the payload for a feature flag.
     ///
     /// - Parameter key: The feature flag key.

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -2026,23 +2026,25 @@ let maxRetryDelay = 30.0
         return result is String ? true : (result as? Bool) ?? false
     }
 
-    /// Returns all currently loaded feature flags keyed by flag name.
+    /// Returns all currently loaded feature flags as structured results.
     ///
-    /// Each value is the flag's resolved value: `Bool` for boolean flags or `String`
-    /// for multivariate flags. Flags become available after they finish loading from
-    /// the server; before the first load (or when the SDK is disabled) this returns `nil`.
-    /// Reading does not capture `$feature_flag_called` events.
+    /// Each `PostHogFeatureFlagResult` carries the flag's `key`, `enabled` state,
+    /// `variant` (for multivariate flags), and decoded `payload`. Flags become available
+    /// after they finish loading from the server; before the first load (or when the SDK
+    /// is disabled) this returns `nil`. Reading does not capture `$feature_flag_called` events.
     ///
-    /// - Returns: A dictionary of flag keys to values, or `nil` if no flags are loaded.
+    /// - Returns: An array of `PostHogFeatureFlagResult`, or `nil` if no flags are loaded.
     ///
     /// ```swift
-    /// let flags = PostHogSDK.shared.getFeatureFlags()
+    /// for flag in PostHogSDK.shared.getAllFeatureFlags() ?? [] {
+    ///     print(flag.key, flag.enabled, flag.payload as Any)
+    /// }
     /// ```
-    @objc public func getFeatureFlags() -> [String: Any]? {
+    @objc public func getAllFeatureFlags() -> [PostHogFeatureFlagResult]? {
         if !isEnabled() {
             return nil
         }
-        return remoteConfig?.getFeatureFlags()
+        return remoteConfig?.getAllFeatureFlagResults()
     }
 
     /// Returns the payload for a feature flag.

--- a/PostHogTests/PostHogFeatureFlagsTest.swift
+++ b/PostHogTests/PostHogFeatureFlagsTest.swift
@@ -849,6 +849,99 @@ enum PostHogFeatureFlagsTest {
         }
     }
 
+    @Suite("Test getAllFeatureFlags")
+    class TestGetAllFeatureFlags: BaseTestClass {
+        @Test("returns nil before flags are loaded")
+        func returnsNilBeforeLoad() {
+            let sut = track(PostHogSDK.with(config))
+            #expect(sut.getAllFeatureFlags() == nil)
+            sut.close()
+        }
+
+        @Test("returns all loaded flags, including disabled ones")
+        func returnsAllFlagsIncludingDisabled() async {
+            let sut = track(PostHogSDK.with(config))
+            await withCheckedContinuation { continuation in
+                sut.reloadFeatureFlags { continuation.resume() }
+            }
+
+            let all = sut.getAllFeatureFlags()
+            #expect(all != nil)
+
+            // Order is not guaranteed, so key by flag key.
+            let byKey = Dictionary(uniqueKeysWithValues: (all ?? []).map { ($0.key, $0) })
+
+            // Enabled boolean flag
+            #expect(byKey["bool-value"]?.enabled == true)
+            #expect(byKey["bool-value"]?.variant == nil)
+
+            // Multivariate flag carries its variant
+            #expect(byKey["string-value"]?.enabled == true)
+            #expect(byKey["string-value"]?.variant == "test")
+
+            // Disabled flag is INCLUDED as enabled=false (not filtered out) — matches Android.
+            #expect(byKey["disabled-flag"] != nil, "disabled flags should be included in the result")
+            #expect(byKey["disabled-flag"]?.enabled == false)
+            #expect(byKey["disabled-flag"]?.variant == nil)
+
+            sut.close()
+        }
+
+        @Test("decodes payloads (object and scalar)")
+        func decodesPayloads() async {
+            let sut = track(PostHogSDK.with(config))
+            await withCheckedContinuation { continuation in
+                sut.reloadFeatureFlags { continuation.resume() }
+            }
+
+            let byKey = Dictionary(uniqueKeysWithValues: (sut.getAllFeatureFlags() ?? []).map { ($0.key, $0) })
+
+            // Scalar payload parsed via .fragmentsAllowed
+            #expect(byKey["number-value"]?.payload as? Int == 2)
+            // Object payload parsed to a dictionary
+            #expect(byKey["payload-json"]?.payload as? [String: String] == ["foo": "bar"])
+
+            sut.close()
+        }
+
+        @Test("each result matches getFeatureFlagResult for that key")
+        func matchesSingleKeyResult() async {
+            let sut = track(PostHogSDK.with(config))
+            await withCheckedContinuation { continuation in
+                sut.reloadFeatureFlags { continuation.resume() }
+            }
+
+            for flag in sut.getAllFeatureFlags() ?? [] {
+                let single = sut.getFeatureFlagResult(flag.key, sendFeatureFlagEvent: false)
+                #expect(flag.enabled == single?.enabled, "enabled mismatch for \(flag.key)")
+                #expect(flag.variant == single?.variant, "variant mismatch for \(flag.key)")
+            }
+
+            sut.close()
+        }
+
+        @Test("does not send $feature_flag_called")
+        func doesNotSendEvent() async {
+            config.sendFeatureFlagEvent = true
+            config.flushAt = 1
+            let sut = track(PostHogSDK.with(config))
+            await withCheckedContinuation { continuation in
+                sut.reloadFeatureFlags { continuation.resume() }
+            }
+
+            server.reset(batchCount: 1)
+
+            _ = sut.getAllFeatureFlags()
+
+            sut.flush()
+            let events = getBatchedEvents(server, timeout: 0.5, failIfNotCompleted: false)
+            let ffEvent = events.first { $0.event == "$feature_flag_called" }
+            #expect(ffEvent == nil, "getAllFeatureFlags must not emit $feature_flag_called")
+
+            sut.close()
+        }
+    }
+
     @Suite("Test PostHogFeatureFlagResult payload methods")
     final class TestFeatureFlagResultPayloadMethods {
         @Test("payloadAs returns nil for nil payload")

--- a/api/posthog-ios.public-api.txt
+++ b/api/posthog-ios.public-api.txt
@@ -266,6 +266,7 @@ PostHog | PostHogSDK.didReceiveFeatureFlags | type.property | @objc static let d
 PostHog | PostHogSDK.didStartNotification | type.property | @objc static let didStartNotification: Notification.Name | c:@CM@PostHog@objc(cs)PostHogSDK(cpy)didStartNotification
 PostHog | PostHogSDK.endSession() | method | @objc func endSession() | c:@M@PostHog@objc(cs)PostHogSDK(im)endSession
 PostHog | PostHogSDK.flush() | method | @objc func flush() | c:@M@PostHog@objc(cs)PostHogSDK(im)flush
+PostHog | PostHogSDK.getAllFeatureFlags() | method | @objc func getAllFeatureFlags() -> [PostHogFeatureFlagResult]? | c:@M@PostHog@objc(cs)PostHogSDK(im)getAllFeatureFlags
 PostHog | PostHogSDK.getAnonymousId() | method | @objc func getAnonymousId() -> String | c:@M@PostHog@objc(cs)PostHogSDK(im)getAnonymousId
 PostHog | PostHogSDK.getDeviceId() | method | @objc func getDeviceId() -> String | c:@M@PostHog@objc(cs)PostHogSDK(im)getDeviceId
 PostHog | PostHogSDK.getDistinctId() | method | @objc func getDistinctId() -> String | c:@M@PostHog@objc(cs)PostHogSDK(im)getDistinctId
@@ -274,7 +275,6 @@ PostHog | PostHogSDK.getFeatureFlag(_:sendFeatureFlagEvent:) | method | @objc(ge
 PostHog | PostHogSDK.getFeatureFlagPayload(_:) | method | @objc func getFeatureFlagPayload(_ key: String) -> Any? | c:@M@PostHog@objc(cs)PostHogSDK(im)getFeatureFlagPayload:
 PostHog | PostHogSDK.getFeatureFlagResult(_:) | method | @objc func getFeatureFlagResult(_ key: String) -> PostHogFeatureFlagResult? | c:@M@PostHog@objc(cs)PostHogSDK(im)getFeatureFlagResult:
 PostHog | PostHogSDK.getFeatureFlagResult(_:sendFeatureFlagEvent:) | method | @objc(getFeatureFlagResultWithKey:sendFeatureFlagEvent:) func getFeatureFlagResult(_ key: String, sendFeatureFlagEvent: Bool) -> PostHogFeatureFlagResult? | c:@M@PostHog@objc(cs)PostHogSDK(im)getFeatureFlagResultWithKey:sendFeatureFlagEvent:
-PostHog | PostHogSDK.getFeatureFlags() | method | @objc func getFeatureFlags() -> [String : Any]? | c:@M@PostHog@objc(cs)PostHogSDK(im)getFeatureFlags
 PostHog | PostHogSDK.getSessionId() | method | @objc func getSessionId() -> String? | c:@M@PostHog@objc(cs)PostHogSDK(im)getSessionId
 PostHog | PostHogSDK.group(type:key:) | method | @objc(groupWithType:key:) func group(type: String, key: String) | c:@M@PostHog@objc(cs)PostHogSDK(im)groupWithType:key:
 PostHog | PostHogSDK.group(type:key:groupProperties:) | method | @objc(groupWithType:key:groupProperties:) func group(type: String, key: String, groupProperties: [String : Any]? = nil) | c:@M@PostHog@objc(cs)PostHogSDK(im)groupWithType:key:groupProperties:

--- a/api/posthog-ios.public-api.txt
+++ b/api/posthog-ios.public-api.txt
@@ -274,6 +274,7 @@ PostHog | PostHogSDK.getFeatureFlag(_:sendFeatureFlagEvent:) | method | @objc(ge
 PostHog | PostHogSDK.getFeatureFlagPayload(_:) | method | @objc func getFeatureFlagPayload(_ key: String) -> Any? | c:@M@PostHog@objc(cs)PostHogSDK(im)getFeatureFlagPayload:
 PostHog | PostHogSDK.getFeatureFlagResult(_:) | method | @objc func getFeatureFlagResult(_ key: String) -> PostHogFeatureFlagResult? | c:@M@PostHog@objc(cs)PostHogSDK(im)getFeatureFlagResult:
 PostHog | PostHogSDK.getFeatureFlagResult(_:sendFeatureFlagEvent:) | method | @objc(getFeatureFlagResultWithKey:sendFeatureFlagEvent:) func getFeatureFlagResult(_ key: String, sendFeatureFlagEvent: Bool) -> PostHogFeatureFlagResult? | c:@M@PostHog@objc(cs)PostHogSDK(im)getFeatureFlagResultWithKey:sendFeatureFlagEvent:
+PostHog | PostHogSDK.getFeatureFlags() | method | @objc func getFeatureFlags() -> [String : Any]? | c:@M@PostHog@objc(cs)PostHogSDK(im)getFeatureFlags
 PostHog | PostHogSDK.getSessionId() | method | @objc func getSessionId() -> String? | c:@M@PostHog@objc(cs)PostHogSDK(im)getSessionId
 PostHog | PostHogSDK.group(type:key:) | method | @objc(groupWithType:key:) func group(type: String, key: String) | c:@M@PostHog@objc(cs)PostHogSDK(im)groupWithType:key:
 PostHog | PostHogSDK.group(type:key:groupProperties:) | method | @objc(groupWithType:key:groupProperties:) func group(type: String, key: String, groupProperties: [String : Any]? = nil) | c:@M@PostHog@objc(cs)PostHogSDK(im)groupWithType:key:groupProperties:


### PR DESCRIPTION
## :bulb: Motivation and Context

Closes: https://github.com/PostHog/posthog-ios/issues/503
and supports https://github.com/PostHog/posthog-kmp/pull/1/changes

Adds `@objc public func getAllFeatureFlags() -> [PostHogFeatureFlagResult]?` on `PostHogSDK`, returning all currently loaded feature flags as structured results (`key`, `enabled`, `variant`, `payload`). It reuses the same result-construction path as `getFeatureFlagResult(_:)` via a new `PostHogRemoteConfig.getAllFeatureFlagResults()`, reading the cached flags + payloads under one `featureFlagsLock`. This is a bulk read — it does not fire `$feature_flag_called`.

This matches Android's `getAllFeatureFlags(): List<FeatureFlagResult>?` in both name and shape, so a downstream Kotlin Multiplatform wrapper can implement `getAllFeatureFlags()` on iOS. Until now no public accessor for all flags existed (only per-key `getFeatureFlag(_:)` / `getFeatureFlagResult(_:)` / `isFeatureEnabled(_:)`).

## :green_heart: How did you test it?

- `swift build` — compiles clean; the `@objc` `[PostHogFeatureFlagResult]?` return type is Objective-C-representable (`PostHogFeatureFlagResult` is an `NSObject`).
- Public API snapshot regenerated via `make apiUpdate`; the only diff is the new `getAllFeatureFlags()` entry, so the `make apiCheck` CI job passes.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
