### PR TITLE
fix: let caller-supplied feature-flag props override cached values

### DIFF
--- a/.changeset/feature-flag-prop-precedence.md
+++ b/.changeset/feature-flag-prop-precedence.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Feature-flag properties (`$feature/*` and `$active_feature_flags`) passed explicitly to `capture()` now take precedence over the SDK's cached flag values, matching posthog-js (web) and posthog-android.

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -538,7 +538,11 @@ let maxRetryDelay = 30.0
             props["distinct_id"] = distinctId
         }
 
-        props = props.merging(properties ?? [:]) { current, _ in current }
+        let callerProps = properties ?? [:]
+        props = props.merging(callerProps) { current, _ in current }
+        // Caller-supplied feature-flag properties take precedence over the cached values
+        let callerFlagProps = callerProps.filter { $0.key.hasPrefix("$feature/") || $0.key == "$active_feature_flags" }
+        props = props.merging(callerFlagProps) { _, new in new }
 
         return props
     }

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -508,6 +508,31 @@ class PostHogSDKTest: QuickSpec {
             sut.close()
         }
 
+        it("caller-supplied feature flag properties override cached values") {
+            let sut = self.getSut()
+
+            sut.reloadFeatureFlags()
+            waitForFeatureFlagsLoaded(server, sut)
+
+            sut.capture("event", properties: [
+                "$feature/bool-value": "server-value",
+                "$active_feature_flags": ["server-flag"],
+            ])
+
+            let events = getBatchedEvents(server)
+
+            expect(events.count) == 1
+            let event = events.first!
+
+            expect(event.properties["$feature/bool-value"] as? String) == "server-value"
+            let activeFlags = event.properties["$active_feature_flags"] as? [Any] ?? []
+            expect(activeFlags.count) == 1
+            expect(activeFlags.first as? String) == "server-flag"
+
+            sut.reset()
+            sut.close()
+        }
+
         it("sanitize properties") {
             let sut = self.getSut(flushAt: 1)
 


### PR DESCRIPTION
## :bulb: Motivation and Context

When you pass a `$feature/<flag>` property explicitly to `capture()`, the SDK silently drops it in favor of its own cached flag value. In `buildProperties()` the cached flags are injected first (via `dynamicContext()`) and caller properties are merged last with `merging(...) { current, _ in current }`, which keeps the already-present (cached) value on conflict.

This blocks a real customer use case (server-side local evaluation feeding explicit flag values into iOS exposure events, e.g. paywall screen views) as a safety net for when the client's cached flags are stale or a server-side person property changed evaluation.

This also makes iOS inconsistent with the rest of the SDKs. Current `$feature/foo`-on-`capture()` precedence:

| SDK | Behavior |
| --- | --- |
| posthog-js (web) | caller wins |
| posthog-android | caller wins |
| **posthog-ios** | **SDK-cached wins** (this PR flips it to caller wins) |
| posthog core (React Native) | SDK-cached wins (separate follow-up) |
| posthog-flutter | delegates to native (inherits this fix on iOS) |

After this change, caller-supplied `$feature/*` and `$active_feature_flags` win over the cached values; all other property precedence is unchanged.

## :green_heart: How did you test it?

- Added a regression test (`caller-supplied feature flag properties override cached values`) asserting an explicit `$feature/bool-value` and `$active_feature_flags` passed to `capture()` survive into the sent event over the loaded flags.
- Ran the full `PostHogTests` suite locally via `swift test`: 143 tests, 0 failures.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Anna directed this work with Claude Code after a customer (Portola) escalation in Slack about server/client feature-flag values on iOS. The agent traced the exact merge in `buildProperties()`, then confirmed cross-SDK behavior (web, Android, React Native core, Flutter) to establish "caller wins" as the target — matching web and Android — rather than inventing new behavior. Scope was deliberately limited to `$feature/*` and `$active_feature_flags` to keep the blast radius small; general caller-vs-context precedence is unchanged. The equivalent bug in the shared core (React Native) is left as a separate follow-up.
