### PR TITLE
feat: add requestHeaders config option

### DIFF
--- a/.changeset/request-headers.md
+++ b/.changeset/request-headers.md
@@ -1,5 +1,5 @@
 ---
-'posthog-ios': patch
+'posthog-ios': minor
 ---
 
 Add `requestHeaders` config option to send custom headers (e.g. `Authorization`) with every request to the PostHog API. Useful for reverse-proxy setups that require authentication.

--- a/.changeset/request-headers.md
+++ b/.changeset/request-headers.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': patch
+---
+
+Add `requestHeaders` config option to send custom headers (e.g. `Authorization`) with every request to the PostHog API. Useful for reverse-proxy setups that require authentication.

--- a/PostHog/PostHogApi.swift
+++ b/PostHog/PostHogApi.swift
@@ -42,8 +42,7 @@ class PostHogApi {
 
     private let config: PostHogConfig
 
-    /// Snapshot taken at init so the per-request and redirect paths stay consistent even if the
-    /// caller mutates `config.requestHeaders` afterwards.
+    /// Snapshot at init; treated as immutable after setup.
     private let customRequestHeaders: [String: String]
 
     // default is 60s but we do 10s
@@ -94,8 +93,7 @@ class PostHogApi {
         return request
     }
 
-    /// Applies the custom headers to requests for the configured host. SDK-set headers take
-    /// precedence, and requests to rewritten hosts (e.g. the static-config CDN) are skipped.
+    /// Adds custom headers to requests for the configured host, skipping SDK-managed keys.
     private func applyCustomHeaders(_ request: inout URLRequest) {
         guard !customRequestHeaders.isEmpty, request.url?.host == config.host.host else { return }
         for (key, value) in customRequestHeaders
@@ -106,9 +104,7 @@ class PostHogApi {
         }
     }
 
-    /// Headers the SDK manages itself; custom values for these are ignored. Compared
-    /// case-insensitively since HTTP header names are case-insensitive. `Content-Type`,
-    /// `User-Agent`, and `Accept-Encoding` are set on the session; `Content-Encoding` per request.
+    /// SDK-managed headers that custom values can't override (compared lowercase).
     private static let reservedHeaderKeys: Set<String> = [
         "content-type", "user-agent", "accept-encoding", "content-encoding",
     ]

--- a/PostHog/PostHogApi.swift
+++ b/PostHog/PostHogApi.swift
@@ -98,10 +98,20 @@ class PostHogApi {
     /// precedence, and requests to rewritten hosts (e.g. the static-config CDN) are skipped.
     private func applyCustomHeaders(_ request: inout URLRequest) {
         guard !customRequestHeaders.isEmpty, request.url?.host == config.host.host else { return }
-        for (key, value) in customRequestHeaders where request.value(forHTTPHeaderField: key) == nil {
+        for (key, value) in customRequestHeaders
+            where request.value(forHTTPHeaderField: key) == nil
+            && !Self.reservedHeaderKeys.contains(key.lowercased())
+        {
             request.setValue(value, forHTTPHeaderField: key)
         }
     }
+
+    /// Headers the SDK manages itself; custom values for these are ignored. Compared
+    /// case-insensitively since HTTP header names are case-insensitive. `Content-Type`,
+    /// `User-Agent`, and `Accept-Encoding` are set on the session; `Content-Encoding` per request.
+    private static let reservedHeaderKeys: Set<String> = [
+        "content-type", "user-agent", "accept-encoding", "content-encoding",
+    ]
 
     private func requestAndPayload(url: URL, data: Data, endpointName: String) -> (URLRequest, Data) {
         do {

--- a/PostHog/PostHogApi.swift
+++ b/PostHog/PostHogApi.swift
@@ -76,10 +76,20 @@ class PostHogApi {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.timeoutInterval = defaultTimeout
+        applyCustomHeaders(&request)
         if gzipped {
             request.setValue("gzip", forHTTPHeaderField: "Content-Encoding")
         }
         return request
+    }
+
+    /// Applies the caller-supplied `config.requestHeaders` (e.g. an `Authorization` header for a
+    /// reverse proxy) to every request the SDK sends.
+    private func applyCustomHeaders(_ request: inout URLRequest) {
+        guard let requestHeaders = config.requestHeaders else { return }
+        for (key, value) in requestHeaders {
+            request.setValue(value, forHTTPHeaderField: key)
+        }
     }
 
     private func requestAndPayload(url: URL, data: Data, endpointName: String) -> (URLRequest, Data) {
@@ -126,6 +136,7 @@ class PostHogApi {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.timeoutInterval = defaultTimeout
+        applyCustomHeaders(&request)
         return request
     }
 

--- a/PostHog/PostHogApi.swift
+++ b/PostHog/PostHogApi.swift
@@ -67,7 +67,13 @@ class PostHogApi {
         headers["User-Agent"] = "\(postHogSdkName)/\(postHogVersion)"
         headers["Accept-Encoding"] = "gzip"
         sessionConfig.httpAdditionalHeaders = headers
-        session = URLSession(configuration: sessionConfig)
+        // Strip custom headers on cross-host redirects so they don't leak to another origin.
+        if let requestHeaders = config.requestHeaders, !requestHeaders.isEmpty {
+            let stripper = PostHogRedirectHeaderStripper(allowedHost: config.host.host, headerKeys: Array(requestHeaders.keys))
+            session = URLSession(configuration: sessionConfig, delegate: stripper, delegateQueue: nil)
+        } else {
+            session = URLSession(configuration: sessionConfig)
+        }
     }
 
     /// `gzipped: true` adds `Content-Encoding: gzip` for upload endpoints
@@ -83,11 +89,12 @@ class PostHogApi {
         return request
     }
 
-    /// Applies the caller-supplied `config.requestHeaders` (e.g. an `Authorization` header for a
-    /// reverse proxy) to every request the SDK sends.
+    /// Applies `config.requestHeaders` to requests for the configured host. SDK-set headers take
+    /// precedence, and requests to rewritten hosts (e.g. the static-config CDN) are skipped.
     private func applyCustomHeaders(_ request: inout URLRequest) {
         guard let requestHeaders = config.requestHeaders else { return }
-        for (key, value) in requestHeaders {
+        guard request.url?.host == config.host.host else { return }
+        for (key, value) in requestHeaders where request.value(forHTTPHeaderField: key) == nil {
             request.setValue(value, forHTTPHeaderField: key)
         }
     }
@@ -402,4 +409,33 @@ extension PostHogApi {
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         return decoder
     }()
+}
+
+/// Strips custom headers on redirects that leave the configured host.
+private final class PostHogRedirectHeaderStripper: NSObject, URLSessionTaskDelegate {
+    private let allowedHost: String?
+    private let headerKeys: [String]
+
+    init(allowedHost: String?, headerKeys: [String]) {
+        self.allowedHost = allowedHost
+        self.headerKeys = headerKeys
+    }
+
+    func urlSession(
+        _: URLSession,
+        task _: URLSessionTask,
+        willPerformHTTPRedirection _: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        guard request.url?.host != allowedHost else {
+            completionHandler(request)
+            return
+        }
+        var redirected = request
+        for key in headerKeys {
+            redirected.setValue(nil, forHTTPHeaderField: key)
+        }
+        completionHandler(redirected)
+    }
 }

--- a/PostHog/PostHogApi.swift
+++ b/PostHog/PostHogApi.swift
@@ -42,6 +42,10 @@ class PostHogApi {
 
     private let config: PostHogConfig
 
+    /// Snapshot taken at init so the per-request and redirect paths stay consistent even if the
+    /// caller mutates `config.requestHeaders` afterwards.
+    private let customRequestHeaders: [String: String]
+
     // default is 60s but we do 10s
     private let defaultTimeout: TimeInterval = 10
 
@@ -53,6 +57,7 @@ class PostHogApi {
 
     init(_ config: PostHogConfig) {
         self.config = config
+        customRequestHeaders = config.requestHeaders ?? [:]
 
         // Copy first so SDK mutations don't leak back to the caller's object.
         let sessionConfig = (config.urlSessionConfiguration?.copy() as? URLSessionConfiguration)
@@ -68,11 +73,11 @@ class PostHogApi {
         headers["Accept-Encoding"] = "gzip"
         sessionConfig.httpAdditionalHeaders = headers
         // Strip custom headers on cross-host redirects so they don't leak to another origin.
-        if let requestHeaders = config.requestHeaders, !requestHeaders.isEmpty {
-            let stripper = PostHogRedirectHeaderStripper(allowedHost: config.host.host, headerKeys: Array(requestHeaders.keys))
-            session = URLSession(configuration: sessionConfig, delegate: stripper, delegateQueue: nil)
-        } else {
+        if customRequestHeaders.isEmpty {
             session = URLSession(configuration: sessionConfig)
+        } else {
+            let stripper = PostHogRedirectHeaderStripper(allowedHost: config.host.host, headerKeys: Array(customRequestHeaders.keys))
+            session = URLSession(configuration: sessionConfig, delegate: stripper, delegateQueue: nil)
         }
     }
 
@@ -89,12 +94,11 @@ class PostHogApi {
         return request
     }
 
-    /// Applies `config.requestHeaders` to requests for the configured host. SDK-set headers take
+    /// Applies the custom headers to requests for the configured host. SDK-set headers take
     /// precedence, and requests to rewritten hosts (e.g. the static-config CDN) are skipped.
     private func applyCustomHeaders(_ request: inout URLRequest) {
-        guard let requestHeaders = config.requestHeaders else { return }
-        guard request.url?.host == config.host.host else { return }
-        for (key, value) in requestHeaders where request.value(forHTTPHeaderField: key) == nil {
+        guard !customRequestHeaders.isEmpty, request.url?.host == config.host.host else { return }
+        for (key, value) in customRequestHeaders where request.value(forHTTPHeaderField: key) == nil {
             request.setValue(value, forHTTPHeaderField: key)
         }
     }

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -356,6 +356,7 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
 
     /// Custom headers to send with every request to the PostHog API.
     /// Useful for reverse-proxy setups that require authentication, e.g. an `Authorization` header.
+    /// Read once when the SDK is set up; changes after setup are ignored.
     @objc public var requestHeaders: [String: String]?
 
     // only internal

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -354,6 +354,10 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
     /// Useful for testing, proxying, or custom network configurations
     @objc public var urlSessionConfiguration: URLSessionConfiguration?
 
+    /// Custom headers to send with every request to the PostHog API.
+    /// Useful for reverse-proxy setups that require authentication, e.g. an `Authorization` header.
+    @objc public var requestHeaders: [String: String]?
+
     // only internal
     var disableReachabilityForTesting: Bool = false
     var disableQueueTimerForTesting: Bool = false

--- a/PostHogTests/PostHogApiTest.swift
+++ b/PostHogTests/PostHogApiTest.swift
@@ -273,6 +273,17 @@ enum PostHogApiTests {
             let request = try #require(server.batchRequests.first)
             #expect(request.value(forHTTPHeaderField: "Authorization") == nil)
         }
+
+        @Test("does not let custom headers override SDK-managed headers")
+        func doesNotOverrideSDKManagedHeaders() async throws {
+            let sut = getSut(host: "http://localhost", requestHeaders: ["content-type": "text/plain", "User-Agent": "evil"])
+            _ = await getApiResponse { completion in
+                sut.batch(events: [], completion: completion)
+            }
+            let request = try #require(server.batchRequests.first)
+            #expect(request.value(forHTTPHeaderField: "Content-Type") != "text/plain")
+            #expect(request.value(forHTTPHeaderField: "User-Agent") != "evil")
+        }
     }
 
     @Suite("Custom request headers host scoping", .serialized)

--- a/PostHogTests/PostHogApiTest.swift
+++ b/PostHogTests/PostHogApiTest.swift
@@ -233,6 +233,49 @@ enum PostHogApiTests {
         }
     }
 
+    /// Custom `config.requestHeaders` (e.g. an Authorization header for a reverse
+    /// proxy) must be attached to every request the SDK sends.
+    @Suite("Custom request headers")
+    class TestCustomRequestHeaders: BaseTestSuite {
+        func getSut(host: String, requestHeaders: [String: String]?) -> PostHogApi {
+            let config = PostHogConfig(projectToken: "test_project_token", host: host)
+            config.requestHeaders = requestHeaders
+            return PostHogApi(config)
+        }
+
+        @Test("attaches custom headers to /batch requests")
+        func attachesToBatch() async throws {
+            let sut = getSut(host: "http://localhost", requestHeaders: ["Authorization": "Bearer test-jwt"])
+            _ = await getApiResponse { completion in
+                sut.batch(events: [], completion: completion)
+            }
+            let request = try #require(server.batchRequests.first)
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer test-jwt")
+        }
+
+        @Test("attaches custom headers to /flags requests")
+        func attachesToFlags() async throws {
+            let sut = getSut(host: "http://localhost", requestHeaders: ["Authorization": "Bearer test-jwt"])
+            _ = await getApiResponse { completion in
+                sut.flags(distinctId: "x", anonymousId: nil, groups: [:], personProperties: [:]) { data, _ in
+                    completion(data)
+                }
+            }
+            let request = try #require(server.flagsRequests.first)
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer test-jwt")
+        }
+
+        @Test("does not attach an Authorization header when none is configured")
+        func noHeaderWhenUnset() async throws {
+            let sut = getSut(host: "http://localhost", requestHeaders: nil)
+            _ = await getApiResponse { completion in
+                sut.batch(events: [], completion: completion)
+            }
+            let request = try #require(server.batchRequests.first)
+            #expect(request.value(forHTTPHeaderField: "Authorization") == nil)
+        }
+    }
+
     @Suite("Test flags endpoint with different host paths")
     class TestFlagsEndpoint: BaseTestSuite {
         @Test("feature flag retry delay starts at 300ms and doubles")

--- a/PostHogTests/PostHogApiTest.swift
+++ b/PostHogTests/PostHogApiTest.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import OHHTTPStubs
+import OHHTTPStubsSwift
 @testable import PostHog
 import Testing
 
@@ -233,8 +234,6 @@ enum PostHogApiTests {
         }
     }
 
-    /// Custom `config.requestHeaders` (e.g. an Authorization header for a reverse
-    /// proxy) must be attached to every request the SDK sends.
     @Suite("Custom request headers")
     class TestCustomRequestHeaders: BaseTestSuite {
         func getSut(host: String, requestHeaders: [String: String]?) -> PostHogApi {
@@ -273,6 +272,53 @@ enum PostHogApiTests {
             }
             let request = try #require(server.batchRequests.first)
             #expect(request.value(forHTTPHeaderField: "Authorization") == nil)
+        }
+    }
+
+    @Suite("Custom request headers host scoping", .serialized)
+    final class TestCustomRequestHeadersHostScoping {
+        init() {
+            HTTPStubs.removeAllStubs()
+        }
+        deinit { HTTPStubs.removeAllStubs() }
+
+        @Test("does not send custom headers to the rewritten static-config host")
+        func skipsRewrittenConfigHost() async throws {
+            let captured = CapturedRequestBox()
+            stub(condition: isHost("us-assets.i.posthog.com")) { request in
+                captured.set(request)
+                return HTTPStubsResponse(jsonObject: [:], statusCode: 200, headers: nil)
+            }
+            let config = PostHogConfig(projectToken: "test_project_token", host: "https://us.i.posthog.com")
+            config.requestHeaders = ["Authorization": "Bearer test-jwt"]
+            let sut = PostHogApi(config)
+
+            await withCheckedContinuation { continuation in
+                sut.remoteConfig { _, _ in continuation.resume() }
+            }
+
+            #expect(captured.request?.value(forHTTPHeaderField: "Authorization") == nil)
+        }
+
+        @Test("strips custom headers on a redirect to a different host")
+        func stripsHeadersOnCrossHostRedirect() async throws {
+            let captured = CapturedRequestBox()
+            stub(condition: isHost("proxy.example.com")) { _ in
+                HTTPStubsResponse(data: Data(), statusCode: 307, headers: ["Location": "https://other.example.com/flags"])
+            }
+            stub(condition: isHost("other.example.com")) { request in
+                captured.set(request)
+                return HTTPStubsResponse(jsonObject: ["featureFlags": [:]], statusCode: 200, headers: nil)
+            }
+            let config = PostHogConfig(projectToken: "test_project_token", host: "https://proxy.example.com")
+            config.requestHeaders = ["Authorization": "Bearer test-jwt"]
+            let sut = PostHogApi(config)
+
+            await withCheckedContinuation { continuation in
+                sut.flags(distinctId: "x", anonymousId: nil, groups: [:], personProperties: [:]) { _, _ in continuation.resume() }
+            }
+
+            #expect(captured.request?.value(forHTTPHeaderField: "Authorization") == nil)
         }
     }
 
@@ -432,5 +478,18 @@ enum PostHogApiTests {
         func testHostWithPortNumberAndTrailingSlash() async throws {
             try await testFlagsEndpoint(forHost: "http://localhost:9000/api/v1/")
         }
+    }
+}
+
+private final class CapturedRequestBox {
+    private let lock = NSLock()
+    private var stored: URLRequest?
+
+    var request: URLRequest? {
+        lock.withLock { stored }
+    }
+
+    func set(_ request: URLRequest) {
+        lock.withLock { stored = request }
     }
 }

--- a/api/posthog-ios.public-api.txt
+++ b/api/posthog-ios.public-api.txt
@@ -72,6 +72,7 @@ PostHog | PostHogConfig.projectToken | property | @objc let projectToken: String
 PostHog | PostHogConfig.propertiesSanitizer | property | @objc var propertiesSanitizer: (any PostHogPropertiesSanitizer)? { get set } | c:@M@PostHog@objc(cs)PostHogConfig(py)propertiesSanitizer
 PostHog | PostHogConfig.rageClickConfig | property | @objc let rageClickConfig: PostHogRageClickConfig | c:@M@PostHog@objc(cs)PostHogConfig(py)rageClickConfig
 PostHog | PostHogConfig.remoteConfig | property | @objc var remoteConfig: Bool { get set } | c:@M@PostHog@objc(cs)PostHogConfig(py)remoteConfig
+PostHog | PostHogConfig.requestHeaders | property | @objc var requestHeaders: [String : String]? | c:@M@PostHog@objc(cs)PostHogConfig(py)requestHeaders
 PostHog | PostHogConfig.reuseAnonymousId | property | @objc var reuseAnonymousId: Bool | c:@M@PostHog@objc(cs)PostHogConfig(py)reuseAnonymousId
 PostHog | PostHogConfig.sendFeatureFlagEvent | property | @objc var sendFeatureFlagEvent: Bool | c:@M@PostHog@objc(cs)PostHogConfig(py)sendFeatureFlagEvent
 PostHog | PostHogConfig.sessionReplay | property | @objc var sessionReplay: Bool | c:@M@PostHog@objc(cs)PostHogConfig(py)sessionReplay


### PR DESCRIPTION
## :bulb: Motivation and Context

Part of the cross-SDK work for PostHog/posthog-js#2132 (no way to include `Authorization` headers in reverse-proxy setups). React Native session replay and native crash uploads are sent directly by this native SDK, so they bypass any JS-layer header support. This adds first-class custom-header support to the iOS SDK so those (and all other) requests can carry an `Authorization` header for an authenticated reverse proxy.

## :green_heart: How did you test it?

- Added a `Custom request headers` suite in `PostHogApiTest` asserting the header reaches `/batch` and `/flags`, and is absent when unset (uses the existing `MockPostHogServer` / OHHTTPStubs harness, same pattern as the Content-Encoding tests).
- Verified the SDK compiles (`xcrun swift build --arch arm64`). The simulator test run couldn't execute from my local git worktree due to the project's local SPM package path resolving outside the worktree; CI runs the suite on-simulator.
- `swiftformat --lint` and `swiftlint` clean on the changed files.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @ioannisj / @marandaneto while wiring up `requestHeaders` for React Native — the native SDK needs to honor the header for replay/crash uploads. Chose to apply the headers per-request in `PostHogApi` (via a small `applyCustomHeaders` helper on each `URLRequest`) rather than via `URLSessionConfiguration.httpAdditionalHeaders`, because session-level headers are not observable through OHHTTPStubs and the per-request approach is both testable and keeps SDK-set headers (gzip `Content-Encoding`) applied last. Tool used: Claude Code.

---

Related: PostHog/posthog-js#2132
