### PR TITLE
fix: Session Replay crash on AVAggregateAssetDownl oadTask when resume() probes currentRequest

### DIFF
--- a/.changeset/fine-colts-attend.md
+++ b/.changeset/fine-colts-attend.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+fix: prevent Session Replay crashes on AVAggregateAssetDownloadTask

--- a/Package.swift
+++ b/Package.swift
@@ -26,13 +26,22 @@ let package = Package(
         .target(
             name: "PostHog",
             dependencies: [
+                "PostHogObjCExceptionSupport",
                 "phlibwebp",
                 .target(name: "PHPLCrashReporter", condition: .when(platforms: [.iOS, .macOS, .tvOS])),
             ],
             path: "PostHog",
+            exclude: [
+                "ObjCExceptionSupport",
+            ],
             resources: [
                 .copy("Resources/PrivacyInfo.xcprivacy"),
             ]
+        ),
+        .target(
+            name: "PostHogObjCExceptionSupport",
+            path: "PostHog/ObjCExceptionSupport",
+            publicHeadersPath: "."
         ),
         .target(
             name: "phlibwebp",

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -25,13 +25,22 @@ let package = Package(
         .target(
             name: "PostHog",
             dependencies: [
+                "PostHogObjCExceptionSupport",
                 "phlibwebp",
                 .target(name: "PHPLCrashReporter", condition: .when(platforms: [.iOS, .macOS, .macCatalyst, .tvOS])),
             ],
             path: "PostHog",
+            exclude: [
+                "ObjCExceptionSupport",
+            ],
             resources: [
                 .copy("Resources/PrivacyInfo.xcprivacy"),
             ]
+        ),
+        .target(
+            name: "PostHogObjCExceptionSupport",
+            path: "PostHog/ObjCExceptionSupport",
+            publicHeadersPath: "."
         ),
         .target(
             name: "phlibwebp",

--- a/PostHog.podspec
+++ b/PostHog.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) PLCR_PRIVATE PLCF_RELEASE_BUILD PLCRASHREPORTER_PREFIX=PH SWIFT_PACKAGE',
     'HEADER_SEARCH_PATHS' => '$(inherited) "${PODS_TARGET_SRCROOT}/vendor/PHPLCrashReporter/Dependencies/protobuf-c" "${PODS_TARGET_SRCROOT}/vendor/PHPLCrashReporter/Dependencies/protobuf-c/protobuf-c" "${PODS_TARGET_SRCROOT}/vendor/PHPLCrashReporter/Source"',
-    'SWIFT_INCLUDE_PATHS' => '$(inherited) "${PODS_TARGET_SRCROOT}/PostHog/PrivateModules/phlibwebp" "${PODS_TARGET_SRCROOT}/PostHog/PrivateModules/PHPLCrashReporter"'
+    'SWIFT_INCLUDE_PATHS' => '$(inherited) "${PODS_TARGET_SRCROOT}/PostHog/PrivateModules/phlibwebp" "${PODS_TARGET_SRCROOT}/PostHog/PrivateModules/PHPLCrashReporter" "${PODS_TARGET_SRCROOT}/PostHog/PrivateModules/PostHogObjCExceptionSupport"'
   }
 
   s.source_files = [
@@ -44,6 +44,7 @@ Pod::Spec.new do |s|
   # Only PostHog's umbrella header should be public; vendored implementation headers stay private.
   s.public_header_files = 'PostHog/PostHog.h'
   s.private_header_files = [
+    'PostHog/ObjCExceptionSupport/PHURLSessionTaskSafeAccess.h',
     'vendor/libwebp/**/*.h',
     'vendor/PHPLCrashReporter/Source/**/*.{h,hpp}',
     'vendor/PHPLCrashReporter/Dependencies/protobuf-c/**/*.h'

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		3AA34D01296D951B003398F4 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3AA34D00296D951B003398F4 /* Preview Assets.xcassets */; };
 		3AA34D17296D9993003398F4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA34D16296D9993003398F4 /* AppDelegate.swift */; };
 		3AC745C6296D6FE60025C109 /* PostHog.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AC745B8296D6FE60025C109 /* PostHog.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1A0B0063A0B000100000001 /* PHURLSessionTaskSafeAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = E1A0B0023A0B000100000001 /* PHURLSessionTaskSafeAccess.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E1A0B0013A0B000100000001 /* PHURLSessionTaskSafeAccess.m in Sources */ = {isa = PBXBuildFile; fileRef = E1A0B0033A0B000100000001 /* PHURLSessionTaskSafeAccess.m */; };
 		3AE3FB2C2991320300AFFC18 /* Api.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE3FB2B2991320300AFFC18 /* Api.swift */; };
 		3AE3FB332991388500AFFC18 /* PostHogQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE3FB322991388500AFFC18 /* PostHogQueue.swift */; };
 		3AE3FB37299162EA00AFFC18 /* PostHogApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE3FB36299162EA00AFFC18 /* PostHogApi.swift */; };
@@ -75,6 +77,7 @@
 		690FF0ED2AEFF23300A0B06B /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 690FF0EC2AEFF23300A0B06B /* Nimble */; };
 		690FF0EF2AEFF23D00A0B06B /* OHHTTPStubsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 690FF0EE2AEFF23D00A0B06B /* OHHTTPStubsSwift */; };
 		690FF0F12AEFF24200A0B06B /* OHHTTPStubs in Frameworks */ = {isa = PBXBuildFile; productRef = 690FF0F02AEFF24200A0B06B /* OHHTTPStubs */; };
+		E1A0B0203A0D000100000001 /* CwlCatchException in Frameworks */ = {isa = PBXBuildFile; productRef = E1A0B0213A0D000100000001 /* CwlCatchException */; };
 		690FF0F52AF0F06100A0B06B /* PostHogSDKTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690FF0F42AF0F06100A0B06B /* PostHogSDKTest.swift */; };
 		69261D132AD5685B00232EC7 /* PostHogRemoteConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69261D122AD5685B00232EC7 /* PostHogRemoteConfig.swift */; };
 		69261D192AD9673500232EC7 /* PostHogUploadInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69261D182AD9673500232EC7 /* PostHogUploadInfo.swift */; };
@@ -787,6 +790,8 @@
 		3AC745B5296D6FE60025C109 /* PostHog.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PostHog.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AC745B8296D6FE60025C109 /* PostHog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PostHog.h; sourceTree = "<group>"; };
 		3AC745BF296D6FE60025C109 /* PostHogTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PostHogTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		E1A0B0023A0B000100000001 /* PHURLSessionTaskSafeAccess.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PHURLSessionTaskSafeAccess.h; sourceTree = "<group>"; };
+		E1A0B0033A0B000100000001 /* PHURLSessionTaskSafeAccess.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PHURLSessionTaskSafeAccess.m; sourceTree = "<group>"; };
 		3AE3FB2B2991320300AFFC18 /* Api.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Api.swift; sourceTree = "<group>"; };
 		3AE3FB322991388500AFFC18 /* PostHogQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogQueue.swift; sourceTree = "<group>"; };
 		3AE3FB36299162EA00AFFC18 /* PostHogApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogApi.swift; sourceTree = "<group>"; };
@@ -1414,6 +1419,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E1A0B0203A0D000100000001 /* CwlCatchException in Frameworks */,
 				690FF0F12AEFF24200A0B06B /* OHHTTPStubs in Frameworks */,
 				DA929C082D0B3A1D0018369C /* PostHog.framework in Frameworks */,
 				690FF0ED2AEFF23300A0B06B /* Nimble in Frameworks */,
@@ -1577,6 +1583,7 @@
 				DACC08B52D6E3C6800115E46 /* PostHogIntegration.swift */,
 				DAB06F9C2D09A744005B1C9B /* PostHog.modulemap */,
 				3AC745B8296D6FE60025C109 /* PostHog.h */,
+				E1A0B0053A0B000100000001 /* ObjCExceptionSupport */,
 				DA1D29612D115E13003A31DA /* DI.swift */,
 				DA578E912D6768A100B3A56C /* ScreenViews */,
 				DA703C132D6615300069097B /* AppLifeCycle */,
@@ -1614,6 +1621,15 @@
 				D977A46D673A5FA52C03105F /* Logs */,
 			);
 			path = PostHog;
+			sourceTree = "<group>";
+		};
+		E1A0B0053A0B000100000001 /* ObjCExceptionSupport */ = {
+			isa = PBXGroup;
+			children = (
+				E1A0B0023A0B000100000001 /* PHURLSessionTaskSafeAccess.h */,
+				E1A0B0033A0B000100000001 /* PHURLSessionTaskSafeAccess.m */,
+			);
+			path = ObjCExceptionSupport;
 			sourceTree = "<group>";
 		};
 		3AC745C3296D6FE60025C109 /* PostHogTests */ = {
@@ -2516,6 +2532,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3AC745C6296D6FE60025C109 /* PostHog.h in Headers */,
+				E1A0B0063A0B000100000001 /* PHURLSessionTaskSafeAccess.h in Headers */,
 				DA0B66A52D64EC00006F5FF3 /* ph_sharpyuv_csp.h in Headers */,
 				DA0B66A62D64EC00006F5FF3 /* ph_sharpyuv_dsp.h in Headers */,
 				DA0B66A72D64EC00006F5FF3 /* ph_huffman_utils.h in Headers */,
@@ -2706,6 +2723,7 @@
 			);
 			name = PostHogTests;
 			packageProductDependencies = (
+				E1A0B0213A0D000100000001 /* CwlCatchException */,
 				690FF0EA2AEFF22F00A0B06B /* Quick */,
 				690FF0EC2AEFF23300A0B06B /* Nimble */,
 				690FF0EE2AEFF23D00A0B06B /* OHHTTPStubsSwift */,
@@ -2837,6 +2855,7 @@
 			);
 			mainGroup = 3AC745AB296D6FE60025C109;
 			packageReferences = (
+				E1A0B0223A0D000100000001 /* XCRemoteSwiftPackageReference "CwlCatchException" */,
 				3A867B6E29C1DF73009D0852 /* XCRemoteSwiftPackageReference "Quick" */,
 				3A867B7129C1DFEF009D0852 /* XCRemoteSwiftPackageReference "Nimble" */,
 				3A580B3D29E481F200C5C6F3 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */,
@@ -3066,6 +3085,7 @@
 				DAB9E23D2DE8901D00E62DB9 /* URLSessionExtension.swift in Sources */,
 				DAB9E23E2DE8901D00E62DB9 /* URLSessionSwizzler.swift in Sources */,
 				DAB9E23F2DE8901D00E62DB9 /* URLSessionInterceptor.swift in Sources */,
+				E1A0B0013A0B000100000001 /* PHURLSessionTaskSafeAccess.m in Sources */,
 				DA5175B32F6C4CEA00F0E00A /* PostHogReplayBufferDelegate.swift in Sources */,
 				DA5175B42F6C4CEA00F0E00A /* PostHogReplayBufferQueue.swift in Sources */,
 				69F23A782BB30991001194F6 /* NetworkSample.swift in Sources */,
@@ -3813,7 +3833,7 @@
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/PostHog/PrivateModules/phlibwebp $(SRCROOT)/PostHog/PrivateModules/PHPLCrashReporter";
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/PostHog/PrivateModules/phlibwebp $(SRCROOT)/PostHog/PrivateModules/PHPLCrashReporter $(SRCROOT)/PostHog/PrivateModules/PostHogObjCExceptionSupport";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,7";
@@ -3887,7 +3907,7 @@
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/PostHog/PrivateModules/phlibwebp $(SRCROOT)/PostHog/PrivateModules/PHPLCrashReporter";
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/PostHog/PrivateModules/phlibwebp $(SRCROOT)/PostHog/PrivateModules/PHPLCrashReporter $(SRCROOT)/PostHog/PrivateModules/PostHogObjCExceptionSupport";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,7";
@@ -4379,7 +4399,7 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG TESTING";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/PostHog/PrivateModules/phlibwebp $(SRCROOT)/PostHog/PrivateModules/PHPLCrashReporter";
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/PostHog/PrivateModules/phlibwebp $(SRCROOT)/PostHog/PrivateModules/PHPLCrashReporter $(SRCROOT)/PostHog/PrivateModules/PostHogObjCExceptionSupport";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,7";
@@ -4696,6 +4716,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		E1A0B0223A0D000100000001 /* XCRemoteSwiftPackageReference "CwlCatchException" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mattgallagher/CwlCatchException.git";
+			requirement = {
+				kind = exactVersion;
+				version = 2.2.1;
+			};
+		};
 		3A580B3D29E481F200C5C6F3 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/AliSoftware/OHHTTPStubs";
@@ -4723,6 +4751,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		E1A0B0213A0D000100000001 /* CwlCatchException */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E1A0B0223A0D000100000001 /* XCRemoteSwiftPackageReference "CwlCatchException" */;
+			productName = CwlCatchException;
+		};
 		690FF0EA2AEFF22F00A0B06B /* Quick */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 3A867B6E29C1DF73009D0852 /* XCRemoteSwiftPackageReference "Quick" */;

--- a/PostHog/ObjCExceptionSupport/PHURLSessionTaskSafeAccess.h
+++ b/PostHog/ObjCExceptionSupport/PHURLSessionTaskSafeAccess.h
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PHURLSessionTaskSafeAccess : NSObject
+
++ (nullable NSURLRequest *)currentRequestFromTask:(NSURLSessionTask *)task NS_SWIFT_NAME(currentRequest(from:));
++ (BOOL)setCurrentRequest:(NSURLRequest *)request onTask:(NSURLSessionTask *)task key:(NSString *)key NS_SWIFT_NAME(setCurrentRequest(_:on:key:));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/PostHog/ObjCExceptionSupport/PHURLSessionTaskSafeAccess.m
+++ b/PostHog/ObjCExceptionSupport/PHURLSessionTaskSafeAccess.m
@@ -1,0 +1,22 @@
+#import "PHURLSessionTaskSafeAccess.h"
+
+@implementation PHURLSessionTaskSafeAccess
+
++ (nullable NSURLRequest *)currentRequestFromTask:(NSURLSessionTask *)task {
+    @try {
+        return task.currentRequest;
+    } @catch (__unused NSException *exception) {
+        return nil;
+    }
+}
+
++ (BOOL)setCurrentRequest:(NSURLRequest *)request onTask:(NSURLSessionTask *)task key:(NSString *)key {
+    @try {
+        [task setValue:request forKey:key];
+        return YES;
+    } @catch (__unused NSException *exception) {
+        return NO;
+    }
+}
+
+@end

--- a/PostHog/PrivateModules/PostHogObjCExceptionSupport/module.modulemap
+++ b/PostHog/PrivateModules/PostHogObjCExceptionSupport/module.modulemap
@@ -1,0 +1,4 @@
+module PostHogObjCExceptionSupport {
+  header "../../ObjCExceptionSupport/PHURLSessionTaskSafeAccess.h"
+  export *
+}

--- a/PostHog/Replay/Plugins/Network/URLSessionSwizzler.swift
+++ b/PostHog/Replay/Plugins/Network/URLSessionSwizzler.swift
@@ -9,6 +9,7 @@
 #if os(iOS)
 
     import Foundation
+    @_implementationOnly import PostHogObjCExceptionSupport
 
     final class URLSessionInstrumentation {
         typealias RequestModifier = (URLRequest) -> URLRequest
@@ -306,13 +307,23 @@
                 }
             }
 
-            private func modifyTaskRequests(_ task: URLSessionTask) {
+            // Internal, used for testing
+            func modifyTaskRequests(_ task: URLSessionTask) {
                 // Only rewrite `currentRequest` for the async/await fallback path.
                 // This is the request closest to what will go over the wire and avoids
-                // mutating `originalRequest` unnecessarily. Use KVC instead of invoking
-                // a private setter selector directly.
-                if let currentRequest = task.currentRequest {
-                    task.setValue(modifyRequest(currentRequest) as NSURLRequest, forKey: Self.currentRequestKey)
+                // mutating `originalRequest` unnecessarily. Some task subclasses throw
+                // on request access or mutation, so this path has to stay best-effort.
+                guard let currentRequest = PHURLSessionTaskSafeAccess.currentRequest(from: task) as URLRequest? else {
+                    hedgeLog("[Session Replay] Skipping request header injection for task \(NSStringFromClass(type(of: task))) because currentRequest is unavailable")
+                    return
+                }
+
+                if !PHURLSessionTaskSafeAccess.setCurrentRequest(
+                    modifyRequest(currentRequest),
+                    on: task,
+                    key: Self.currentRequestKey
+                ) {
+                    hedgeLog("[Session Replay] Failed to inject tracing headers into currentRequest for task \(NSStringFromClass(type(of: task)))")
                 }
             }
         }

--- a/PostHogTests/PostHogSessionReplayPluginTest.swift
+++ b/PostHogTests/PostHogSessionReplayPluginTest.swift
@@ -1,6 +1,9 @@
 #if os(iOS)
     import Foundation
     @testable import PostHog
+    #if !SWIFT_PACKAGE
+        import CwlCatchException
+    #endif
     import Testing
 
     @Suite("Session Replay Plugin Remote Config Tests")
@@ -218,5 +221,201 @@
                 ) == testCase.expected
             )
         }
+
+        #if !SWIFT_PACKAGE
+            @Test("Task resume fallback ignores AVFoundation tasks that throw on currentRequest")
+            func taskResumeFallbackIgnoresAVFoundationTasksThatThrowOnCurrentRequest() throws {
+                let swizzler = try URLSessionSwizzler.TaskResume.build { request in
+                    var modifiedRequest = request
+                    modifiedRequest.setValue("1", forHTTPHeaderField: "X-PostHog-Test")
+                    return modifiedRequest
+                }
+
+                let task = ThrowingAggregateAssetDownloadTask()
+
+                let exception = NSException.catchException {
+                    swizzler.modifyTaskRequests(task)
+                }
+
+                #expect(exception == nil)
+                #expect(task.didAttemptCurrentRequestMutation == false)
+            }
+
+            @Test("Task resume fallback ignores generic getter exceptions when probing currentRequest")
+            func taskResumeFallbackIgnoresGenericGetterExceptionsWhenProbingCurrentRequest() throws {
+                let swizzler = try URLSessionSwizzler.TaskResume.build { request in
+                    var modifiedRequest = request
+                    modifiedRequest.setValue("1", forHTTPHeaderField: "X-PostHog-Test")
+                    return modifiedRequest
+                }
+
+                let task = ThrowingCurrentRequestTask()
+
+                let exception = NSException.catchException {
+                    swizzler.modifyTaskRequests(task)
+                }
+
+                #expect(exception == nil)
+                #expect(task.didAttemptCurrentRequestMutation == false)
+            }
+
+            @Test("Task resume fallback ignores tasks whose currentRequest is nil")
+            func taskResumeFallbackIgnoresTasksWhoseCurrentRequestIsNil() throws {
+                let swizzler = try URLSessionSwizzler.TaskResume.build { request in
+                    var modifiedRequest = request
+                    modifiedRequest.setValue("1", forHTTPHeaderField: "X-PostHog-Test")
+                    return modifiedRequest
+                }
+
+                let task = NilCurrentRequestTask()
+
+                let exception = NSException.catchException {
+                    swizzler.modifyTaskRequests(task)
+                }
+
+                #expect(exception == nil)
+                #expect(task.currentRequest == nil)
+                #expect(task.didAttemptCurrentRequestMutation == false)
+            }
+
+            @Test("Task resume fallback still rewrites standard request-backed tasks")
+            func taskResumeFallbackStillRewritesStandardRequestBackedTasks() throws {
+                let swizzler = try URLSessionSwizzler.TaskResume.build { request in
+                    var modifiedRequest = request
+                    modifiedRequest.setValue("1", forHTTPHeaderField: "X-PostHog-Test")
+                    return modifiedRequest
+                }
+
+                let url = try #require(URL(string: "https://example.com"))
+                let task = MutableCurrentRequestTask(request: URLRequest(url: url))
+
+                swizzler.modifyTaskRequests(task)
+
+                #expect(task.currentRequest?.value(forHTTPHeaderField: "X-PostHog-Test") == "1")
+            }
+
+            @Test("Task resume fallback ignores setter exceptions when mutating currentRequest")
+            func taskResumeFallbackIgnoresSetterExceptionsWhenMutatingCurrentRequest() throws {
+                let swizzler = try URLSessionSwizzler.TaskResume.build { request in
+                    var modifiedRequest = request
+                    modifiedRequest.setValue("1", forHTTPHeaderField: "X-PostHog-Test")
+                    return modifiedRequest
+                }
+
+                let url = try #require(URL(string: "https://example.com"))
+                let task = ThrowingCurrentRequestSetterTask(request: URLRequest(url: url))
+
+                let exception = NSException.catchException {
+                    swizzler.modifyTaskRequests(task)
+                }
+
+                #expect(exception == nil)
+                #expect(task.currentRequest?.value(forHTTPHeaderField: "X-PostHog-Test") == nil)
+            }
+        #endif
     }
+
+    #if !SWIFT_PACKAGE
+        @objc(TestAVAggregateAssetDownloadTaskNoChildTask)
+        private final class ThrowingAggregateAssetDownloadTask: URLSessionTask, @unchecked Sendable {
+            private(set) var didAttemptCurrentRequestMutation = false
+
+            override var currentRequest: URLRequest? {
+                NSException(
+                    name: NSExceptionName("UnsupportedCurrentRequest"),
+                    reason: "AVAggregateAssetDownloadTask does not support currentRequest",
+                    userInfo: nil
+                ).raise()
+                return nil
+            }
+
+            override func setValue(_ value: Any?, forKey key: String) {
+                if key == "currentRequest" {
+                    didAttemptCurrentRequestMutation = true
+                }
+
+                super.setValue(value, forKey: key)
+            }
+        }
+
+        private final class ThrowingCurrentRequestTask: URLSessionTask, @unchecked Sendable {
+            private(set) var didAttemptCurrentRequestMutation = false
+
+            override var currentRequest: URLRequest? {
+                NSException(
+                    name: NSExceptionName("UnsupportedCurrentRequest"),
+                    reason: "Task does not support currentRequest",
+                    userInfo: nil
+                ).raise()
+                return nil
+            }
+
+            override func setValue(_ value: Any?, forKey key: String) {
+                if key == "currentRequest" {
+                    didAttemptCurrentRequestMutation = true
+                }
+
+                super.setValue(value, forKey: key)
+            }
+        }
+
+        private final class NilCurrentRequestTask: URLSessionTask, @unchecked Sendable {
+            private(set) var didAttemptCurrentRequestMutation = false
+
+            override var currentRequest: URLRequest? {
+                nil
+            }
+
+            override func setValue(_ value: Any?, forKey key: String) {
+                if key == "currentRequest" {
+                    didAttemptCurrentRequestMutation = true
+                }
+
+                super.setValue(value, forKey: key)
+            }
+        }
+
+        private final class MutableCurrentRequestTask: URLSessionTask, @unchecked Sendable {
+            private var storedCurrentRequest: NSURLRequest?
+
+            init(request: URLRequest) {
+                storedCurrentRequest = request as NSURLRequest
+                super.init()
+            }
+
+            override var currentRequest: URLRequest? {
+                storedCurrentRequest as URLRequest?
+            }
+
+            @objc(setCurrentRequest:)
+            func setCurrentRequest(_ request: NSURLRequest) {
+                storedCurrentRequest = request
+            }
+        }
+
+        private final class ThrowingCurrentRequestSetterTask: URLSessionTask, @unchecked Sendable {
+            private let storedCurrentRequest: NSURLRequest
+
+            init(request: URLRequest) {
+                storedCurrentRequest = request as NSURLRequest
+                super.init()
+            }
+
+            override var currentRequest: URLRequest? {
+                storedCurrentRequest as URLRequest
+            }
+
+            override func setValue(_ value: Any?, forKey key: String) {
+                if key == "currentRequest" {
+                    NSException(
+                        name: NSExceptionName("UnsupportedCurrentRequestMutation"),
+                        reason: "Task does not support mutating currentRequest",
+                        userInfo: nil
+                    ).raise()
+                }
+
+                super.setValue(value, forKey: key)
+            }
+        }
+    #endif
 #endif


### PR DESCRIPTION
## :bulb: Motivation and Context
Fixes #703.

Session Replay network instrumentation currently assumes every URLSessionTask subclass safely exposes and mutates currentRequest during the swizzled resume() path. That breaks for AVFoundation-backed download tasks such as AVAggregateAssetDownloadTask, which can raise NSGenericException on request access instead of returning nil.

This change makes request probing and mutation best-effort by routing both operations through a small Objective-C @try/@catch helper. Unsupported task subclasses now skip request rewriting instead of crashing the host app.


## :green_heart: How did you test it?
Ran the focused iOS regression suite:
`xcrun xcodebuild test -scheme PostHog -destination 'platform=iOS Simulator,OS=18.6,name=iPhone 16' -only-testing:PostHogTests/PostHogSessionReplayPluginTests`

Ran a SwiftPM build to verify the new Objective-C helper target and package wiring:
`swift build`


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context
Autonomy: Human-driven (agent-assisted)

This change was prepared with Codex in Conductor.

A narrow class-name skip for AVFoundation tasks was considered as a stopgap, but it only fixes the reported crash and leaves the underlying assumption intact. The final change uses an internal Objective-C exception boundary because the real failure mode is NSException from request access/mutation, and Swift cannot catch that safely.

Regression coverage was added for three cases: AVFoundation-style getter exceptions, generic getter exceptions, and setter exceptions, while preserving the normal request-rewrite path for standard request-backed tasks.
