### PR TITLE
fix: Retry flags requests on 502 and 504

### DIFF
--- a/.changeset/gentle-flags-retry.md
+++ b/.changeset/gentle-flags-retry.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': patch
+---
+
+Retry remote feature flag requests after transient 502 and 504 responses.

--- a/PostHog/PostHogApi.swift
+++ b/PostHog/PostHogApi.swift
@@ -303,14 +303,13 @@ class PostHogApi {
         session.uploadTask(with: request, from: payload) { data, response, error in
             if let error {
                 if Self.isRetryableFlagsError(error), retryCount < self.config.featureFlagRequestMaxRetries {
-                    let nextRetryCount = retryCount + 1
-                    let delay = Self.featureFlagsRetryDelay(forFailedAttempt: nextRetryCount)
-                    hedgeLog(
-                        "Error calling the flags API: \(error). Retrying in \(delay) seconds (attempt \(nextRetryCount)/\(self.config.featureFlagRequestMaxRetries))."
+                    self.retryFlagsRequest(
+                        request,
+                        payload: payload,
+                        retryCount: retryCount,
+                        reason: String(describing: error),
+                        completion: completion
                     )
-                    DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + delay) {
-                        self.uploadFlagsRequest(request, payload: payload, retryCount: nextRetryCount, completion: completion)
-                    }
                     return
                 }
 
@@ -327,9 +326,21 @@ class PostHogApi {
 
             if !(200 ... 299 ~= httpResponse.statusCode) {
                 let jsonBody = fromJSONData(data, options: .allowFragments)
-                let errorMessage = "Error calling flags API: status: \(httpResponse.statusCode), body: \(String(describing: jsonBody))."
-                hedgeLog(errorMessage)
+                let retryReason = "status: \(httpResponse.statusCode), body: \(String(describing: jsonBody))"
+                let errorMessage = "Error calling flags API: \(retryReason)."
 
+                if Self.isRetryableFlagsStatusCode(httpResponse.statusCode), retryCount < self.config.featureFlagRequestMaxRetries {
+                    self.retryFlagsRequest(
+                        request,
+                        payload: payload,
+                        retryCount: retryCount,
+                        reason: retryReason,
+                        completion: completion
+                    )
+                    return
+                }
+
+                hedgeLog(errorMessage)
                 return completion(nil,
                                   InternalPostHogError(description: errorMessage))
             } else {
@@ -346,6 +357,23 @@ class PostHogApi {
         }.resume()
     }
 
+    private func retryFlagsRequest(
+        _ request: URLRequest,
+        payload: Data,
+        retryCount: Int,
+        reason: String,
+        completion: @escaping ([String: Any]?, _ error: Error?) -> Void
+    ) {
+        let nextRetryCount = retryCount + 1
+        let delay = Self.featureFlagsRetryDelay(forFailedAttempt: nextRetryCount)
+        hedgeLog(
+            "Error calling the flags API: \(reason). Retrying in \(delay) seconds (attempt \(nextRetryCount)/\(config.featureFlagRequestMaxRetries))."
+        )
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + delay) {
+            self.uploadFlagsRequest(request, payload: payload, retryCount: nextRetryCount, completion: completion)
+        }
+    }
+
     static func featureFlagsRetryDelay(forFailedAttempt failedAttempt: Int) -> TimeInterval {
         min(flagsRetryDelay * pow(2.0, TimeInterval(failedAttempt - 1)), maxRetryDelay)
     }
@@ -356,6 +384,10 @@ class PostHogApi {
             return false
         }
         return nsError.code == NSURLErrorTimedOut || nsError.code == NSURLErrorNetworkConnectionLost
+    }
+
+    private static func isRetryableFlagsStatusCode(_ statusCode: Int) -> Bool {
+        statusCode == 502 || statusCode == 504
     }
 
     func remoteConfig(

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -95,7 +95,7 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
     /// resets on a successful 2xx response. Default 3.
     @objc public var maxRetries: Int = Defaults.maxRetries
 
-    /// Maximum number of retries for feature flag requests after transient network errors.
+    /// Maximum number of retries for feature flag requests after transient network errors or retryable HTTP responses.
     /// Defaults to 1. Set to 0 to disable feature flag request retries.
     @objc public var featureFlagRequestMaxRetries: Int = Defaults.featureFlagRequestMaxRetries
     /// Required network connectivity mode for flushing queued data.

--- a/PostHogTests/PostHogApiTest.swift
+++ b/PostHogTests/PostHogApiTest.swift
@@ -469,6 +469,28 @@ enum PostHogApiTests {
             #expect(server.flagsRequests.count == 1)
         }
 
+        @Test("stops retrying retryable HTTP status responses after feature flag request max retries", arguments: [502, 504])
+        func stopsRetryingRetryableHTTPStatusResponsesAfterFeatureFlagRequestMaxRetries(statusCode: Int) async throws {
+            server.reset(flagsCount: 3)
+            server.flagsResponseHandler = { _ in
+                HTTPStubsResponse(jsonObject: ["error": "server error"], statusCode: Int32(statusCode), headers: nil)
+            }
+
+            let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost")
+            config.featureFlagRequestMaxRetries = 2
+            let sut = PostHogApi(config)
+
+            let resp = await getApiResponse { completion in
+                sut.flags(distinctId: "", anonymousId: "", groups: [:], personProperties: [:]) { data, error in
+                    completion((data, error))
+                }
+            }
+
+            #expect(resp.0 == nil)
+            #expect(resp.1 != nil)
+            #expect(server.flagsRequests.count == 3)
+        }
+
         @Test("stops retrying transient URLSession errors after feature flag request max retries")
         func stopsRetryingTransientURLSessionErrorsAfterFeatureFlagRequestMaxRetries() async throws {
             server.reset(flagsCount: 3)

--- a/PostHogTests/PostHogApiTest.swift
+++ b/PostHogTests/PostHogApiTest.swift
@@ -377,6 +377,73 @@ enum PostHogApiTests {
             #expect(server.flagsRequests.count == 2)
         }
 
+        @Test("retries retryable HTTP status responses before returning flags", arguments: [502, 504])
+        func retriesRetryableHTTPStatusResponses(statusCode: Int) async throws {
+            server.reset(flagsCount: 2)
+
+            var requestCount = 0
+            let requestCountLock = NSLock()
+            server.flagsResponseHandler = { _ in
+                requestCountLock.lock()
+                requestCount += 1
+                let currentRequestCount = requestCount
+                requestCountLock.unlock()
+
+                if currentRequestCount == 1 {
+                    return HTTPStubsResponse(jsonObject: ["error": "server error"], statusCode: Int32(statusCode), headers: nil)
+                }
+
+                return HTTPStubsResponse(
+                    jsonObject: [
+                        "errorsWhileComputingFlags": false,
+                        "featureFlags": ["retry-flag": "success"],
+                    ],
+                    statusCode: 200,
+                    headers: nil
+                )
+            }
+
+            let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost")
+            config.featureFlagRequestMaxRetries = 1
+            let sut = PostHogApi(config)
+
+            let resp = await getApiResponse { completion in
+                sut.flags(distinctId: "", anonymousId: "", groups: [:], personProperties: [:]) { data, error in
+                    completion((data, error))
+                }
+            }
+
+            let data = try #require(resp.0)
+            #expect(data["errorsWhileComputingFlags"] as! Bool == false)
+            #expect((data["featureFlags"] as? [String: Any])?["retry-flag"] as? String == "success")
+            #expect(resp.1 == nil)
+            #expect(server.flagsRequests.count == 2)
+        }
+
+        @Test("does not retry retryable HTTP status responses when feature flag request max retries is zero", arguments: [502, 504])
+        func doesNotRetryRetryableHTTPStatusResponsesWhenFeatureFlagRequestMaxRetriesIsZero(statusCode: Int) async throws {
+            server.reset(flagsCount: 1)
+            server.flagsResponseHandler = { _ in
+                HTTPStubsResponse(jsonObject: ["error": "server error"], statusCode: Int32(statusCode), headers: nil)
+            }
+
+            let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost")
+            config.featureFlagRequestMaxRetries = 0
+            let sut = PostHogApi(config)
+
+            let resp = await getApiResponse { completion in
+                sut.flags(distinctId: "", anonymousId: "", groups: [:], personProperties: [:]) { data, error in
+                    completion((data, error))
+                }
+            }
+
+            try await Task.sleep(nanoseconds: 50_000_000)
+
+            #expect(resp.0 == nil)
+            #expect(resp.1 != nil)
+            #expect(server.flagsRequests.count == 1)
+        }
+
         @Test("does not retry when feature flag request max retries is zero")
         func doesNotRetryWhenFeatureFlagRequestMaxRetriesIsZero() async throws {
             server.reset(flagsCount: 1)


### PR DESCRIPTION
## :bulb: Motivation and Context

Remote `/flags` requests already retry transient URLSession failures, but HTTP 502/504 responses were returned immediately. This updates only the `/flags` path to retry 502 and 504 using the existing `featureFlagRequestMaxRetries` budget and retry delay.

## :green_heart: How did you test it?

- `make format`
- `make test filter=PostHogApiTests.TestFlagsEndpoint`
- `make lint`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented by an AI coding agent under maintainer direction. The change is intentionally scoped to `/flags` retries: 502 and 504 now share the existing flags retry scheduling and max-retry budget, while other HTTP statuses and capture/log/snapshot upload behavior are unchanged.
