### PR TITLE
fix(flags): retry flag requests on transient network errors

### DIFF
--- a/.changeset/quiet-flags-retry.md
+++ b/.changeset/quiet-flags-retry.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': patch
+---
+
+Retry feature flag requests after network errors only.

--- a/.changeset/quiet-flags-retry.md
+++ b/.changeset/quiet-flags-retry.md
@@ -2,4 +2,4 @@
 'posthog-ios': patch
 ---
 
-Retry feature flag requests after transient network errors only.
+Retry feature flag requests after transient network errors only. The feature flag request retry count defaults to 1 and can be set to 0 to disable retries.

--- a/.changeset/quiet-flags-retry.md
+++ b/.changeset/quiet-flags-retry.md
@@ -2,4 +2,4 @@
 'posthog-ios': patch
 ---
 
-Retry feature flag requests after network errors only.
+Retry feature flag requests after transient network errors only.

--- a/PostHog/PostHogApi.swift
+++ b/PostHog/PostHogApi.swift
@@ -46,11 +46,11 @@ class PostHogApi {
     /// Shared so connection pool, TLS state, and HTTP/2 streams survive
     /// between calls instead of being torn down per request.
     private let session: URLSession
-    private let flagsRetryDelay: TimeInterval
 
-    init(_ config: PostHogConfig, flagsRetryDelay: TimeInterval = retryDelay) {
+    static let flagsRetryDelay: TimeInterval = 0.3
+
+    init(_ config: PostHogConfig) {
         self.config = config
-        self.flagsRetryDelay = flagsRetryDelay
 
         // Copy first so SDK mutations don't leak back to the caller's object.
         let sessionConfig = (config.urlSessionConfiguration?.copy() as? URLSessionConfiguration)
@@ -288,7 +288,7 @@ class PostHogApi {
             if let error {
                 if Self.isRetryableFlagsError(error), retryCount < self.config.featureFlagRequestMaxRetries {
                     let nextRetryCount = retryCount + 1
-                    let delay = min(TimeInterval(nextRetryCount) * self.flagsRetryDelay, maxRetryDelay)
+                    let delay = Self.featureFlagsRetryDelay(forFailedAttempt: nextRetryCount)
                     hedgeLog(
                         "Error calling the flags API: \(error). Retrying in \(delay) seconds (attempt \(nextRetryCount)/\(self.config.featureFlagRequestMaxRetries))."
                     )
@@ -328,6 +328,10 @@ class PostHogApi {
                 completion(nil, error)
             }
         }.resume()
+    }
+
+    static func featureFlagsRetryDelay(forFailedAttempt failedAttempt: Int) -> TimeInterval {
+        min(flagsRetryDelay * pow(2.0, TimeInterval(failedAttempt - 1)), maxRetryDelay)
     }
 
     private static func isRetryableFlagsError(_ error: Error) -> Bool {

--- a/PostHog/PostHogApi.swift
+++ b/PostHog/PostHogApi.swift
@@ -286,8 +286,7 @@ class PostHogApi {
     ) {
         session.uploadTask(with: request, from: payload) { data, response, error in
             if let error {
-                let nsError = error as NSError
-                if nsError.domain == NSURLErrorDomain, retryCount < self.config.maxRetries {
+                if Self.isRetryableFlagsError(error), retryCount < self.config.maxRetries {
                     let nextRetryCount = retryCount + 1
                     let delay = min(TimeInterval(nextRetryCount) * self.flagsRetryDelay, maxRetryDelay)
                     hedgeLog(
@@ -329,6 +328,14 @@ class PostHogApi {
                 completion(nil, error)
             }
         }.resume()
+    }
+
+    private static func isRetryableFlagsError(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        guard nsError.domain == NSURLErrorDomain else {
+            return false
+        }
+        return nsError.code == NSURLErrorTimedOut || nsError.code == NSURLErrorNetworkConnectionLost
     }
 
     func remoteConfig(

--- a/PostHog/PostHogApi.swift
+++ b/PostHog/PostHogApi.swift
@@ -286,11 +286,11 @@ class PostHogApi {
     ) {
         session.uploadTask(with: request, from: payload) { data, response, error in
             if let error {
-                if Self.isRetryableFlagsError(error), retryCount < self.config.maxRetries {
+                if Self.isRetryableFlagsError(error), retryCount < self.config.featureFlagRequestMaxRetries {
                     let nextRetryCount = retryCount + 1
                     let delay = min(TimeInterval(nextRetryCount) * self.flagsRetryDelay, maxRetryDelay)
                     hedgeLog(
-                        "Error calling the flags API: \(error). Retrying in \(delay) seconds (attempt \(nextRetryCount)/\(self.config.maxRetries))."
+                        "Error calling the flags API: \(error). Retrying in \(delay) seconds (attempt \(nextRetryCount)/\(self.config.featureFlagRequestMaxRetries))."
                     )
                     DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + delay) {
                         self.uploadFlagsRequest(request, payload: payload, retryCount: nextRetryCount, completion: completion)

--- a/PostHog/PostHogApi.swift
+++ b/PostHog/PostHogApi.swift
@@ -46,9 +46,11 @@ class PostHogApi {
     /// Shared so connection pool, TLS state, and HTTP/2 streams survive
     /// between calls instead of being torn down per request.
     private let session: URLSession
+    private let flagsRetryDelay: TimeInterval
 
-    init(_ config: PostHogConfig) {
+    init(_ config: PostHogConfig, flagsRetryDelay: TimeInterval = retryDelay) {
         self.config = config
+        self.flagsRetryDelay = flagsRetryDelay
 
         // Copy first so SDK mutations don't leak back to the caller's object.
         let sessionConfig = (config.urlSessionConfiguration?.copy() as? URLSessionConfiguration)
@@ -273,9 +275,31 @@ class PostHogApi {
             return completion(nil, nil)
         }
 
-        session.uploadTask(with: request, from: data) { data, response, error in
-            if error != nil {
-                hedgeLog("Error calling the flags API: \(String(describing: error))")
+        uploadFlagsRequest(request, payload: data, retryCount: 0, completion: completion)
+    }
+
+    private func uploadFlagsRequest(
+        _ request: URLRequest,
+        payload: Data,
+        retryCount: Int,
+        completion: @escaping ([String: Any]?, _ error: Error?) -> Void
+    ) {
+        session.uploadTask(with: request, from: payload) { data, response, error in
+            if let error {
+                let nsError = error as NSError
+                if nsError.domain == NSURLErrorDomain, retryCount < self.config.maxRetries {
+                    let nextRetryCount = retryCount + 1
+                    let delay = min(TimeInterval(nextRetryCount) * self.flagsRetryDelay, maxRetryDelay)
+                    hedgeLog(
+                        "Error calling the flags API: \(error). Retrying in \(delay) seconds (attempt \(nextRetryCount)/\(self.config.maxRetries))."
+                    )
+                    DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + delay) {
+                        self.uploadFlagsRequest(request, payload: payload, retryCount: nextRetryCount, completion: completion)
+                    }
+                    return
+                }
+
+                hedgeLog("Error calling the flags API: \(error)")
                 return completion(nil, error)
             }
 

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -33,6 +33,7 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
         static let maxBatchSize: Int = 50
         static let flushIntervalSeconds: TimeInterval = 30
         static let maxRetries: Int = 3
+        static let featureFlagRequestMaxRetries: Int = 1
     }
 
     /// Network connectivity mode required before queued data may be flushed.
@@ -93,6 +94,10 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
     /// Increments on every retriable failure including HTTP 413 cap halving;
     /// resets on a successful 2xx response. Default 3.
     @objc public var maxRetries: Int = Defaults.maxRetries
+
+    /// Maximum number of retries for feature flag requests after transient network errors.
+    /// Defaults to 1. Set to 0 to disable feature flag request retries.
+    @objc public var featureFlagRequestMaxRetries: Int = Defaults.featureFlagRequestMaxRetries
     /// Required network connectivity mode for flushing queued data.
     ///
     /// Only `.wifi` currently restricts flushing; `.cellular` behaves the same as `.any`.

--- a/PostHogTests/PostHogApiTest.swift
+++ b/PostHogTests/PostHogApiTest.swift
@@ -220,13 +220,13 @@ enum PostHogApiTests {
 
     @Suite("Test flags endpoint with different host paths")
     class TestFlagsEndpoint: BaseTestSuite {
-        @Test("retries URLSession errors before returning flags")
+        @Test("retries transient URLSession errors before returning flags")
         func retriesURLSessionErrors() async throws {
             server.reset(flagsCount: 2)
 
             var requestCount = 0
             let requestCountLock = NSLock()
-            let networkError = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, userInfo: nil)
+            let networkError = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut, userInfo: nil)
             server.flagsResponseHandler = { _ in
                 requestCountLock.lock()
                 requestCount += 1
@@ -253,6 +253,31 @@ enum PostHogApiTests {
             #expect(try #require(resp.0)["errorsWhileComputingFlags"] as! Bool == false)
             #expect(resp.1 == nil)
             #expect(server.flagsRequests.count == 2)
+        }
+
+        @Test("does not retry connection refused errors")
+        func doesNotRetryConnectionRefused() async throws {
+            server.reset(flagsCount: 1)
+            let networkError = NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotConnectToHost, userInfo: nil)
+            server.flagsResponseHandler = { _ in
+                HTTPStubsResponse(error: networkError)
+            }
+
+            let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost")
+            config.maxRetries = 1
+            let sut = PostHogApi(config, flagsRetryDelay: 0.01)
+
+            let resp = await getApiResponse { completion in
+                sut.flags(distinctId: "", anonymousId: "", groups: [:], personProperties: [:]) { data, error in
+                    completion((data, error))
+                }
+            }
+
+            try await Task.sleep(nanoseconds: 50_000_000)
+
+            #expect(resp.0 == nil)
+            #expect(resp.1 != nil)
+            #expect(server.flagsRequests.count == 1)
         }
 
         @Test("does not retry HTTP 408 responses")

--- a/PostHogTests/PostHogApiTest.swift
+++ b/PostHogTests/PostHogApiTest.swift
@@ -64,7 +64,7 @@ enum PostHogApiTests {
 
             let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost")
             config.featureFlagRequestMaxRetries = 1
-            let sut = PostHogApi(config, flagsRetryDelay: 0.01)
+            let sut = PostHogApi(config)
 
             let resp = await getApiResponse { completion in
                 sut.flags(distinctId: "", anonymousId: "", groups: [:], personProperties: [:]) { data, error in
@@ -220,6 +220,13 @@ enum PostHogApiTests {
 
     @Suite("Test flags endpoint with different host paths")
     class TestFlagsEndpoint: BaseTestSuite {
+        @Test("feature flag retry delay starts at 300ms and doubles")
+        func featureFlagRetryDelayStartsAt300msAndDoubles() {
+            #expect(abs(PostHogApi.featureFlagsRetryDelay(forFailedAttempt: 1) - 0.3) < 0.0001)
+            #expect(abs(PostHogApi.featureFlagsRetryDelay(forFailedAttempt: 2) - 0.6) < 0.0001)
+            #expect(abs(PostHogApi.featureFlagsRetryDelay(forFailedAttempt: 3) - 1.2) < 0.0001)
+        }
+
         @Test("retries transient URLSession errors before returning flags")
         func retriesURLSessionErrors() async throws {
             server.reset(flagsCount: 2)
@@ -242,7 +249,7 @@ enum PostHogApiTests {
 
             let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost")
             config.featureFlagRequestMaxRetries = 1
-            let sut = PostHogApi(config, flagsRetryDelay: 0.01)
+            let sut = PostHogApi(config)
 
             let resp = await getApiResponse { completion in
                 sut.flags(distinctId: "", anonymousId: "", groups: [:], personProperties: [:]) { data, error in
@@ -265,7 +272,7 @@ enum PostHogApiTests {
 
             let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost")
             config.featureFlagRequestMaxRetries = 0
-            let sut = PostHogApi(config, flagsRetryDelay: 0.01)
+            let sut = PostHogApi(config)
 
             let resp = await getApiResponse { completion in
                 sut.flags(distinctId: "", anonymousId: "", groups: [:], personProperties: [:]) { data, error in
@@ -290,7 +297,7 @@ enum PostHogApiTests {
 
             let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost")
             config.featureFlagRequestMaxRetries = 2
-            let sut = PostHogApi(config, flagsRetryDelay: 0.01)
+            let sut = PostHogApi(config)
 
             let resp = await getApiResponse { completion in
                 sut.flags(distinctId: "", anonymousId: "", groups: [:], personProperties: [:]) { data, error in
@@ -313,7 +320,7 @@ enum PostHogApiTests {
 
             let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost")
             config.featureFlagRequestMaxRetries = 1
-            let sut = PostHogApi(config, flagsRetryDelay: 0.01)
+            let sut = PostHogApi(config)
 
             let resp = await getApiResponse { completion in
                 sut.flags(distinctId: "", anonymousId: "", groups: [:], personProperties: [:]) { data, error in

--- a/PostHogTests/PostHogApiTest.swift
+++ b/PostHogTests/PostHogApiTest.swift
@@ -280,10 +280,33 @@ enum PostHogApiTests {
             #expect(server.flagsRequests.count == 1)
         }
 
-        @Test("does not retry connection refused errors")
-        func doesNotRetryConnectionRefused() async throws {
+        @Test("stops retrying transient URLSession errors after feature flag request max retries")
+        func stopsRetryingTransientURLSessionErrorsAfterFeatureFlagRequestMaxRetries() async throws {
+            server.reset(flagsCount: 3)
+            let networkError = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut, userInfo: nil)
+            server.flagsResponseHandler = { _ in
+                HTTPStubsResponse(error: networkError)
+            }
+
+            let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost")
+            config.featureFlagRequestMaxRetries = 2
+            let sut = PostHogApi(config, flagsRetryDelay: 0.01)
+
+            let resp = await getApiResponse { completion in
+                sut.flags(distinctId: "", anonymousId: "", groups: [:], personProperties: [:]) { data, error in
+                    completion((data, error))
+                }
+            }
+
+            #expect(resp.0 == nil)
+            #expect(resp.1 != nil)
+            #expect(server.flagsRequests.count == 3)
+        }
+
+        @Test("does not retry non-transient URLSession errors", arguments: [NSURLErrorCannotConnectToHost, NSURLErrorCancelled])
+        func doesNotRetryNonTransientURLSessionErrors(errorCode: Int) async throws {
             server.reset(flagsCount: 1)
-            let networkError = NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotConnectToHost, userInfo: nil)
+            let networkError = NSError(domain: NSURLErrorDomain, code: errorCode, userInfo: nil)
             server.flagsResponseHandler = { _ in
                 HTTPStubsResponse(error: networkError)
             }
@@ -305,19 +328,9 @@ enum PostHogApiTests {
             #expect(server.flagsRequests.count == 1)
         }
 
-        @Test("does not retry HTTP 408 responses")
-        func doesNotRetryHTTP408() async throws {
-            try await testFlagsDoesNotRetryHTTPStatus(408)
-        }
-
-        @Test("does not retry HTTP 429 responses")
-        func doesNotRetryHTTP429() async throws {
-            try await testFlagsDoesNotRetryHTTPStatus(429)
-        }
-
-        @Test("does not retry HTTP 500 responses")
-        func doesNotRetryHTTP500() async throws {
-            try await testFlagsDoesNotRetryHTTPStatus(500)
+        @Test("does not retry HTTP error responses", arguments: [408, 429, 500])
+        func doesNotRetryHTTPErrorResponses(statusCode: Int) async throws {
+            try await testFlagsDoesNotRetryHTTPStatus(statusCode)
         }
 
         @Test("with host containing no path")

--- a/PostHogTests/PostHogApiTest.swift
+++ b/PostHogTests/PostHogApiTest.swift
@@ -63,7 +63,7 @@ enum PostHogApiTests {
             }
 
             let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost")
-            config.maxRetries = 1
+            config.featureFlagRequestMaxRetries = 1
             let sut = PostHogApi(config, flagsRetryDelay: 0.01)
 
             let resp = await getApiResponse { completion in
@@ -241,7 +241,7 @@ enum PostHogApiTests {
             }
 
             let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost")
-            config.maxRetries = 1
+            config.featureFlagRequestMaxRetries = 1
             let sut = PostHogApi(config, flagsRetryDelay: 0.01)
 
             let resp = await getApiResponse { completion in
@@ -255,6 +255,31 @@ enum PostHogApiTests {
             #expect(server.flagsRequests.count == 2)
         }
 
+        @Test("does not retry when feature flag request max retries is zero")
+        func doesNotRetryWhenFeatureFlagRequestMaxRetriesIsZero() async throws {
+            server.reset(flagsCount: 1)
+            let networkError = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut, userInfo: nil)
+            server.flagsResponseHandler = { _ in
+                HTTPStubsResponse(error: networkError)
+            }
+
+            let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost")
+            config.featureFlagRequestMaxRetries = 0
+            let sut = PostHogApi(config, flagsRetryDelay: 0.01)
+
+            let resp = await getApiResponse { completion in
+                sut.flags(distinctId: "", anonymousId: "", groups: [:], personProperties: [:]) { data, error in
+                    completion((data, error))
+                }
+            }
+
+            try await Task.sleep(nanoseconds: 50_000_000)
+
+            #expect(resp.0 == nil)
+            #expect(resp.1 != nil)
+            #expect(server.flagsRequests.count == 1)
+        }
+
         @Test("does not retry connection refused errors")
         func doesNotRetryConnectionRefused() async throws {
             server.reset(flagsCount: 1)
@@ -264,7 +289,7 @@ enum PostHogApiTests {
             }
 
             let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost")
-            config.maxRetries = 1
+            config.featureFlagRequestMaxRetries = 1
             let sut = PostHogApi(config, flagsRetryDelay: 0.01)
 
             let resp = await getApiResponse { completion in

--- a/PostHogTests/PostHogApiTest.swift
+++ b/PostHogTests/PostHogApiTest.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import OHHTTPStubs
 @testable import PostHog
 import Testing
 
@@ -53,6 +54,29 @@ enum PostHogApiTests {
             }
 
             #expect(try #require(resp)["errorsWhileComputingFlags"] as! Bool == false)
+        }
+
+        func testFlagsDoesNotRetryHTTPStatus(_ statusCode: Int) async throws {
+            server.reset(flagsCount: 1)
+            server.flagsResponseHandler = { _ in
+                HTTPStubsResponse(jsonObject: ["error": "server error"], statusCode: Int32(statusCode), headers: nil)
+            }
+
+            let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost")
+            config.maxRetries = 1
+            let sut = PostHogApi(config, flagsRetryDelay: 0.01)
+
+            let resp = await getApiResponse { completion in
+                sut.flags(distinctId: "", anonymousId: "", groups: [:], personProperties: [:]) { data, error in
+                    completion((data, error))
+                }
+            }
+
+            try await Task.sleep(nanoseconds: 50_000_000)
+
+            #expect(resp.0 == nil)
+            #expect(resp.1 != nil)
+            #expect(server.flagsRequests.count == 1)
         }
 
         func testBatchEndpoint(forHost host: String) async throws {
@@ -196,6 +220,56 @@ enum PostHogApiTests {
 
     @Suite("Test flags endpoint with different host paths")
     class TestFlagsEndpoint: BaseTestSuite {
+        @Test("retries URLSession errors before returning flags")
+        func retriesURLSessionErrors() async throws {
+            server.reset(flagsCount: 2)
+
+            var requestCount = 0
+            let requestCountLock = NSLock()
+            let networkError = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, userInfo: nil)
+            server.flagsResponseHandler = { _ in
+                requestCountLock.lock()
+                requestCount += 1
+                let currentRequestCount = requestCount
+                requestCountLock.unlock()
+
+                if currentRequestCount == 1 {
+                    return HTTPStubsResponse(error: networkError)
+                }
+
+                return HTTPStubsResponse(jsonObject: ["errorsWhileComputingFlags": false], statusCode: 200, headers: nil)
+            }
+
+            let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost")
+            config.maxRetries = 1
+            let sut = PostHogApi(config, flagsRetryDelay: 0.01)
+
+            let resp = await getApiResponse { completion in
+                sut.flags(distinctId: "", anonymousId: "", groups: [:], personProperties: [:]) { data, error in
+                    completion((data, error))
+                }
+            }
+
+            #expect(try #require(resp.0)["errorsWhileComputingFlags"] as! Bool == false)
+            #expect(resp.1 == nil)
+            #expect(server.flagsRequests.count == 2)
+        }
+
+        @Test("does not retry HTTP 408 responses")
+        func doesNotRetryHTTP408() async throws {
+            try await testFlagsDoesNotRetryHTTPStatus(408)
+        }
+
+        @Test("does not retry HTTP 429 responses")
+        func doesNotRetryHTTP429() async throws {
+            try await testFlagsDoesNotRetryHTTPStatus(429)
+        }
+
+        @Test("does not retry HTTP 500 responses")
+        func doesNotRetryHTTP500() async throws {
+            try await testFlagsDoesNotRetryHTTPStatus(500)
+        }
+
         @Test("with host containing no path")
         func testHostWithNoPath() async throws {
             try await testFlagsEndpoint(forHost: "http://localhost")

--- a/api/posthog-ios.public-api.txt
+++ b/api/posthog-ios.public-api.txt
@@ -64,6 +64,7 @@ PostHog | PostHogConfig.logs | property | @objc let logs: PostHogLogsConfig | c:
 PostHog | PostHogConfig.maxBatchSize | property | @objc var maxBatchSize: Int | c:@M@PostHog@objc(cs)PostHogConfig(py)maxBatchSize
 PostHog | PostHogConfig.maxQueueSize | property | @objc var maxQueueSize: Int | c:@M@PostHog@objc(cs)PostHogConfig(py)maxQueueSize
 PostHog | PostHogConfig.maxRetries | property | @objc var maxRetries: Int | c:@M@PostHog@objc(cs)PostHogConfig(py)maxRetries
+PostHog | PostHogConfig.featureFlagRequestMaxRetries | property | @objc var featureFlagRequestMaxRetries: Int | c:@M@PostHog@objc(cs)PostHogConfig(py)featureFlagRequestMaxRetries
 PostHog | PostHogConfig.optOut | property | @objc var optOut: Bool | c:@M@PostHog@objc(cs)PostHogConfig(py)optOut
 PostHog | PostHogConfig.personProfiles | property | @objc var personProfiles: PostHogPersonProfiles | c:@M@PostHog@objc(cs)PostHogConfig(py)personProfiles
 PostHog | PostHogConfig.preloadFeatureFlags | property | @objc var preloadFeatureFlags: Bool | c:@M@PostHog@objc(cs)PostHogConfig(py)preloadFeatureFlags

--- a/api/posthog-ios.public-api.txt
+++ b/api/posthog-ios.public-api.txt
@@ -52,6 +52,7 @@ PostHog | PostHogConfig.enableSwizzling | property | @objc var enableSwizzling: 
 PostHog | PostHogConfig.errorTrackingConfig | property | @objc let errorTrackingConfig: PostHogErrorTrackingConfig | c:@M@PostHog@objc(cs)PostHogConfig(py)errorTrackingConfig
 PostHog | PostHogConfig.evaluationContexts | property | @objc var evaluationContexts: [String]? | c:@M@PostHog@objc(cs)PostHogConfig(py)evaluationContexts
 PostHog | PostHogConfig.evaluationEnvironments | property | @objc var evaluationEnvironments: [String]? { get set } | c:@M@PostHog@objc(cs)PostHogConfig(py)evaluationEnvironments
+PostHog | PostHogConfig.featureFlagRequestMaxRetries | property | @objc var featureFlagRequestMaxRetries: Int | c:@M@PostHog@objc(cs)PostHogConfig(py)featureFlagRequestMaxRetries
 PostHog | PostHogConfig.flushAt | property | @objc var flushAt: Int | c:@M@PostHog@objc(cs)PostHogConfig(py)flushAt
 PostHog | PostHogConfig.flushIntervalSeconds | property | @objc var flushIntervalSeconds: TimeInterval | c:@M@PostHog@objc(cs)PostHogConfig(py)flushIntervalSeconds
 PostHog | PostHogConfig.getAnonymousId | property | @objc var getAnonymousId: (UUID) -> UUID | c:@M@PostHog@objc(cs)PostHogConfig(py)getAnonymousId
@@ -64,7 +65,6 @@ PostHog | PostHogConfig.logs | property | @objc let logs: PostHogLogsConfig | c:
 PostHog | PostHogConfig.maxBatchSize | property | @objc var maxBatchSize: Int | c:@M@PostHog@objc(cs)PostHogConfig(py)maxBatchSize
 PostHog | PostHogConfig.maxQueueSize | property | @objc var maxQueueSize: Int | c:@M@PostHog@objc(cs)PostHogConfig(py)maxQueueSize
 PostHog | PostHogConfig.maxRetries | property | @objc var maxRetries: Int | c:@M@PostHog@objc(cs)PostHogConfig(py)maxRetries
-PostHog | PostHogConfig.featureFlagRequestMaxRetries | property | @objc var featureFlagRequestMaxRetries: Int | c:@M@PostHog@objc(cs)PostHogConfig(py)featureFlagRequestMaxRetries
 PostHog | PostHogConfig.optOut | property | @objc var optOut: Bool | c:@M@PostHog@objc(cs)PostHogConfig(py)optOut
 PostHog | PostHogConfig.personProfiles | property | @objc var personProfiles: PostHogPersonProfiles | c:@M@PostHog@objc(cs)PostHogConfig(py)personProfiles
 PostHog | PostHogConfig.preloadFeatureFlags | property | @objc var preloadFeatureFlags: Bool | c:@M@PostHog@objc(cs)PostHogConfig(py)preloadFeatureFlags


### PR DESCRIPTION
## :bulb: Motivation and Context

`/flags/?v=2` evaluation should tolerate transient network failures, but should not retry HTTP/API responses such as 408, 429, or 5xx.

This PR adds bounded retry/backoff only for transient network failures (timeouts, connection resets/lost connections, and EOF-style failures) and keeps HTTP/API status errors terminal.

## :green_heart: How did you test it?

See the repo-specific command below.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented by pi after a maintainer-directed cross-SDK pass. The chosen policy is transient network-only retry/backoff for `/flags/?v=2`; HTTP/API statuses remain non-retryable by design. Connection-refused failures also fail fast where the platform exposes that distinction.

Tested with:

```bash
make test filter=PostHogApiTests
```

Note: build output included existing Swift warnings in unrelated queue tests; `PostHogApiTests` passed.
