### PR TITLE
fix: silence vendored analyzer warnings

### DIFF
--- a/vendor/PHPLCrashReporter/Source/PLCrashAsync.h
+++ b/vendor/PHPLCrashReporter/Source/PLCrashAsync.h
@@ -123,7 +123,11 @@ typedef int64_t pl_vm_off_t;
 
 // assert() support. We prefer to leave assertions on in release builds, but need
 // to disable them in async-safe code paths.
-#ifdef PLCF_RELEASE_BUILD
+#if defined(__clang_analyzer__)
+
+#define PLCF_ASSERT(expr) do { if (!(expr)) __builtin_unreachable(); } while (0)
+
+#elif defined(PLCF_RELEASE_BUILD)
 
 #define PLCF_ASSERT(expr)
 

--- a/vendor/PHPLCrashReporter/Source/PLCrashAsyncThread_arm.c
+++ b/vendor/PHPLCrashReporter/Source/PLCrashAsyncThread_arm.c
@@ -534,4 +534,6 @@ bool plcrash_async_thread_state_map_dwarf_to_reg (const plcrash_async_thread_sta
     return false;
 }
 
+#else
+__attribute__((used, visibility("hidden"))) const int PLCrashAsyncThreadArmTranslationUnitAnchor = 0;
 #endif /* __arm__ || __arm64__ */

--- a/vendor/UPSTREAM.md
+++ b/vendor/UPSTREAM.md
@@ -14,4 +14,4 @@ This file records the upstream sources and commit hashes used to pull vendored d
 - `PHPLCrashReporter` commit is verified against upstream history. The vendored copy includes local compiler-warning cleanup for explicit integer conversions in PLCrashReporter/protobuf-c sources.
 - `libwebp` commit is inferred from the vendored code ABI surface and import timing.
 - `libwebp` was slimmed down after vendoring to remove unused components (for example, animated image support paths) and keep the SDK footprint smaller.
-- Both vendored dependencies include local PostHog-prefixed/private integration changes after import.
+- Both vendored dependencies include local PostHog-prefixed/private integration changes after import, including assertion contracts that are made explicit for Clang static analyzer runs.

--- a/vendor/libwebp/ph_utils.h
+++ b/vendor/libwebp/ph_utils.h
@@ -59,7 +59,11 @@ static inline void posthog_ASSERT(bool condition, const char *file, int line) {
 /**
  * Macro to capture FILE and LINE for `posthog_ASSERT`.
  */
+#if defined(__clang_analyzer__)
+#define ASSERT(condition) do { if (!(condition)) __builtin_unreachable(); } while (0)
+#else
 #define ASSERT(condition) posthog_ASSERT((condition) ? true : false, __FILE__, __LINE__)
+#endif
 
 
 static WEBP_INLINE int CheckSizeOverflow(uint64_t size) {


### PR DESCRIPTION
## Summary
- make vendored libwebp ASSERT contracts visible to Clang static analyzer
- make PLCrashReporter PLCF_ASSERT contracts visible to Clang static analyzer
- add a hidden translation-unit anchor for the non-arm PLCrashAsyncThread_arm.c slice
- document the vendored analyzer assertion contract in vendor/UPSTREAM.md

## Validation
- xcrun --sdk iphonesimulator clang --analyze on the noisy libwebp files
- xcrun --sdk iphonesimulator clang --analyze -fobjc-arc on PLCrashLogWriter.m
- direct compile of PLCrashAsyncThread_arm.c for x86_64 and arm64 simulator
- swift build