### PR TITLE
chore: group codeql-action Dependabot bumps into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    cooldown:
-      default-days: 7
     directory: "/"
     schedule:
       interval: weekly
@@ -10,3 +8,7 @@ updates:
       default-days: 7
     reviewers:
       - "PostHog/team-client-libraries"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"


### PR DESCRIPTION
## Problem

`github/codeql-action` is a monorepo published as separate sub-actions (`init`, `analyze`, ...) that **must run the same version** in a job. Dependabot was opening a separate PR per sub-action, so each PR bumped only one and left the other behind, producing:

```
Loaded a configuration file for version '4.36.3', but running version '4.36.2'
```

We hit this with #706 / #705 (had to manually consolidate both bumps into #706 so CodeQL would pass).

## Fix

Group the `github/codeql-action*` actions so `init` and `analyze` always bump together in a single, self-consistent PR. Scoped to only the codeql-action family — every other action still updates in its own PR as before.

Also dropped a duplicate `cooldown:` key that was present in the config.