### PR TITLE
fix: fall back when payload compression fails

### DIFF
--- a/.changeset/cold-buckets-gzip.md
+++ b/.changeset/cold-buckets-gzip.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': patch
+---
+
+Fall back to uncompressed uploads when local gzip compression fails.

--- a/PostHog/PostHogApi.swift
+++ b/PostHog/PostHogApi.swift
@@ -38,6 +38,8 @@ private func processUploadResponse(
 }
 
 class PostHogApi {
+    static var gzipData: (Data) throws -> Data = { try $0.gzipped() }
+
     private let config: PostHogConfig
 
     // default is 60s but we do 10s
@@ -80,7 +82,7 @@ class PostHogApi {
 
     private func requestAndPayload(url: URL, data: Data, endpointName: String) -> (URLRequest, Data) {
         do {
-            return (getURLRequest(url, gzipped: true), try data.gzipped())
+            return (getURLRequest(url, gzipped: true), try Self.gzipData(data))
         } catch {
             hedgeLog("Error gzipping the \(endpointName) body, sending it uncompressed: \(error).")
             return (getURLRequest(url), data)

--- a/PostHog/PostHogApi.swift
+++ b/PostHog/PostHogApi.swift
@@ -78,6 +78,15 @@ class PostHogApi {
         return request
     }
 
+    private func requestAndPayload(url: URL, data: Data, endpointName: String) -> (URLRequest, Data) {
+        do {
+            return (getURLRequest(url, gzipped: true), try data.gzipped())
+        } catch {
+            hedgeLog("Error gzipping the \(endpointName) body, sending it uncompressed: \(error).")
+            return (getURLRequest(url), data)
+        }
+    }
+
     private func getEndpointURL(
         _ endpoint: String,
         queryItems: URLQueryItem...,
@@ -122,8 +131,6 @@ class PostHogApi {
             return completion(PostHogUploadInfo(statusCode: nil, error: nil))
         }
 
-        let request = getURLRequest(url, gzipped: true)
-
         let toSend: [String: Any] = [
             // Wire field name remains api_key, but it carries the PostHog project token.
             "api_key": config.projectToken,
@@ -136,15 +143,9 @@ class PostHogApi {
             return completion(PostHogUploadInfo(statusCode: nil, error: nil))
         }
 
-        let gzippedPayload: Data
-        do {
-            gzippedPayload = try data.gzipped()
-        } catch {
-            hedgeLog("Error gzipping the batch body: \(error).")
-            return completion(PostHogUploadInfo(statusCode: nil, error: error))
-        }
+        let (request, payload) = requestAndPayload(url: url, data: data, endpointName: "batch")
 
-        session.uploadTask(with: request, from: gzippedPayload) { data, response, error in
+        session.uploadTask(with: request, from: payload) { data, response, error in
             processUploadResponse(endpointName: "batch", data: data, response: response, error: error, completion: completion)
         }.resume()
     }
@@ -159,8 +160,6 @@ class PostHogApi {
             event.apiKey = config.projectToken
         }
 
-        let request = getURLRequest(url, gzipped: true)
-
         let toSend = events.map { $0.toJSON() }
 
         guard let data = try? JSONSerialization.data(withJSONObject: toSend) else {
@@ -168,15 +167,9 @@ class PostHogApi {
             return completion(PostHogUploadInfo(statusCode: nil, error: nil))
         }
 
-        let gzippedPayload: Data
-        do {
-            gzippedPayload = try data.gzipped()
-        } catch {
-            hedgeLog("Error gzipping the snapshot body: \(error).")
-            return completion(PostHogUploadInfo(statusCode: nil, error: error))
-        }
+        let (request, payload) = requestAndPayload(url: url, data: data, endpointName: "snapshot")
 
-        session.uploadTask(with: request, from: gzippedPayload) { data, response, error in
+        session.uploadTask(with: request, from: payload) { data, response, error in
             processUploadResponse(endpointName: "snapshot", data: data, response: response, error: error, completion: completion)
         }.resume()
     }
@@ -198,22 +191,14 @@ class PostHogApi {
             return completion(PostHogUploadInfo(statusCode: nil, error: nil))
         }
 
-        let request = getURLRequest(url, gzipped: true)
-
         guard let data = try? JSONSerialization.data(withJSONObject: payload) else {
             hedgeLog("Error parsing the logs body")
             return completion(PostHogUploadInfo(statusCode: nil, error: nil))
         }
 
-        let gzippedPayload: Data
-        do {
-            gzippedPayload = try data.gzipped()
-        } catch {
-            hedgeLog("Error gzipping the logs body: \(error).")
-            return completion(PostHogUploadInfo(statusCode: nil, error: error))
-        }
+        let (request, uploadPayload) = requestAndPayload(url: url, data: data, endpointName: "logs")
 
-        session.uploadTask(with: request, from: gzippedPayload) { data, response, error in
+        session.uploadTask(with: request, from: uploadPayload) { data, response, error in
             processUploadResponse(endpointName: "logs", data: data, response: response, error: error, completion: completion)
         }.resume()
     }

--- a/PostHogTests/PostHogApiTest.swift
+++ b/PostHogTests/PostHogApiTest.swift
@@ -181,6 +181,21 @@ enum PostHogApiTests {
             #expect(request.value(forHTTPHeaderField: "Content-Encoding") == "gzip")
         }
 
+        @Test("/batch falls back to uncompressed when gzip fails")
+        func batchFallsBackToUncompressedWhenGzipFails() async throws {
+            let originalGzipData = PostHogApi.gzipData
+            PostHogApi.gzipData = { _ in throw NSError(domain: "PostHogApiTests", code: 1) }
+            defer { PostHogApi.gzipData = originalGzipData }
+
+            let sut = getSut(host: "http://localhost")
+            _ = await getApiResponse { completion in
+                sut.batch(events: [], completion: completion)
+            }
+            let request = try #require(server.batchRequests.first)
+            #expect(request.value(forHTTPHeaderField: "Content-Encoding") == nil)
+            #expect(server.parseRequest(request, gzip: false)?["batch"] != nil)
+        }
+
         @Test("/flags does not declare Content-Encoding")
         func flagsDoesNotDeclareGzip() async throws {
             let sut = getSut(host: "http://localhost")


### PR DESCRIPTION
## :bulb: Motivation and Context

If local gzip compression fails while preparing batch, snapshot, or logs uploads, the SDK should still send the original payload uncompressed instead of dropping the upload before the request is sent.

This changes the upload request construction to use gzip when it succeeds, and to retry the same local send path without `Content-Encoding: gzip` when `Data.gzipped()` throws.

## :green_heart: How did you test it?

- `swift build`
- Also tried `swift test`; it currently fails on existing `PostHogIntegrationInstallationTest` compile errors unrelated to this change (`clearInstalls`, `getAppLifeCycleIntegration`, `getScreenViewIntegration`).

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented as part of a cross-SDK consistency pass for client-side compression failure fallback. Kept the change scoped to request payload selection for existing upload endpoints.
