### PR TITLE
ci: update SDK harness to 0.9.0

### DIFF
--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -17,7 +17,7 @@ import Foundation
     import WatchKit
 #endif
 
-// SDK compliance harness 0.8.0 validates retry timing against this base cadence.
+// SDK compliance harness 0.9.0 validates retry timing against this base cadence.
 let retryDelay = 1.0
 let maxRetryDelay = 30.0
 

--- a/sdk_compliance_adapter/docker-compose.yml
+++ b/sdk_compliance_adapter/docker-compose.yml
@@ -15,7 +15,7 @@ version: '3.8'
 
 services:
   test-harness:
-    image: ${TEST_HARNESS_IMAGE:-ghcr.io/posthog/sdk-test-harness:0.8.0}
+    image: ${TEST_HARNESS_IMAGE:-ghcr.io/posthog/sdk-test-harness:0.9.0}
     command: ["run", "--adapter-url", "http://host.docker.internal:8080", "--mock-url", "http://host.docker.internal:8081", "--sdk-type", "server", "--output", "text", "--report", "/report/sdk-compliance-report.md", "--debug"]
     ports:
       - "8081:8081"


### PR DESCRIPTION
## :bulb: Motivation and Context

Update the iOS SDK's local compliance Docker Compose setup to use posthog-sdk-test-harness 0.9.0 and keep the nearby compliance-harness version comment in sync.

## :green_heart: How did you test it?

- Confirmed the PR branch has no remaining references to the previous `0.8.0` harness image/version.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Updated SDK compliance harness references only. This repo uses a custom macOS/iOS compliance workflow, so there is no reusable workflow ref to pin here.
