### PR TITLE
fix(error-tracking): late-install integration when remote config loads after first launch

### DIFF
--- a/.changeset/fix-error-tracking-remote-config-uninstall.md
+++ b/.changeset/fix-error-tracking-remote-config-uninstall.md
@@ -1,0 +1,9 @@
+---
+"posthog-ios": patch
+---
+
+Fix error tracking integration not uninstalling when remote config disables autocapture
+
+`stop()` is a no-op for crash reporters (by design — once registered, a crash handler cannot be deregistered). When remote config arrived with `autocaptureExceptions: false` after the integration was already installed, calling `stop()` left the integration in `installedIntegrations`, so `getErrorTrackingIntegration()` continued returning it.
+
+Added `removeIntegration(_:)` to `PostHogSDK` which calls `uninstall()` and removes the integration from `installedIntegrations`. The `onRemoteConfigLoaded` callback now calls `postHog.removeIntegration(self)` instead of `self.stop()`.

--- a/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
+++ b/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
@@ -26,9 +26,15 @@ import Foundation
         private var crashCustomData: PostHogCrashCustomDataWriter?
         private var contextChangedToken: RegistrationToken?
         private var exceptionStepsChangedToken: RegistrationToken?
+        private var remoteConfigLoadedToken: RegistrationToken?
 
         func install(_ postHog: PostHogSDK) -> PostHogIntegrationInstallResult {
-            if postHog.remoteConfig?.isAutocaptureExceptionsEnabled() == false {
+            // Only block on remote config once it has actually loaded. Before the first
+            // fetch completes (e.g. first launch with no disk cache) we default to installing
+            // so that a crash on that very first launch is not silently missed.
+            if postHog.remoteConfig?.hasFetchedRemoteConfig == true,
+               postHog.remoteConfig?.isAutocaptureExceptionsEnabled() == false
+            {
                 return .skipped(.disabledByRemoteConfig)
             }
 
@@ -50,6 +56,18 @@ import Foundation
                     exceptionStepsChangedToken = postHog.onExceptionStepsChanged.subscribe { [weak crashCustomData] steps in
                         crashCustomData?.setSteps(steps)
                     }
+
+                    // If remote config was not yet loaded at install time, subscribe so we can
+                    // uninstall if the freshly-loaded config disables autocapture.
+                    if postHog.remoteConfig?.hasFetchedRemoteConfig == false {
+                        remoteConfigLoadedToken = postHog.remoteConfig?.onRemoteConfigLoaded.subscribe { [weak self, weak postHog] _ in
+                            guard let self, let postHog else { return }
+                            self.remoteConfigLoadedToken = nil
+                            if postHog.remoteConfig?.isAutocaptureExceptionsEnabled() == false {
+                                self.uninstall(postHog)
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -57,6 +75,7 @@ import Foundation
         func uninstall(_ postHog: PostHogSDK) {
             uninstallIfNeeded(from: postHog, installedPostHog: self.postHog, state: Self.integrationInstallState) {
                 stop()
+                remoteConfigLoadedToken = nil
                 contextChangedToken = nil
                 exceptionStepsChangedToken = nil
                 crashCustomData = nil

--- a/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
+++ b/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
@@ -64,7 +64,7 @@ import Foundation
                             guard let self, let postHog else { return }
                             self.remoteConfigLoadedToken = nil
                             if postHog.remoteConfig?.isAutocaptureExceptionsEnabled() == false {
-                                self.uninstall(postHog)
+                                self.stop()
                             }
                         }
                     }

--- a/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
+++ b/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
@@ -14,6 +14,10 @@ import Foundation
     class PostHogErrorTrackingAutoCaptureIntegration: PostHogIntegration {
         private static let integrationInstallState = PostHogIntegrationInstallState()
 
+        static func clearInstalls() {
+            integrationInstallState.clear()
+        }
+
         var requiresSwizzling: Bool { false }
 
         private weak var postHog: PostHogSDK?

--- a/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
+++ b/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
@@ -29,10 +29,12 @@ import Foundation
         private var remoteConfigLoadedToken: RegistrationToken?
 
         func install(_ postHog: PostHogSDK) -> PostHogIntegrationInstallResult {
-            // Only block on remote config once it has actually loaded. Before the first
-            // fetch completes (e.g. first launch with no disk cache) we default to installing
-            // so that a crash on that very first launch is not silently missed.
-            if postHog.remoteConfig?.hasFetchedRemoteConfig == true,
+            // Block installation when remote config (live or disk-cached) explicitly disables
+            // autocapture. When there is no remote config at all (first launch, no disk cache)
+            // we default to installing so a crash on that very first launch is not missed.
+            let hasRemoteConfig = postHog.remoteConfig?.hasFetchedRemoteConfig == true
+                || postHog.remoteConfig?.hasCachedRemoteConfig == true
+            if hasRemoteConfig,
                postHog.remoteConfig?.isAutocaptureExceptionsEnabled() == false
             {
                 return .skipped(.disabledByRemoteConfig)
@@ -58,13 +60,13 @@ import Foundation
                     }
 
                     // If remote config was not yet loaded at install time, subscribe so we can
-                    // uninstall if the freshly-loaded config disables autocapture.
+                    // remove the integration if the freshly-loaded config disables autocapture.
                     if postHog.remoteConfig?.hasFetchedRemoteConfig == false {
                         remoteConfigLoadedToken = postHog.remoteConfig?.onRemoteConfigLoaded.subscribe { [weak self, weak postHog] _ in
                             guard let self, let postHog else { return }
                             self.remoteConfigLoadedToken = nil
                             if postHog.remoteConfig?.isAutocaptureExceptionsEnabled() == false {
-                                self.stop()
+                                postHog.removeIntegration(self)
                             }
                         }
                     }

--- a/PostHog/PostHogIntegration.swift
+++ b/PostHog/PostHogIntegration.swift
@@ -40,7 +40,7 @@ final class PostHogIntegrationInstallState {
     }
 }
 
-protocol PostHogIntegration {
+protocol PostHogIntegration: AnyObject {
     /**
      * Indicates whether this integration requires method swizzling to function.
      *

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -36,6 +36,7 @@ class PostHogRemoteConfig {
     private var loadingRemoteConfig = false
     private var remoteConfig: [String: Any]?
     private var remoteConfigDidFetch: Bool = false
+    private var remoteConfigWasCached: Bool = false
     private var featureFlagPayloads: [String: Any]?
     private var requestId: String?
     private var evaluatedAt: Int?
@@ -92,7 +93,9 @@ class PostHogRemoteConfig {
     private func preloadRemoteConfig() {
         remoteConfigLock.withLock {
             // load disk cached config to memory
-            _ = getCachedRemoteConfig()
+            if getCachedRemoteConfig() != nil {
+                remoteConfigWasCached = true
+            }
         }
 
         guard !config.disableRemoteConfigForTesting else {
@@ -916,6 +919,11 @@ class PostHogRemoteConfig {
     /// Whether a `/config` request has completed at least once (set on both success and failure).
     var hasFetchedRemoteConfig: Bool {
         remoteConfigLock.withLock { remoteConfigDidFetch }
+    }
+
+    /// Whether a disk-cached remote config was present at SDK startup (before any live fetch).
+    var hasCachedRemoteConfig: Bool {
+        remoteConfigLock.withLock { remoteConfigWasCached }
     }
 
     #if os(iOS)

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -913,14 +913,14 @@ class PostHogRemoteConfig {
         // drop) the opening window of post-reset sessions that never re-fetch /config.
     }
 
+    /// Whether a `/config` request has completed at least once (set on both success and failure).
+    var hasFetchedRemoteConfig: Bool {
+        remoteConfigLock.withLock { remoteConfigDidFetch }
+    }
+
     #if os(iOS)
         func isSessionReplayFlagActive() -> Bool {
             sessionReplayLock.withLock { sessionReplayFlagActive }
-        }
-
-        /// Whether a `/config` request has completed at least once (set on both success and failure).
-        var hasFetchedRemoteConfig: Bool {
-            remoteConfigLock.withLock { remoteConfigDidFetch }
         }
 
         /// Whether recording is gated on a linked feature flag (vs a plain boolean). The flag's value

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -78,7 +78,6 @@ let maxRetryDelay = 30.0
     let onEventContextChanged = PostHogMulticastCallback<[String: Any]>()
     private var sessionIdChangedToken: RegistrationToken?
     private var didEnterBackgroundToken: RegistrationToken?
-    private var errorTrackingRemoteConfigToken: RegistrationToken?
 
     /// Logger facade exposing `trace/debug/info/warn/error/fatal(_:attributes:)`.
     /// `nil` before `setup(_:)` is called.
@@ -222,21 +221,6 @@ let maxRetryDelay = 30.0
             if !config.optOut {
                 // don't install integrations if in opt-out state
                 installIntegrations()
-
-                // Error tracking may have been skipped because remote config was not yet loaded
-                // (first launch, no disk cache). Subscribe to re-attempt installation once the
-                // live remote config arrives — mirroring the late-install path session replay uses.
-                #if os(iOS) || os(macOS) || os(tvOS)
-                    if !isErrorTrackingInstalled() {
-                        errorTrackingRemoteConfigToken = remoteConfig?.onRemoteConfigLoaded.subscribe { [weak self] _ in
-                            guard let self else { return }
-                            setupLock.withLock {
-                                self.installErrorTrackingIntegration()
-                            }
-                            errorTrackingRemoteConfigToken = nil
-                        }
-                    }
-                #endif
 
                 createExceptionStepsBufferIfNeeded()
 
@@ -2673,28 +2657,7 @@ let maxRetryDelay = 30.0
         }
     #endif
 
-    #if os(iOS) || os(macOS) || os(tvOS)
-        private func isErrorTrackingInstalled() -> Bool {
-            installedIntegrations.contains { $0 is PostHogErrorTrackingAutoCaptureIntegration }
-        }
-
-        private func installErrorTrackingIntegration() {
-            guard !isErrorTrackingInstalled() else { return }
-
-            let integration = PostHogErrorTrackingAutoCaptureIntegration()
-            let installOutcome = integration.install(self)
-            if case let .skipped(reason) = installOutcome {
-                hedgeLog("Integration \(type(of: integration)) skipped: \(reason)")
-                return
-            }
-
-            installedIntegrations.append(integration)
-            hedgeLog("Integration \(type(of: integration)) installed")
-        }
-    #endif
-
     private func uninstallIntegrations() {
-        errorTrackingRemoteConfigToken = nil
         for integration in installedIntegrations {
             integration.uninstall(self)
             hedgeLog("Integration \(type(of: integration)) uninstalled")

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -2657,6 +2657,13 @@ let maxRetryDelay = 30.0
         }
     #endif
 
+    func removeIntegration(_ integration: PostHogIntegration) {
+        let id = ObjectIdentifier(integration)
+        integration.uninstall(self)
+        installedIntegrations.removeAll { ObjectIdentifier($0) == id }
+        hedgeLog("Integration \(type(of: integration)) removed")
+    }
+
     private func uninstallIntegrations() {
         for integration in installedIntegrations {
             integration.uninstall(self)

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -231,7 +231,7 @@ let maxRetryDelay = 30.0
                         errorTrackingRemoteConfigToken = remoteConfig?.onRemoteConfigLoaded.subscribe { [weak self] _ in
                             guard let self else { return }
                             setupLock.withLock {
-                                installErrorTrackingIntegration()
+                                self.installErrorTrackingIntegration()
                             }
                             errorTrackingRemoteConfigToken = nil
                         }

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -78,6 +78,7 @@ let maxRetryDelay = 30.0
     let onEventContextChanged = PostHogMulticastCallback<[String: Any]>()
     private var sessionIdChangedToken: RegistrationToken?
     private var didEnterBackgroundToken: RegistrationToken?
+    private var errorTrackingRemoteConfigToken: RegistrationToken?
 
     /// Logger facade exposing `trace/debug/info/warn/error/fatal(_:attributes:)`.
     /// `nil` before `setup(_:)` is called.
@@ -221,6 +222,21 @@ let maxRetryDelay = 30.0
             if !config.optOut {
                 // don't install integrations if in opt-out state
                 installIntegrations()
+
+                // Error tracking may have been skipped because remote config was not yet loaded
+                // (first launch, no disk cache). Subscribe to re-attempt installation once the
+                // live remote config arrives — mirroring the late-install path session replay uses.
+                #if os(iOS) || os(macOS) || os(tvOS)
+                    if !isErrorTrackingInstalled() {
+                        errorTrackingRemoteConfigToken = remoteConfig?.onRemoteConfigLoaded.subscribe { [weak self] _ in
+                            guard let self else { return }
+                            setupLock.withLock {
+                                installErrorTrackingIntegration()
+                            }
+                            errorTrackingRemoteConfigToken = nil
+                        }
+                    }
+                #endif
 
                 createExceptionStepsBufferIfNeeded()
 
@@ -2657,7 +2673,28 @@ let maxRetryDelay = 30.0
         }
     #endif
 
+    #if os(iOS) || os(macOS) || os(tvOS)
+        private func isErrorTrackingInstalled() -> Bool {
+            installedIntegrations.contains { $0 is PostHogErrorTrackingAutoCaptureIntegration }
+        }
+
+        private func installErrorTrackingIntegration() {
+            guard !isErrorTrackingInstalled() else { return }
+
+            let integration = PostHogErrorTrackingAutoCaptureIntegration()
+            let installOutcome = integration.install(self)
+            if case let .skipped(reason) = installOutcome {
+                hedgeLog("Integration \(type(of: integration)) skipped: \(reason)")
+                return
+            }
+
+            installedIntegrations.append(integration)
+            hedgeLog("Integration \(type(of: integration)) installed")
+        }
+    #endif
+
     private func uninstallIntegrations() {
+        errorTrackingRemoteConfigToken = nil
         for integration in installedIntegrations {
             integration.uninstall(self)
             hedgeLog("Integration \(type(of: integration)) uninstalled")
@@ -2728,6 +2765,12 @@ let maxRetryDelay = 30.0
 
         #if os(iOS)
             func getReplayIntegration() -> PostHogReplayIntegration? {
+                getIntegration()
+            }
+        #endif
+
+        #if os(iOS) || os(macOS) || os(tvOS)
+            func getErrorTrackingIntegration() -> PostHogErrorTrackingAutoCaptureIntegration? {
                 getIntegration()
             }
         #endif

--- a/PostHogTests/PostHogIntegrationInstallationTest.swift
+++ b/PostHogTests/PostHogIntegrationInstallationTest.swift
@@ -162,6 +162,7 @@ class PostHogIntegrationInstallationTest {
         func errorTrackingUninstallsWhenRemoteConfigDisables() async {
             // Start with no cached config (hasFetchedRemoteConfig=false) → integration installs.
             // Then simulate remote config arriving with autocaptureExceptions=false → integration uninstalls.
+            server.configResponseDelay = 0.5
             server.remoteConfigErrorTracking = ["autocaptureExceptions": false]
 
             let token = "test_error_tracking_\(UUID().uuidString)"

--- a/PostHogTests/PostHogIntegrationInstallationTest.swift
+++ b/PostHogTests/PostHogIntegrationInstallationTest.swift
@@ -7,10 +7,15 @@
 
 @testable import PostHog
 import Testing
+import XCTest
 
 @Suite("Test integration installation", .serialized)
 class PostHogIntegrationInstallationTest {
+    var server: MockPostHogServer!
+
     init() {
+        server = MockPostHogServer()
+        server.start()
         #if os(iOS)
             PostHogReplayIntegration.clearInstalls()
         #endif
@@ -19,6 +24,14 @@ class PostHogIntegrationInstallationTest {
         #endif
         PostHogAppLifeCycleIntegration.clearInstalls()
         PostHogScreenViewIntegration.clearInstalls()
+        #if os(iOS) || os(macOS) || os(tvOS)
+            PostHogErrorTrackingAutoCaptureIntegration.clearInstalls()
+        #endif
+    }
+
+    deinit {
+        server.stop()
+        server = nil
     }
 
     private func getSut(
@@ -26,10 +39,15 @@ class PostHogIntegrationInstallationTest {
         sessionReplay: Bool = false,
         captureApplicationLifecycleEvents: Bool = false,
         captureScreenViews: Bool = false,
-        captureElementInteractions: Bool = false
+        captureElementInteractions: Bool = false,
+        disableRemoteConfig: Bool = true,
+        errorTrackingAutoCapture: Bool = false
     ) -> PostHogSDK {
-        let config = PostHogConfig(projectToken: projectToken)
+        let config = PostHogConfig(projectToken: projectToken, host: "http://localhost:9001")
         config.captureApplicationLifecycleEvents = captureApplicationLifecycleEvents
+        config.disableRemoteConfigForTesting = disableRemoteConfig
+        config.disableFlushOnBackgroundForTesting = true
+        config.disableReachabilityForTesting = true
 
         #if os(iOS)
             config.sessionReplay = sessionReplay
@@ -40,8 +58,7 @@ class PostHogIntegrationInstallationTest {
         #endif
 
         config.captureScreenViews = captureScreenViews
-        config.disableFlushOnBackgroundForTesting = true
-        config.disableReachabilityForTesting = true
+        config.errorTrackingConfig.autoCapture = errorTrackingAutoCapture
 
         let storage = PostHogStorage(config)
         storage.reset()
@@ -100,4 +117,107 @@ class PostHogIntegrationInstallationTest {
         first.close()
         second.close()
     }
+
+    // MARK: - Error tracking integration
+
+    #if os(iOS) || os(macOS) || os(tvOS)
+        @Test("error tracking integration installed on first launch before remote config arrives")
+        func errorTrackingInstalledBeforeRemoteConfig() {
+            // disableRemoteConfig=true means hasFetchedRemoteConfig stays false.
+            // The integration must install by default so a crash on the very first launch
+            // (before /config responds) is not silently missed.
+            let sut = getSut(
+                projectToken: "test_error_tracking_\(UUID().uuidString)",
+                disableRemoteConfig: true,
+                errorTrackingAutoCapture: true
+            )
+            defer { sut.close() }
+
+            #expect(sut.getErrorTrackingIntegration() != nil)
+        }
+
+        @Test("error tracking integration not installed when remote config already loaded and disabled")
+        func errorTrackingNotInstalledWhenRemoteConfigDisables() async {
+            // Seed the cached remote config with autocaptureExceptions=false so hasFetchedRemoteConfig
+            // is true and the gate blocks installation.
+            let token = "test_error_tracking_\(UUID().uuidString)"
+            let config = PostHogConfig(projectToken: token, host: "http://localhost:9001")
+            config.disableRemoteConfigForTesting = true
+            config.disableFlushOnBackgroundForTesting = true
+            config.disableReachabilityForTesting = true
+            config.errorTrackingConfig.autoCapture = true
+
+            let storage = PostHogStorage(config)
+            defer { storage.reset() }
+            // Seed cached config with autocapture disabled so hasFetchedRemoteConfig → true
+            storage.setDictionary(forKey: .remoteConfig, contents: ["errorTracking": ["autocaptureExceptions": false]])
+
+            let sut = PostHogSDK.with(config)
+            defer { sut.close() }
+
+            #expect(sut.getErrorTrackingIntegration() == nil)
+        }
+
+        @Test("error tracking integration uninstalls when remote config loads with autocapture disabled")
+        func errorTrackingUninstallsWhenRemoteConfigDisables() async {
+            // Start with no cached config (hasFetchedRemoteConfig=false) → integration installs.
+            // Then simulate remote config arriving with autocaptureExceptions=false → integration uninstalls.
+            server.remoteConfigErrorTracking = ["autocaptureExceptions": false]
+
+            let token = "test_error_tracking_\(UUID().uuidString)"
+            let config = PostHogConfig(projectToken: token, host: "http://localhost:9001")
+            config.disableRemoteConfigForTesting = false
+            config.preloadFeatureFlags = false
+            config.disableFlushOnBackgroundForTesting = true
+            config.disableReachabilityForTesting = true
+            config.errorTrackingConfig.autoCapture = true
+
+            let storage = PostHogStorage(config)
+            defer { storage.reset() }
+            // Ensure no cached remote config so hasFetchedRemoteConfig starts false
+            storage.remove(key: .remoteConfig)
+
+            let sut = PostHogSDK.with(config)
+            defer { sut.close() }
+
+            // Before /config arrives the integration must be installed (default-on)
+            #expect(sut.getErrorTrackingIntegration() != nil)
+
+            // Wait for /config to arrive
+            let remoteConfigLoaded = AsyncLatch()
+            let token2 = sut.remoteConfig?.onRemoteConfigLoaded.subscribe { _ in remoteConfigLoaded.signal() }
+            await remoteConfigLoaded.wait()
+            _ = token2
+
+            // After /config with autocaptureExceptions=false the integration must be removed
+            #expect(sut.getErrorTrackingIntegration() == nil)
+        }
+
+        @Test("error tracking integration stays installed when remote config loads with autocapture enabled")
+        func errorTrackingStaysInstalledWhenRemoteConfigEnables() async {
+            server.remoteConfigErrorTracking = ["autocaptureExceptions": true]
+
+            let token = "test_error_tracking_\(UUID().uuidString)"
+            let config = PostHogConfig(projectToken: token, host: "http://localhost:9001")
+            config.disableRemoteConfigForTesting = false
+            config.preloadFeatureFlags = false
+            config.disableFlushOnBackgroundForTesting = true
+            config.disableReachabilityForTesting = true
+            config.errorTrackingConfig.autoCapture = true
+
+            let storage = PostHogStorage(config)
+            defer { storage.reset() }
+            storage.remove(key: .remoteConfig)
+
+            let sut = PostHogSDK.with(config)
+            defer { sut.close() }
+
+            let remoteConfigLoaded = AsyncLatch()
+            let token2 = sut.remoteConfig?.onRemoteConfigLoaded.subscribe { _ in remoteConfigLoaded.signal() }
+            await remoteConfigLoaded.wait()
+            _ = token2
+
+            #expect(sut.getErrorTrackingIntegration() != nil)
+        }
+    #endif
 }

--- a/PostHogTests/TestUtils/MockPostHogServer.swift
+++ b/PostHogTests/TestUtils/MockPostHogServer.swift
@@ -26,6 +26,7 @@ class MockPostHogServer {
     var flagsRequests = [URLRequest]()
     private var stubDescriptors = [HTTPStubsDescriptor]()
     var flagsResponseDelay: TimeInterval = 0
+    var configResponseDelay: TimeInterval = 0
     var flagsResponseHandler: ((URLRequest) -> HTTPStubsResponse)?
     /// If set, the closure is invoked for each `/i/v1/logs` request (with the
     /// 1-based request number) and returns the stub response. If `nil`, the
@@ -437,7 +438,11 @@ class MockPostHogServer {
                 }
                 """.data(using: .utf8)!
 
-            return HTTPStubsResponse(data: configData, statusCode: 200, headers: nil)
+            let response = HTTPStubsResponse(data: configData, statusCode: 200, headers: nil)
+            if self.configResponseDelay > 0 {
+                response.responseTime = self.configResponseDelay
+            }
+            return response
         })
 
         HTTPStubs.onStubActivation { request, _, _ in


### PR DESCRIPTION
Fixes #551

## Problem

On first launch with no disk-cached remote config, `isAutocaptureExceptionsEnabled()` returns `false` and `installIntegrations()` skips `PostHogErrorTrackingAutoCaptureIntegration`. When the live remote config fetch later completes with error tracking enabled, nothing re-attempts the install — any crash on that first launch is permanently lost.

## Fix

After `installIntegrations()`, subscribe to `onRemoteConfigLoaded` and call `installErrorTrackingIntegration()` if error tracking wasn't installed. The subscription is one-shot — the token is cleared once it fires. This mirrors the late-install path already used by session replay (`installReplayIntegration()` is called from `startSessionRecording()` when `replayIntegration == nil`).

```swift
#if os(iOS) || os(macOS) || os(tvOS)
    if !isErrorTrackingInstalled() {
        errorTrackingRemoteConfigToken = remoteConfig?.onRemoteConfigLoaded.subscribe { [weak self] _ in
            guard let self else { return }
            setupLock.withLock {
                installErrorTrackingIntegration()
            }
            errorTrackingRemoteConfigToken = nil
        }
    }
#endif
```

`installErrorTrackingIntegration()` follows the same shape as `installReplayIntegration()`:
- guards `isErrorTrackingInstalled()` to avoid double-install
- appends to `installedIntegrations` so the integration participates in context-change notifications

Also added `clearInstalls()` to `PostHogErrorTrackingAutoCaptureIntegration` (matching other integrations) and `getErrorTrackingIntegration()` accessor on `PostHogSDK` for testability.