### PR TITLE
ci: suppress Semgrep secrets inherit finding

### DIFF
--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -17,4 +17,4 @@ jobs:
             pr_number: ${{ github.event.pull_request.number }}
             pr_node_id: ${{ github.event.pull_request.node_id }}
             is_draft: ${{ github.event.pull_request.draft }}
-        secrets: inherit
+        secrets: inherit # nosemgrep: yaml.github-actions.security.secrets-inherit.secrets-inherit -- reusable workflow requires inherited secrets


### PR DESCRIPTION
## :bulb: Motivation and Context

Semgrep's GitHub Actions rules now flag `secrets: inherit` in the feature flags project-board caller workflow. This matches the fix used in PostHog/posthog-js#4034: keep inheriting secrets for the reusable workflow, but document and suppress this specific Semgrep finding inline.

## :green_heart: How did you test it?

Ran Semgrep's GitHub Actions rules against the changed workflow file:

```bash
docker run --rm -v "$PWD:/src" -w /src semgrep/semgrep:1.163.0@sha256:7cad2bc2d1e44f87f0bf4be6d1fa23aa90fb72015bebc89fb91385d813987a03 semgrep --config p/github-actions --error --metrics=off .github/workflows/call-flags-project-board.yml
```

Result: 0 findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A coding agent investigated the intermittent Semgrep failure, compared with the merged posthog-js fix, and applied the same inline `nosemgrep` suppression because the reusable workflow currently relies on inherited secrets.
