### PR TITLE
chore: add changeset for upload symbols path fix

### DIFF
--- a/.changeset/brave-badgers-upload.md
+++ b/.changeset/brave-badgers-upload.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': patch
+---
+
+Fix the upload symbols script for projects with spaces in their paths.


### PR DESCRIPTION
## :bulb: Motivation and Context
PR #699 fixed the upload symbols script for projects with spaces in their paths, but it was merged without a changeset.

Refs #698 and #699.

## :green_heart: How did you test it?
Verified the changeset file contents and ran `pnpm changeset status --since main` to confirm `posthog-ios` gets a patch bump.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A coding agent added the missing patch changeset for the already-merged upload symbols path handling fix. The change is limited to a single `.changeset` file; no SDK source code was modified.
