### PR TITLE
chore: Silence vendored build warnings

### DIFF
--- a/vendor/PHPLCrashReporter/Dependencies/protobuf-c/protobuf-c/protobuf-c.c
+++ b/vendor/PHPLCrashReporter/Dependencies/protobuf-c/protobuf-c/protobuf-c.c
@@ -450,16 +450,16 @@ required_field_get_packed_size(const ProtobufCFieldDescriptor *field,
 	case PROTOBUF_C_TYPE_STRING: {
 		const char *str = *(char * const *) member;
 		size_t len = str ? strlen(str) : 0;
-		return rv + uint32_size(len) + len;
+		return rv + uint32_size((uint32_t) len) + len;
 	}
 	case PROTOBUF_C_TYPE_BYTES: {
 		size_t len = ((const ProtobufCBinaryData *) member)->len;
-		return rv + uint32_size(len) + len;
+		return rv + uint32_size((uint32_t) len) + len;
 	}
 	case PROTOBUF_C_TYPE_MESSAGE: {
 		const ProtobufCMessage *msg = *(ProtobufCMessage * const *) member;
 		size_t subrv = msg ? protobuf_c_message_get_packed_size(msg) : 0;
-		return rv + uint32_size(subrv) + subrv;
+		return rv + uint32_size((uint32_t) subrv) + subrv;
 	}
 	}
 	PROTOBUF_C__ASSERT_NOT_REACHED();
@@ -667,26 +667,26 @@ repeated_field_get_packed_size(const ProtobufCFieldDescriptor *field,
 	case PROTOBUF_C_TYPE_STRING:
 		for (i = 0; i < count; i++) {
 			size_t len = strlen(((char **) array)[i]);
-			rv += uint32_size(len) + len;
+			rv += uint32_size((uint32_t) len) + len;
 		}
 		break;
 	case PROTOBUF_C_TYPE_BYTES:
 		for (i = 0; i < count; i++) {
 			size_t len = ((ProtobufCBinaryData *) array)[i].len;
-			rv += uint32_size(len) + len;
+			rv += uint32_size((uint32_t) len) + len;
 		}
 		break;
 	case PROTOBUF_C_TYPE_MESSAGE:
 		for (i = 0; i < count; i++) {
 			size_t len = protobuf_c_message_get_packed_size(
 				((ProtobufCMessage **) array)[i]);
-			rv += uint32_size(len) + len;
+			rv += uint32_size((uint32_t) len) + len;
 		}
 		break;
 	}
 
 	if (0 != (field->flags & PROTOBUF_C_FIELD_FLAG_PACKED))
-		header_size += uint32_size(rv);
+		header_size += uint32_size((uint32_t) rv);
 	return header_size + rv;
 }
 
@@ -1004,7 +1004,7 @@ string_pack(const char *str, uint8_t *out)
 		return 1;
 	} else {
 		size_t len = strlen(str);
-		size_t rv = uint32_pack(len, out);
+		size_t rv = uint32_pack((uint32_t) len, out);
 		memcpy(out + rv, str, len);
 		return rv + len;
 	}
@@ -1025,7 +1025,7 @@ static inline size_t
 binary_data_pack(const ProtobufCBinaryData *bd, uint8_t *out)
 {
 	size_t len = bd->len;
-	size_t rv = uint32_pack(len, out);
+	size_t rv = uint32_pack((uint32_t) len, out);
 	memcpy(out + rv, bd->data, len);
 	return rv + len;
 }
@@ -1049,10 +1049,10 @@ prefixed_message_pack(const ProtobufCMessage *message, uint8_t *out)
 		return 1;
 	} else {
 		size_t rv = protobuf_c_message_pack(message, out + 1);
-		uint32_t rv_packed_size = uint32_size(rv);
+		size_t rv_packed_size = uint32_size((uint32_t) rv);
 		if (rv_packed_size != 1)
 			memmove(out + rv_packed_size, out + 1, rv);
-		return uint32_pack(rv, out) + rv;
+		return uint32_pack((uint32_t) rv, out) + rv;
 	}
 }
 
@@ -1439,14 +1439,14 @@ repeated_field_pack(const ProtobufCFieldDescriptor *field,
 		}
 
 		payload_len = payload_at - (out + header_len);
-		actual_length_size = uint32_size(payload_len);
+		actual_length_size = uint32_size((uint32_t) payload_len);
 		if (length_size_min != actual_length_size) {
 			assert(actual_length_size == length_size_min + 1);
 			memmove(out + header_len + 1, out + header_len,
 				payload_len);
 			header_len++;
 		}
-		uint32_pack(payload_len, out + len_start);
+		uint32_pack((uint32_t) payload_len, out + len_start);
 		return header_len + payload_len;
 	} else {
 		/* not "packed" cased */
@@ -1608,7 +1608,7 @@ required_field_pack_to_buffer(const ProtobufCFieldDescriptor *field,
 		size_t sublen = str ? strlen(str) : 0;
 
 		scratch[0] |= PROTOBUF_C_WIRE_TYPE_LENGTH_PREFIXED;
-		rv += uint32_pack(sublen, scratch + rv);
+		rv += uint32_pack((uint32_t) sublen, scratch + rv);
 		buffer->append(buffer, rv, scratch);
 		buffer->append(buffer, sublen, (const uint8_t *) str);
 		rv += sublen;
@@ -1619,7 +1619,7 @@ required_field_pack_to_buffer(const ProtobufCFieldDescriptor *field,
 		size_t sublen = bd->len;
 
 		scratch[0] |= PROTOBUF_C_WIRE_TYPE_LENGTH_PREFIXED;
-		rv += uint32_pack(sublen, scratch + rv);
+		rv += uint32_pack((uint32_t) sublen, scratch + rv);
 		buffer->append(buffer, rv, scratch);
 		buffer->append(buffer, sublen, bd->data);
 		rv += sublen;
@@ -1634,7 +1634,7 @@ required_field_pack_to_buffer(const ProtobufCFieldDescriptor *field,
 			buffer->append(buffer, rv, scratch);
 		} else {
 			size_t sublen = protobuf_c_message_get_packed_size(msg);
-			rv += uint32_pack(sublen, scratch + rv);
+			rv += uint32_pack((uint32_t) sublen, scratch + rv);
 			buffer->append(buffer, rv, scratch);
 			protobuf_c_message_pack_to_buffer(msg, buffer);
 			rv += sublen;
@@ -1924,7 +1924,7 @@ repeated_field_pack_to_buffer(const ProtobufCFieldDescriptor *field,
 		size_t tmp;
 
 		scratch[0] |= PROTOBUF_C_WIRE_TYPE_LENGTH_PREFIXED;
-		rv += uint32_pack(payload_len, scratch + rv);
+		rv += uint32_pack((uint32_t) payload_len, scratch + rv);
 		buffer->append(buffer, rv, scratch);
 		tmp = pack_buffer_packed_payload(field, count, array, buffer);
 		assert(tmp == payload_len);

--- a/vendor/PHPLCrashReporter/Source/PLCrashAsyncDwarfCFAState.cpp
+++ b/vendor/PHPLCrashReporter/Source/PLCrashAsyncDwarfCFAState.cpp
@@ -117,7 +117,7 @@ dwarf_cfa_state<machine_ptr, machine_ptr_s>::dwarf_cfa_state (void) {
 template <typename machine_ptr, typename machine_ptr_s>
 bool dwarf_cfa_state<machine_ptr, machine_ptr_s>::set_register (dwarf_cfa_state_regnum_t regnum, plcrash_dwarf_cfa_reg_rule_t rule, machine_ptr value) {
     /* Check for an existing entry, or find the target entry off which we'll chain our entry */
-    unsigned int bucket = regnum % (sizeof(_table_stack[0]) / sizeof(_table_stack[0][0]));
+    size_t bucket = regnum % (sizeof(_table_stack[0]) / sizeof(_table_stack[0][0]));
     
     dwarf_cfa_reg_entry_t *parent = NULL;
     for (uint8_t parent_idx = _table_stack[_table_depth][bucket]; parent_idx != DWARF_CFA_STATE_INVALID_ENTRY_IDX; parent_idx = parent->next) {
@@ -177,7 +177,7 @@ bool dwarf_cfa_state<machine_ptr, machine_ptr_s>::set_register (dwarf_cfa_state_
 template <typename machine_ptr, typename machine_ptr_s>
 bool dwarf_cfa_state<machine_ptr, machine_ptr_s>::get_register_rule (dwarf_cfa_state_regnum_t regnum, plcrash_dwarf_cfa_reg_rule_t *rule, machine_ptr *value) {
     /* Search for the entry */
-    unsigned int bucket = regnum % (sizeof(_table_stack[0]) / sizeof(_table_stack[0][0]));
+    size_t bucket = regnum % (sizeof(_table_stack[0]) / sizeof(_table_stack[0][0]));
     
     dwarf_cfa_reg_entry_t *entry = NULL;
     for (uint8_t entry_idx = _table_stack[_table_depth][bucket]; entry_idx != DWARF_CFA_STATE_INVALID_ENTRY_IDX; entry_idx = entry->next) {
@@ -208,7 +208,7 @@ bool dwarf_cfa_state<machine_ptr, machine_ptr_s>::get_register_rule (dwarf_cfa_s
 template <typename machine_ptr, typename machine_ptr_s>
 void dwarf_cfa_state<machine_ptr, machine_ptr_s>::remove_register (dwarf_cfa_state_regnum_t regnum) {
     /* Search for the entry */
-    unsigned int bucket = regnum % (sizeof(_table_stack[0]) / sizeof(_table_stack[0][0]));
+    size_t bucket = regnum % (sizeof(_table_stack[0]) / sizeof(_table_stack[0][0]));
     
     dwarf_cfa_reg_entry *prev = NULL;
     dwarf_cfa_reg_entry_t *entry = NULL;

--- a/vendor/UPSTREAM.md
+++ b/vendor/UPSTREAM.md
@@ -11,7 +11,7 @@ This file records the upstream sources and commit hashes used to pull vendored d
 
 ## Notes
 
-- `PHPLCrashReporter` commit is verified against upstream history.
+- `PHPLCrashReporter` commit is verified against upstream history. The vendored copy includes local compiler-warning cleanup for explicit integer conversions in PLCrashReporter/protobuf-c sources.
 - `libwebp` commit is inferred from the vendored code ABI surface and import timing.
 - `libwebp` was slimmed down after vendoring to remove unused components (for example, animated image support paths) and keep the SDK footprint smaller.
 - Both vendored dependencies include local PostHog-prefixed/private integration changes after import.


### PR DESCRIPTION
## :bulb: Motivation and Context

Reduce noisy compiler output from vendored PLCrashReporter/protobuf-c sources by making existing integer conversions explicit.

This is a non-user-facing build log cleanup, so no changeset was added.

## :green_heart: How did you test it?

- `make buildSdk`
- `make test`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented a small build-log cleanup requested by the maintainer. The changes are limited to vendored C/C++ sources and preserve existing runtime behavior by replacing implicit integer conversions with explicit casts/types. Added a note in `vendor/UPSTREAM.md` documenting the local vendored warning cleanup. No changeset was added because this is not user-facing.
