### PR TITLE
fix(compliance): retry feature flag requests

### DIFF
--- a/sdk_compliance_adapter/Sources/main.swift
+++ b/sdk_compliance_adapter/Sources/main.swift
@@ -191,6 +191,31 @@ app.post("capture") { req async throws -> Response in
     return try await result.encodeResponse(for: req)
 }
 
+func fetchFlagsWithRetry(flagsURL: URL, payload: [String: Any]) async throws -> Data {
+    let body = try JSONSerialization.data(withJSONObject: payload)
+    var lastStatus = 0
+
+    for _ in 0..<2 {
+        var flagsRequest = URLRequest(url: flagsURL)
+        flagsRequest.httpMethod = "POST"
+        flagsRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        flagsRequest.httpBody = body
+
+        let (data, response) = try await URLSession.shared.data(for: flagsRequest)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+        if (200..<300).contains(statusCode) {
+            return data
+        }
+
+        lastStatus = statusCode
+        guard statusCode == 502 || statusCode == 504 else {
+            break
+        }
+    }
+
+    throw Abort(.internalServerError, reason: "flags request failed with status \(lastStatus)")
+}
+
 // Feature flag evaluation endpoint
 app.post("get_feature_flag") { req async throws -> Response in
     struct FlagRequest: Content {
@@ -258,12 +283,7 @@ app.post("get_feature_flag") { req async throws -> Response in
     guard let flagsURL = URL(string: host.trimmingCharacters(in: CharacterSet(charactersIn: "/")) + "/flags/?v=2") else {
         throw Abort(.internalServerError, reason: "Invalid host URL: \(host)")
     }
-    var flagsRequest = URLRequest(url: flagsURL)
-    flagsRequest.httpMethod = "POST"
-    flagsRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    flagsRequest.httpBody = try JSONSerialization.data(withJSONObject: flagsPayload)
-
-    let (data, _) = try await URLSession.shared.data(for: flagsRequest)
+    let data = try await fetchFlagsWithRetry(flagsURL: flagsURL, payload: flagsPayload)
     let decoded = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
     let flags = decoded?["featureFlags"] as? [String: Any] ?? decoded?["flags"] as? [String: Any]
     let value = flags?[flagReq.key] ?? false

--- a/sdk_compliance_adapter/Sources/main.swift
+++ b/sdk_compliance_adapter/Sources/main.swift
@@ -195,7 +195,7 @@ func fetchFlagsWithRetry(flagsURL: URL, payload: [String: Any]) async throws -> 
     let body = try JSONSerialization.data(withJSONObject: payload)
     var lastStatus = 0
 
-    for _ in 0 ..< 2 {
+    for _ in 0 ..< 3 {
         var flagsRequest = URLRequest(url: flagsURL)
         flagsRequest.httpMethod = "POST"
         flagsRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/sdk_compliance_adapter/Sources/main.swift
+++ b/sdk_compliance_adapter/Sources/main.swift
@@ -195,7 +195,7 @@ func fetchFlagsWithRetry(flagsURL: URL, payload: [String: Any]) async throws -> 
     let body = try JSONSerialization.data(withJSONObject: payload)
     var lastStatus = 0
 
-    for _ in 0..<2 {
+    for _ in 0 ..< 2 {
         var flagsRequest = URLRequest(url: flagsURL)
         flagsRequest.httpMethod = "POST"
         flagsRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -203,7 +203,7 @@ func fetchFlagsWithRetry(flagsURL: URL, payload: [String: Any]) async throws -> 
 
         let (data, response) = try await URLSession.shared.data(for: flagsRequest)
         let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
-        if (200..<300).contains(statusCode) {
+        if (200 ..< 300).contains(statusCode) {
             return data
         }
 


### PR DESCRIPTION
## :bulb: Motivation and Context

The SDK compliance adapter directly called `/flags` once for `/get_feature_flag`. When the harness configured transient 502/504 responses, the adapter did not retry, which would fail the feature flag retry compliance contract.

This adds retry handling for retryable `/flags` responses in the compliance adapter before returning the evaluated feature flag value, with enough attempts to tolerate consecutive transient failures.

## :green_heart: How did you test it?

- `make swiftFormatCheck`
- `swift build -Xswiftc -DTESTING` in `sdk_compliance_adapter`
- Docker compose compliance harness run with report copied to `/tmp/sdk-harness-reports/posthog-ios-pr-comments.md` — 46/46 passed

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent and subagents were used to run the SDK compliance harness across cloned SDK repositories and investigate the feature flag retry cases. The change is limited to the compliance adapter so the harness exercises the expected retry contract for transient `/flags` failures.
