### PR TITLE
ci: skip heavy CI for non-impacting changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,14 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  detect-markdown-only:
-    uses: PostHog/.github/.github/workflows/detect-markdown-only.yml@ec25337d9fae0100622cbfea1bd5bd88284ac10b
+  detect-non-impacting-changes:
+    uses: ./.github/workflows/detect-non-impacting-changes.yml
     permissions:
+      contents: read
       pull-requests: read
 
   build:
-    needs: detect-markdown-only
+    needs: detect-non-impacting-changes
     runs-on: macos-15-xlarge
     strategy:
       fail-fast: false
@@ -39,22 +40,22 @@ jobs:
             command: set -o pipefail && xcrun xcodebuild clean build -scheme PostHog -destination generic/platform=xros | xcpretty
     name: Build SDK (${{ matrix.platform }})
     steps:
-      - name: Complete markdown-only PR check
-        if: needs.detect-markdown-only.outputs.markdown_only == 'true'
-        run: echo "Only Markdown files changed; no additional work is required for this check."
+      - name: Complete non-impacting PR check
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy == 'true'
+        run: echo "Only non-impacting files changed; no additional work is required for this check."
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
         with:
           xcode-version: latest-stable
       - name: Build SDK (${{ matrix.platform }})
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
         run: ${{ matrix.command }}
 
   public-api:
-    needs: detect-markdown-only
-    if: github.event_name == 'pull_request' && needs.detect-markdown-only.outputs.markdown_only != 'true'
+    needs: detect-non-impacting-changes
+    if: github.event_name == 'pull_request' && needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
     runs-on: macos-15
     name: Public API snapshot
     steps:
@@ -66,34 +67,34 @@ jobs:
         run: make apiCheck
 
   build-sdk-swift53-compat:
-    needs: detect-markdown-only
+    needs: detect-non-impacting-changes
     runs-on: macos-14-xlarge
     name: Build SDK (Swift 5 compatibility on Xcode 15.4 with CocoaPods)
     steps:
-      - name: Complete markdown-only PR check
-        if: needs.detect-markdown-only.outputs.markdown_only == 'true'
-        run: echo "Only Markdown files changed; no additional work is required for this check."
+      - name: Complete non-impacting PR check
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy == 'true'
+        run: echo "Only non-impacting files changed; no additional work is required for this check."
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
         with:
           xcode-version: '15.4'
       - name: Print toolchain versions
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
         run: |
           xcodebuild -version
           xcrun swift --version
       - name: Install CocoaPods
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
         run: gem install cocoapods
       - name: Install Pods
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
         run: |
           cd PostHogExampleWithPods
           USE_FRAMEWORKS=static pod install
       - name: Build SDK with Swift 5 language mode via CocoaPods
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
         run: |
           set -o pipefail
           cd PostHogExampleWithPods
@@ -104,8 +105,8 @@ jobs:
             SWIFT_VERSION=5 | xcpretty
 
   podspec-lint:
-    needs: detect-markdown-only
-    if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+    needs: detect-non-impacting-changes
+    if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
     runs-on: macos-15
     name: CocoaPods package lint
     steps:

--- a/.github/workflows/detect-non-impacting-changes.yml
+++ b/.github/workflows/detect-non-impacting-changes.yml
@@ -1,0 +1,109 @@
+name: Detect non-impacting changes
+
+on:
+  workflow_call:
+    outputs:
+      skip_heavy:
+        description: "Whether required heavy CI work can be skipped for this PR"
+        value: ${{ jobs.classify.outputs.skip_heavy }}
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    outputs:
+      skip_heavy: ${{ steps.classify.outputs.skip_heavy }}
+    steps:
+      - name: Classify changed files
+        id: classify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Default to running full CI for pushes, manual runs, API failures, empty file lists,
+          # or any path the generic global safe set does not explicitly mark as non-impacting.
+          finish() {
+            echo "skip_heavy=$1" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "Full CI required for $EVENT_NAME events."
+            finish false
+          fi
+
+          is_non_impacting_file() {
+            case "$1" in
+              *.md) return 0 ;;
+              docs/*) return 0 ;;
+              .github/ISSUE_TEMPLATE/*) return 0 ;;
+              .github/PULL_REQUEST_TEMPLATE/*) return 0 ;;
+              .github/pull_request_template.md) return 0 ;;
+              .github/CODEOWNERS) return 0 ;;
+              CODEOWNERS) return 0 ;;
+              .github/dependabot.yml) return 0 ;;
+              .github/workflows/release.yml) return 0 ;;
+              .github/workflows/release.yaml) return 0 ;;
+              .github/workflows/publish.yml) return 0 ;;
+              .github/workflows/publish.yaml) return 0 ;;
+              .github/workflows/stale.yml) return 0 ;;
+              .github/workflows/stale.yaml) return 0 ;;
+              .github/workflows/lint-pr.yml) return 0 ;;
+              .github/workflows/lint-pr.yaml) return 0 ;;
+              .github/workflows/call-flags-project-board.yml) return 0 ;;
+              .github/workflows/call-flags-project-board.yaml) return 0 ;;
+              .github/workflows/changeset-hygiene.yml) return 0 ;;
+              .github/workflows/changeset-hygiene.yaml) return 0 ;;
+              .github/workflows/dependabot-changeset.yml) return 0 ;;
+              .github/workflows/dependabot-changeset.yaml) return 0 ;;
+              .github/workflows/validate-versioning.yml) return 0 ;;
+              .github/workflows/validate-versioning.yaml) return 0 ;;
+              .github/workflows/new-pr.yml) return 0 ;;
+              .github/workflows/new-pr.yaml) return 0 ;;
+              .github/workflows/generated-files-notice.yml) return 0 ;;
+              .github/workflows/generated-files-notice.yaml) return 0 ;;
+              .github/workflows/posthog-upgrade.yml) return 0 ;;
+              .github/workflows/posthog-upgrade.yaml) return 0 ;;
+              .github/workflows/posthog-watcher-*.yml) return 0 ;;
+              .github/workflows/posthog-watcher-*.yaml) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+
+          changed_files="$(mktemp)"
+          if ! gh api --paginate "repos/$REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" \
+            --jq '.[] | [.filename, (.previous_filename // "")] | @tsv' > "$changed_files"; then
+            echo "Unable to fetch pull request files; running full CI."
+            finish false
+          fi
+
+          if [ ! -s "$changed_files" ]; then
+            echo "No changed files found; running full CI."
+            finish false
+          fi
+
+          while IFS=$'\t' read -r filename previous_filename || [ -n "$filename" ]; do
+            if [ -z "$filename" ]; then
+              continue
+            fi
+
+            if ! is_non_impacting_file "$filename"; then
+              echo "Full CI required because '$filename' may affect build, test, or lint."
+              finish false
+            fi
+
+            if [ -n "$previous_filename" ] && ! is_non_impacting_file "$previous_filename"; then
+              echo "Full CI required because previous path '$previous_filename' may affect build, test, or lint."
+              finish false
+            fi
+          done < "$changed_files"
+
+          echo "All changed files are non-impacting for required heavy CI."
+          finish true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,37 +12,38 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  detect-markdown-only:
-    uses: PostHog/.github/.github/workflows/detect-markdown-only.yml@ec25337d9fae0100622cbfea1bd5bd88284ac10b
+  detect-non-impacting-changes:
+    uses: ./.github/workflows/detect-non-impacting-changes.yml
     permissions:
+      contents: read
       pull-requests: read
 
   swiftformat:
-    needs: detect-markdown-only
+    needs: detect-non-impacting-changes
     name: SwiftFormat
     runs-on: macos-26
     steps:
-      - name: Complete markdown-only PR check
-        if: needs.detect-markdown-only.outputs.markdown_only == 'true'
-        run: echo "Only Markdown files changed; no additional work is required for this check."
+      - name: Complete non-impacting PR check
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy == 'true'
+        run: echo "Only non-impacting files changed; no additional work is required for this check."
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
 
       - name: Check formatting
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
         run: make swiftFormatCheck
 
   swiftlint:
-    needs: detect-markdown-only
+    needs: detect-non-impacting-changes
     name: SwiftLint
     runs-on: macos-26
     steps:
-      - name: Complete markdown-only PR check
-        if: needs.detect-markdown-only.outputs.markdown_only == 'true'
-        run: echo "Only Markdown files changed; no additional work is required for this check."
+      - name: Complete non-impacting PR check
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy == 'true'
+        run: echo "Only non-impacting files changed; no additional work is required for this check."
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
 
       - name: Run SwiftLint
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
         run: make swiftLintCheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,26 +12,27 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  detect-markdown-only:
-    uses: PostHog/.github/.github/workflows/detect-markdown-only.yml@ec25337d9fae0100622cbfea1bd5bd88284ac10b
+  detect-non-impacting-changes:
+    uses: ./.github/workflows/detect-non-impacting-changes.yml
     permissions:
+      contents: read
       pull-requests: read
 
   test:
-    needs: detect-markdown-only
+    needs: detect-non-impacting-changes
     runs-on: macos-15
     steps:
-      - name: Complete markdown-only PR check
-        if: needs.detect-markdown-only.outputs.markdown_only == 'true'
-        run: echo "Only Markdown files changed; no additional work is required for this check."
+      - name: Complete non-impacting PR check
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy == 'true'
+        run: echo "Only non-impacting files changed; no additional work is required for this check."
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
         with:
           xcode-version: latest-stable
       - name: Cache SPM dependencies
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
@@ -41,27 +42,27 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-spm-
       - name: Test SDK
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
         run: make test
 
   # `make test` runs `swift test` on macOS, which compiles out every `#if os(iOS)` block, so the
   # iOS-only suites (session replay, autocapture, tracing headers, crash reporting, etc.) never run
   # there. Run the iOS test target on a simulator so those suites are actually exercised in CI.
   test-ios-simulator:
-    needs: detect-markdown-only
+    needs: detect-non-impacting-changes
     runs-on: macos-15
     steps:
-      - name: Complete markdown-only PR check
-        if: needs.detect-markdown-only.outputs.markdown_only == 'true'
-        run: echo "Only Markdown files changed; no additional work is required for this check."
+      - name: Complete non-impacting PR check
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy == 'true'
+        run: echo "Only non-impacting files changed; no additional work is required for this check."
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
         with:
           xcode-version: latest-stable
       - name: Test SDK on iOS Simulator
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
         # Retries (3 iterations) protect merges from transient simulator flakiness; the macOS `test`
         # job runs without retries, so a genuine flake still surfaces as a hard failure there.
         run: make testOniOSSimulator
@@ -69,7 +70,7 @@ jobs:
         # Retries can hide flakiness by turning a transient red into green. Surface any test that only
         # passed after a retry so flakes get tracked and fixed instead of silently masked. Best-effort:
         # never fails the job.
-        if: ${{ needs.detect-markdown-only.outputs.markdown_only != 'true' && (always()) }}
+        if: ${{ needs.detect-non-impacting-changes.outputs.skip_heavy != 'true' && (always()) }}
         run: |
           log=xcodebuild-ios.log
           [ -f "$log" ] || { echo "No build log found; skipping flake report."; exit 0; }
@@ -88,7 +89,7 @@ jobs:
           fi
 
   downgrade-compatibility:
-    needs: detect-markdown-only
+    needs: detect-non-impacting-changes
     runs-on: macos-15
     strategy:
       fail-fast: false
@@ -103,17 +104,17 @@ jobs:
           - 3.58.0
     name: Downgrade compatibility (${{ matrix.downgrade_ref }})
     steps:
-      - name: Complete markdown-only PR check
-        if: needs.detect-markdown-only.outputs.markdown_only == 'true'
-        run: echo "Only Markdown files changed; no additional work is required for this check."
+      - name: Complete non-impacting PR check
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy == 'true'
+        run: echo "Only non-impacting files changed; no additional work is required for this check."
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
         with:
           xcode-version: latest-stable
       - name: Test downgrade compatibility
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        if: needs.detect-non-impacting-changes.outputs.skip_heavy != 'true'
         env:
           DOWNGRADE_REF: ${{ matrix.downgrade_ref }}
         run: make testDowngradeCompatibility


### PR DESCRIPTION
## Summary
- replace the external detector in required Build/Test/Lint workflows with a repo-local changed-file classifier
- keep required check names/jobs running while skipping heavy Xcode/CocoaPods/test/lint steps only for pull requests whose current and previous paths are all in the generic global safe set
- default to full CI for pushes, API failures, empty file lists, source/tests/package/lock/build config/current CI workflow changes, and unknown paths

## Generic safe set
- markdown files anywhere
- docs/*, GitHub issue/PR templates, CODEOWNERS, and .github/dependabot.yml
- non-required maintenance workflows: release, publish, stale, lint-pr, call-flags-project-board, changeset-hygiene, dependabot-changeset, validate-versioning, new-pr, generated-files-notice, posthog-upgrade, and posthog-watcher-* (.yml or .yaml)

## Validation
- Ruby YAML parse for all workflows in .github/workflows
- bash -n of the classifier run block extracted from the workflow
- classifier simulation covering safe markdown/docs/templates/CODEOWNERS/dependabot/maintenance workflows and unsafe source/package/current-CI/unknown/previous-filename/API-failure/empty/push cases
- git diff --check

## Notes
- No SDK/source changes and no changeset.
- This PR changes a current CI classifier workflow, so its own PR correctly runs full required CI.
