### PR TITLE
ci: poll pod trunk info to confirm CocoaPods publish landed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,8 +309,10 @@ jobs:
               echo "PostHog $RELEASE_VERSION is on trunk (attempt $attempt/10). Treating as success."
               exit 0
             fi
-            echo "Not visible yet (attempt $attempt/10); retrying in 30s..."
-            sleep 30
+            if [ "$attempt" -lt 10 ]; then
+              echo "Not visible yet (attempt $attempt/10); retrying in 30s..."
+              sleep 30
+            fi
           done
 
           echo "::error::PostHog $RELEASE_VERSION is not on trunk after polling for ~5 minutes."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,17 +290,30 @@ jobs:
         run: |
           set -euo pipefail
 
+          on_trunk() {
+            pod trunk info PostHog --no-ansi 2>/dev/null \
+              | grep -E -- "^[[:space:]]*- ${RELEASE_VERSION//./\\.} \("
+          }
+
           if make releaseCocoaPods; then
             exit 0
           fi
 
-          echo "::warning::pod trunk push failed. Verifying via pod trunk info..."
-          if pod trunk info PostHog --no-ansi | grep -E -- "^[[:space:]]*- ${RELEASE_VERSION//./\\.} \("; then
-            echo "PostHog $RELEASE_VERSION is on trunk despite the failed push. Treating as success."
-            exit 0
-          fi
+          # `pod trunk push` regularly exits non-zero *after* the spec is already
+          # accepted (its final CDN/response verification times out). Trunk
+          # registration and the `pod trunk info` endpoint can lag a bit and the
+          # info call itself is occasionally flaky, so poll rather than check once.
+          echo "::warning::pod trunk push failed. Polling pod trunk info to confirm the version landed..."
+          for attempt in $(seq 1 10); do
+            if on_trunk; then
+              echo "PostHog $RELEASE_VERSION is on trunk (attempt $attempt/10). Treating as success."
+              exit 0
+            fi
+            echo "Not visible yet (attempt $attempt/10); retrying in 30s..."
+            sleep 30
+          done
 
-          echo "::error::PostHog $RELEASE_VERSION is not on trunk after failed push."
+          echo "::error::PostHog $RELEASE_VERSION is not on trunk after polling for ~5 minutes."
           exit 1
 
       # Notify in case of failure


### PR DESCRIPTION
## :bulb: Motivation and Context

The `publish-cocoapods` step in the release workflow sometimes fails even though the version was actually published — confirmed via `pod trunk info PostHog`.

`pod trunk push` regularly exits non-zero *after* the spec has already been accepted (its final CDN/response verification times out), and trunk registration / the `pod trunk info` endpoint can lag a bit behind. #612 added a fallback that treats "already on trunk" as success, but it checked **once, immediately** — so if the version isn't visible yet on that first read, or the `pod trunk info` call itself is transiently flaky, the job still fails despite a successful publish.

## :green_heart: How did you test it?

Verified locally against live trunk data that the existing/updated grep matches the real `pod trunk info --no-ansi` format (`      - <version> (<date>)`) for the current release, and that a non-matching version returns a clean "not found" without tripping `set -euo pipefail`. Not exercised end-to-end through an actual release run (that only happens on `main`).

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

CI-only change, no changeset needed.

## 🤖 Agent context

**DRI:** @ioannisj
**Autonomy:** Human-driven (agent-assisted)
