### PR TITLE
ci: Align SDK compliance suite and type

### DIFF
--- a/.github/workflows/sdk-compliance.yml
+++ b/.github/workflows/sdk-compliance.yml
@@ -98,7 +98,7 @@ jobs:
           # Run tests via docker-compose
           # Test harness connects to adapter via host.docker.internal:8080
           # Mock server runs in Docker, accessible via localhost:8081
-          REPORT_DIR=${{ github.workspace }}/report docker-compose up --abort-on-container-exit
+          REPORT_DIR=${{ github.workspace }}/report docker-compose up --abort-on-container-exit --exit-code-from test-harness
 
           # Capture exit code
           TEST_EXIT_CODE=$?

--- a/sdk_compliance_adapter/docker-compose.yml
+++ b/sdk_compliance_adapter/docker-compose.yml
@@ -16,7 +16,7 @@ version: '3.8'
 services:
   test-harness:
     image: ${TEST_HARNESS_IMAGE:-ghcr.io/posthog/sdk-test-harness:0.8.0}
-    command: ["run", "--adapter-url", "http://host.docker.internal:8080", "--mock-url", "http://host.docker.internal:8081", "--sdk-type", "server", "--output", "text", "--report", "/report/sdk-compliance-report.md", "--debug"]
+    command: ["run", "--adapter-url", "http://host.docker.internal:8080", "--mock-url", "http://host.docker.internal:8081", "--sdk-type", "client", "--suite", "capture", "--output", "text", "--report", "/report/sdk-compliance-report.md", "--debug"]
     ports:
       - "8081:8081"
     volumes:


### PR DESCRIPTION
## Problem

SDK compliance workflows need explicit harness suite/sdk-type selection and configurable blocking behavior so CI only runs the intended contract checks.

## Changes

- Run the custom hybrid compliance workflow against the capture v0 suite as a client SDK.
- Keep the job non-blocking for now.
- Use `--exit-code-from test-harness` so the captured test-harness container status is accurate inside the non-blocking step.

## Testing

- Parsed workflow YAML.
- Ran `docker compose config` for the adapter compose file.
- Ran `git diff --check`.

## Release / changeset

No SDK package changeset: CI/local compliance configuration only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi using dedicated git worktrees. The change was requested to align SDK compliance harness setup across SDK repositories while keeping non-ready SDKs non-blocking.
