### PR TITLE
fix: generate lowercase UUID strings

### DIFF
--- a/.changeset/lowercase-ios-uuids.md
+++ b/.changeset/lowercase-ios-uuids.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': patch
+---
+
+Generate lowercase UUID strings for SDK-created event, anonymous, session, and queue identifiers.

--- a/PostHog/Models/PostHogEvent.swift
+++ b/PostHog/Models/PostHogEvent.swift
@@ -69,7 +69,7 @@ import Foundation
         guard let distinctId = (json["distinct_id"] as? String) ?? (properties["distinct_id"] as? String) else { return nil }
 
         // `message_id` is deprecated and only accepted for backwards compatibility with legacy persisted events.
-        let uuid = ((json["uuid"] as? String) ?? (json["message_id"] as? String)) ?? UUID.v7().uuidString
+        let uuid = ((json["uuid"] as? String) ?? (json["message_id"] as? String)) ?? UUID.v7String()
         let uuidObj = UUID(uuidString: uuid) ?? UUID.v7()
 
         // Wire field name remains api_key, but it carries the PostHog project token.
@@ -91,7 +91,7 @@ import Foundation
             "distinct_id": distinctId,
             "properties": properties,
             "timestamp": toISO8601String(timestamp),
-            "uuid": uuid.uuidString,
+            "uuid": uuid.postHogUuidString,
         ]
 
         if let projectToken = apiKey {

--- a/PostHog/PostHogFileBackedQueue.swift
+++ b/PostHog/PostHogFileBackedQueue.swift
@@ -72,7 +72,7 @@ class PostHogFileBackedQueue {
 
     func add(_ contents: Data) {
         do {
-            let filename = UUID.v7().uuidString
+            let filename = UUID.v7String()
             try contents.write(to: queue.appendingPathComponent(filename))
             itemsLock.withLock { items.append(filename) }
         } catch {

--- a/PostHog/PostHogSessionManager.swift
+++ b/PostHog/PostHogSessionManager.swift
@@ -216,7 +216,7 @@ import Foundation
             }
         }
 
-        let newSessionId = UUID.v7().uuidString
+        let newSessionId = UUID.v7String()
         setSessionIdInternal(newSessionId, at: timestamp, reason: reason)
         return newSessionId
     }

--- a/PostHog/PostHogStorageManager.swift
+++ b/PostHog/PostHogStorageManager.swift
@@ -44,7 +44,7 @@ public class PostHogStorageManager {
 
                 if anonymousId == nil {
                     let uuid = UUID.v7()
-                    anonymousId = idGen(uuid).uuidString
+                    anonymousId = idGen(uuid).postHogUuidString
                     setAnonId(anonymousId ?? "")
                 } else {
                     // update the memory value

--- a/PostHog/Replay/PostHogReplayBufferQueue.swift
+++ b/PostHog/Replay/PostHogReplayBufferQueue.swift
@@ -49,7 +49,7 @@ class PostHogReplayBufferQueue {
 
     func add(_ contents: Data) {
         do {
-            let filename = UUID.v7().uuidString
+            let filename = UUID.v7String()
             try contents.write(to: queue.appendingPathComponent(filename))
             itemsLock.withLock { items.append(filename) }
         } catch {

--- a/PostHog/Utils/UUIDUtils.swift
+++ b/PostHog/Utils/UUIDUtils.swift
@@ -14,4 +14,12 @@ extension UUID {
     static func v7() -> Self {
         TimeBasedEpochGenerator.shared.v7()
     }
+
+    static func v7String() -> String {
+        v7().postHogUuidString
+    }
+
+    var postHogUuidString: String {
+        uuidString.lowercased()
+    }
 }

--- a/PostHogTests/PostHogStorageManagerTest.swift
+++ b/PostHogTests/PostHogStorageManagerTest.swift
@@ -54,7 +54,7 @@ class PostHogStorageManagerTest: QuickSpec {
             config.getAnonymousId = { _ in fixedUuid }
             let sut = self.getSut(config)
             let anonymousId = sut.getAnonymousId()
-            expect(anonymousId) == fixedUuid.uuidString
+            expect(anonymousId) == fixedUuid.postHogUuidString
 
             sut.reset(true)
         }

--- a/PostHogTests/UUIDTest.swift
+++ b/PostHogTests/UUIDTest.swift
@@ -41,6 +41,19 @@ class UUIDTest: QuickSpec {
             expect(uuid.leastSignificantBits) == -7_503_087_083_654_801_332
         }
 
+        it("generates lowercase UUID strings") {
+            let uuidString = UUID.v7String()
+
+            expect(uuidString).to(match("^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$"))
+            expect(uuidString).to(equal(uuidString.lowercased()))
+        }
+
+        it("formats UUID strings as lowercase") {
+            let uuid = UUID(uuidString: "82CADE9D-1A41-744E-8462-1CDCFDB5B747")!
+
+            expect(uuid.postHogUuidString).to(equal("82cade9d-1a41-744e-8462-1cdcfdb5b747"))
+        }
+
         it("test sorted and duplicated") {
             let count = 10000
 

--- a/PostHogTests/UUIDTest.swift
+++ b/PostHogTests/UUIDTest.swift
@@ -45,13 +45,29 @@ class UUIDTest: QuickSpec {
             let uuidString = UUID.v7String()
 
             expect(uuidString).to(match("^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$"))
-            expect(uuidString).to(equal(uuidString.lowercased()))
         }
 
         it("formats UUID strings as lowercase") {
-            let uuid = UUID(uuidString: "82CADE9D-1A41-744E-8462-1CDCFDB5B747")!
+            let cases = [
+                (
+                    input: "82CADE9D-1A41-744E-8462-1CDCFDB5B747",
+                    expected: "82cade9d-1a41-744e-8462-1cdcfdb5b747"
+                ),
+                (
+                    input: "82cade9d-1a41-744e-8462-1cdcfdb5b747",
+                    expected: "82cade9d-1a41-744e-8462-1cdcfdb5b747"
+                ),
+                (
+                    input: "82CaDe9D-1a41-744e-8462-1cDcFdB5B747",
+                    expected: "82cade9d-1a41-744e-8462-1cdcfdb5b747"
+                ),
+            ]
 
-            expect(uuid.postHogUuidString).to(equal("82cade9d-1a41-744e-8462-1cdcfdb5b747"))
+            for testCase in cases {
+                let uuid = UUID(uuidString: testCase.input)!
+
+                expect(uuid.postHogUuidString).to(equal(testCase.expected))
+            }
         }
 
         it("test sorted and duplicated") {


### PR DESCRIPTION
## :bulb: Motivation and Context

PostHog/posthog#46111 surfaced that UUID casing differs across SDKs. The other SDK-generated UUID strings are lowercase, so this normalizes iOS-generated UUID strings to lowercase for consistency across SDKs.

This keeps UUID values valid while avoiding iOS-specific uppercase UUID strings in generated event UUIDs, anonymous IDs, session IDs, and queue filenames.

## :green_heart: How did you test it?

- `xcodebuildmcp swift-package build --package-path . --target-name PostHog --output text` ✅
- `swiftformat PostHog/Utils/UUIDUtils.swift PostHog/PostHogStorageManager.swift PostHog/PostHogFileBackedQueue.swift PostHog/PostHogSessionManager.swift PostHog/Models/PostHogEvent.swift PostHog/Replay/PostHogReplayBufferQueue.swift PostHogTests/UUIDTest.swift PostHogTests/PostHogStorageManagerTest.swift --lint --swiftversion 5.3` ✅
- `xcodebuildmcp swift-package test --package-path . --filter UUIDTest --output text` ⚠️ did not complete because the package test target currently fails to compile unrelated survey tests (`PostHogSurveyIntegration` / `toDisplaySurvey` missing in `PostHogSurveysTest.swift`).

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented via Pi in a dedicated git worktree. The change centralizes lowercase UUID string formatting in `UUIDUtils`, then uses it for SDK-generated event UUIDs, anonymous IDs, session IDs, and queue/replay filenames. Validation used SwiftPM build and SwiftFormat lint; the focused SwiftPM test command was blocked by unrelated existing survey test compile errors.
