### PR TITLE
fix(queue): keep peek/pop aligned when a file is skipped (#702)

### DIFF
--- a/.changeset/quiet-queues-align.md
+++ b/.changeset/quiet-queues-align.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': patch
+---
+
+Fix event-queue peek/pop misalignment that could re-send already-delivered events when a file was skipped, and stop deleting valid queue files that are only temporarily unreadable (e.g. iOS data protection on a locked device).

--- a/PostHog/PostHogFileBackedQueue.swift
+++ b/PostHog/PostHogFileBackedQueue.swift
@@ -99,6 +99,7 @@ class PostHogFileBackedQueue {
 
     private func loadFiles(_ count: Int) -> [Data] {
         var results = [Data]()
+        var skipped = Set<String>()
 
         let itemsCopy = itemsLock.withLock { items }
 
@@ -107,23 +108,50 @@ class PostHogFileBackedQueue {
             do {
                 if !FileManager.default.fileExists(atPath: itemURL.path) {
                     hedgeLog("File \(itemURL) does not exist")
+                    skipped.insert(item)
                     continue
                 }
                 let contents = try Data(contentsOf: itemURL)
 
                 results.append(contents)
             } catch {
+                if isTemporarilyUnavailable(error) {
+                    hedgeLog("File \(itemURL) is temporarily unavailable, will retry \(error)")
+                    break
+                }
+
                 hedgeLog("File \(itemURL) is corrupted \(error)")
 
                 deleteSafely(itemURL)
+                skipped.insert(item)
             }
 
             if results.count == count {
-                return results
+                break
             }
         }
 
+        if !skipped.isEmpty {
+            itemsLock.withLock { items.removeAll { skipped.contains($0) } }
+        }
+
         return results
+    }
+
+    /// True when a read failed because the file is temporarily unreadable (iOS data protection on a
+    /// locked device) rather than corrupt, so it must be kept rather than deleted.
+    private func isTemporarilyUnavailable(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        if nsError.domain == NSCocoaErrorDomain, nsError.code == NSFileReadNoPermissionError {
+            return true
+        }
+        if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? NSError,
+           underlying.domain == NSPOSIXErrorDomain,
+           underlying.code == Int(EACCES) || underlying.code == Int(EPERM)
+        {
+            return true
+        }
+        return false
     }
 
     private func deleteFiles(_ count: Int) {

--- a/PostHogTests/PostHogFileBackedQueueAlignmentTest.swift
+++ b/PostHogTests/PostHogFileBackedQueueAlignmentTest.swift
@@ -52,38 +52,24 @@ struct PostHogFileBackedQueueAlignmentTest {
         #expect(queue.depth == 0)
     }
 
-    @Test("does not re-deliver a record when a missing file precedes returned items")
-    func missingFilePrecedingReturnedItems() throws {
-        let (queue, dir) = makeQueue()
-        defer { queue.clear()
-            try? FileManager.default.removeItem(at: dir)
-        }
-
-        enqueue(["A", "B", "C", "D"], into: queue)
-        try FileManager.default.removeItem(at: sortedFiles(in: dir)[0])
-
-        let batch1 = decode(queue.peek(2))
-        #expect(batch1 == ["B", "C"])
-        queue.pop(batch1.count)
-
-        let batch2 = decode(queue.peek(2))
-        #expect(Set(batch1).isDisjoint(with: Set(batch2)))
-        #expect(batch2 == ["D"])
+    enum UnreadableHead {
+        case missing // vanished from disk: !fileExists, pruned via `continue`
+        case corrupt // present but unreadable (Data(contentsOf:) throws): deleted then pruned
     }
 
-    @Test("does not re-deliver a record when a corrupt file precedes returned items")
-    func corruptFilePrecedingReturnedItems() throws {
+    @Test("does not re-deliver a record when an unreadable file precedes returned items", arguments: [UnreadableHead.missing, .corrupt])
+    func unreadableFilePrecedingReturnedItems(_ kind: UnreadableHead) throws {
         let (queue, dir) = makeQueue()
         defer { queue.clear()
             try? FileManager.default.removeItem(at: dir)
         }
 
         enqueue(["A", "B", "C", "D"], into: queue)
-
-        // present but unreadable: fileExists true, Data(contentsOf:) throws
         let head = try sortedFiles(in: dir)[0]
         try FileManager.default.removeItem(at: head)
-        try FileManager.default.createDirectory(at: head, withIntermediateDirectories: false)
+        if kind == .corrupt {
+            try FileManager.default.createDirectory(at: head, withIntermediateDirectories: false)
+        }
 
         let batch1 = decode(queue.peek(2))
         #expect(batch1 == ["B", "C"])

--- a/PostHogTests/PostHogFileBackedQueueAlignmentTest.swift
+++ b/PostHogTests/PostHogFileBackedQueueAlignmentTest.swift
@@ -1,0 +1,282 @@
+import Foundation
+@testable import PostHog
+import Testing
+
+@Suite("PostHog file-backed queue peek/pop alignment", .serialized)
+struct PostHogFileBackedQueueAlignmentTest {
+    private func makeQueue() -> (queue: PostHogFileBackedQueue, dir: URL) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ph-queue-align-\(UUID().uuidString)")
+        return (PostHogFileBackedQueue(queue: dir, oldQueues: []), dir)
+    }
+
+    private func sortedFiles(in dir: URL) throws -> [URL] {
+        try FileManager.default
+            .contentsOfDirectory(at: dir, includingPropertiesForKeys: [.creationDateKey])
+            .sorted {
+                let a = (try? $0.resourceValues(forKeys: [.creationDateKey]).creationDate) ?? .distantPast
+                let b = (try? $1.resourceValues(forKeys: [.creationDateKey]).creationDate) ?? .distantPast
+                return a < b
+            }
+    }
+
+    private func enqueue(_ values: [String], into queue: PostHogFileBackedQueue) {
+        for value in values {
+            queue.add(value.data(using: .utf8)!)
+            Thread.sleep(forTimeInterval: 0.005) // distinct creation dates for sortedFiles
+        }
+    }
+
+    private func decode(_ data: [Data]) -> [String] {
+        data.map { String(data: $0, encoding: .utf8)! }
+    }
+
+    @Test("delivers every record once in FIFO order on the happy path")
+    func happyPath() throws {
+        let (queue, dir) = makeQueue()
+        defer { queue.clear()
+            try? FileManager.default.removeItem(at: dir)
+        }
+
+        enqueue(["A", "B", "C", "D"], into: queue)
+
+        #expect(queue.depth == 4)
+        let first = decode(queue.peek(2))
+        #expect(first == ["A", "B"])
+        queue.pop(first.count)
+
+        let second = decode(queue.peek(2))
+        #expect(second == ["C", "D"])
+        queue.pop(second.count)
+
+        #expect(queue.depth == 0)
+    }
+
+    @Test("does not re-deliver a record when a missing file precedes returned items")
+    func missingFilePrecedingReturnedItems() throws {
+        let (queue, dir) = makeQueue()
+        defer { queue.clear()
+            try? FileManager.default.removeItem(at: dir)
+        }
+
+        enqueue(["A", "B", "C", "D"], into: queue)
+        try FileManager.default.removeItem(at: sortedFiles(in: dir)[0])
+
+        let batch1 = decode(queue.peek(2))
+        #expect(batch1 == ["B", "C"])
+        queue.pop(batch1.count)
+
+        let batch2 = decode(queue.peek(2))
+        #expect(Set(batch1).isDisjoint(with: Set(batch2)))
+        #expect(batch2 == ["D"])
+    }
+
+    @Test("does not re-deliver a record when a corrupt file precedes returned items")
+    func corruptFilePrecedingReturnedItems() throws {
+        let (queue, dir) = makeQueue()
+        defer { queue.clear()
+            try? FileManager.default.removeItem(at: dir)
+        }
+
+        enqueue(["A", "B", "C", "D"], into: queue)
+
+        // present but unreadable: fileExists true, Data(contentsOf:) throws
+        let head = try sortedFiles(in: dir)[0]
+        try FileManager.default.removeItem(at: head)
+        try FileManager.default.createDirectory(at: head, withIntermediateDirectories: false)
+
+        let batch1 = decode(queue.peek(2))
+        #expect(batch1 == ["B", "C"])
+        queue.pop(batch1.count)
+
+        let batch2 = decode(queue.peek(2))
+        #expect(Set(batch1).isDisjoint(with: Set(batch2)))
+        #expect(batch2 == ["D"])
+    }
+
+    @Test("prunes unreadable entries so depth reflects deliverable records")
+    func depthReflectsPrunedEntries() throws {
+        let (queue, dir) = makeQueue()
+        defer { queue.clear()
+            try? FileManager.default.removeItem(at: dir)
+        }
+
+        enqueue(["A", "B", "C"], into: queue)
+        try FileManager.default.removeItem(at: sortedFiles(in: dir)[0])
+
+        #expect(queue.depth == 3)
+        _ = queue.peek(10)
+        #expect(queue.depth == 2)
+    }
+
+    @Test("deletes and scans past a run of corrupt files without accumulating them")
+    func deletesRunOfCorruptFiles() throws {
+        let (queue, dir) = makeQueue()
+        defer { queue.clear()
+            try? FileManager.default.removeItem(at: dir)
+        }
+
+        enqueue(["A", "B", "C", "D", "E"], into: queue)
+        let corrupt = Array(try sortedFiles(in: dir).prefix(3))
+        for url in corrupt {
+            try FileManager.default.removeItem(at: url)
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false)
+        }
+
+        #expect(decode(queue.peek(10)) == ["D", "E"])
+        for url in corrupt {
+            #expect(!FileManager.default.fileExists(atPath: url.path))
+        }
+        #expect(queue.depth == 2)
+    }
+
+    @Test("delete(index:) removes a stuck unreadable head so eviction can unblock the queue")
+    func deleteRemovesStuckHead() throws {
+        guard geteuid() != 0 else { return } // chmod read-denial is a no-op for root
+        let (queue, dir) = makeQueue()
+        defer {
+            for file in (try? sortedFiles(in: dir)) ?? [] {
+                try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: file.path)
+            }
+            queue.clear()
+            try? FileManager.default.removeItem(at: dir)
+        }
+
+        enqueue(["A", "B", "C"], into: queue)
+        let head = try sortedFiles(in: dir)[0]
+        try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: head.path)
+
+        #expect(queue.peek(10).isEmpty)
+        queue.delete(index: 0)
+        #expect(decode(queue.peek(10)) == ["B", "C"])
+    }
+
+    @Test("keeps a temporarily unreadable file instead of deleting it, then delivers once readable")
+    func keepsTemporarilyUnreadableFile() throws {
+        guard geteuid() != 0 else { return } // chmod read-denial is a no-op for root
+        let (queue, dir) = makeQueue()
+        defer {
+            for file in (try? sortedFiles(in: dir)) ?? [] {
+                try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: file.path)
+            }
+            queue.clear()
+            try? FileManager.default.removeItem(at: dir)
+        }
+
+        enqueue(["A", "B"], into: queue)
+        let head = try sortedFiles(in: dir)[0]
+        try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: head.path)
+
+        #expect(queue.peek(10).isEmpty)
+        #expect(FileManager.default.fileExists(atPath: head.path))
+        #expect(queue.depth == 2)
+
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: head.path)
+        #expect(decode(queue.peek(10)) == ["A", "B"])
+    }
+
+    @Test("randomized add/vanish/flush interleavings never duplicate a delivered record")
+    func randomizedNoDuplicateDelivery() throws {
+        var rng = SeededGenerator(seed: 0x00C0_FFEE)
+        let (queue, dir) = makeQueue()
+        defer { queue.clear()
+            try? FileManager.default.removeItem(at: dir)
+        }
+
+        var nextId = 0
+        var vanished: Set<Int> = []
+        var delivered: [Int] = []
+
+        func flush(upTo count: Int) {
+            let batch = queue.peek(count).map { Int(String(data: $0, encoding: .utf8)!)! }
+            queue.pop(batch.count)
+            delivered.append(contentsOf: batch)
+        }
+
+        for _ in 0 ..< 400 {
+            switch Int.random(in: 0 ... 2, using: &rng) {
+            case 0:
+                queue.add("\(nextId)".data(using: .utf8)!)
+                nextId += 1
+            case 1:
+                let files = try FileManager.default.contentsOfDirectory(
+                    at: dir, includingPropertiesForKeys: nil
+                )
+                guard let victim = files.randomElement(using: &rng) else { break }
+                let id = Int(try String(decoding: Data(contentsOf: victim), as: UTF8.self))!
+                try FileManager.default.removeItem(at: victim)
+                vanished.insert(id)
+            default:
+                flush(upTo: Int.random(in: 1 ... 3, using: &rng))
+            }
+        }
+
+        while queue.depth > 0 {
+            let before = queue.depth
+            flush(upTo: queue.depth)
+            if queue.depth == before { break }
+        }
+
+        #expect(Set(delivered).count == delivered.count)
+        let expected = Set(0 ..< nextId).subtracting(vanished)
+        #expect(Set(delivered) == expected)
+    }
+
+    @Test("concurrent add/vanish/flush stays consistent and never double-delivers")
+    func concurrentPruneIsThreadSafe() throws {
+        let (queue, dir) = makeQueue()
+        defer { queue.clear()
+            try? FileManager.default.removeItem(at: dir)
+        }
+
+        let deliveredLock = NSLock()
+        var delivered: [String] = []
+        let group = DispatchGroup()
+        let concurrent = DispatchQueue(label: "ph.queue.align.test", attributes: .concurrent)
+
+        for i in 0 ..< 500 {
+            concurrent.async(group: group) {
+                queue.add("\(i)".data(using: .utf8)!)
+            }
+        }
+        for _ in 0 ..< 120 {
+            concurrent.async(group: group) {
+                let files = try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)
+                if let victim = files?.randomElement() {
+                    try? FileManager.default.removeItem(at: victim)
+                }
+            }
+        }
+        concurrent.async(group: group) {
+            for _ in 0 ..< 200 {
+                let batch = queue.peek(5).map { String(data: $0, encoding: .utf8)! }
+                queue.pop(batch.count)
+                deliveredLock.withLock { delivered.append(contentsOf: batch) }
+            }
+        }
+
+        group.wait()
+
+        while queue.depth > 0 {
+            let before = queue.depth
+            let batch = queue.peek(queue.depth).map { String(data: $0, encoding: .utf8)! }
+            queue.pop(batch.count)
+            delivered.append(contentsOf: batch)
+            if queue.depth == before { break }
+        }
+
+        #expect(Set(delivered).count == delivered.count)
+        #expect(queue.depth == 0)
+    }
+}
+
+private struct SeededGenerator: RandomNumberGenerator {
+    private var state: UInt64
+    init(seed: UInt64) {
+        state = seed
+    }
+    mutating func next() -> UInt64 {
+        state = state &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+        return state
+    }
+}

--- a/PostHogTests/PostHogFileBackedQueueAlignmentTest.swift
+++ b/PostHogTests/PostHogFileBackedQueueAlignmentTest.swift
@@ -175,6 +175,34 @@ struct PostHogFileBackedQueueAlignmentTest {
         #expect(decode(queue.peek(10)) == ["A", "B"])
     }
 
+    @Test("prunes a corrupt entry that precedes a temporarily-unavailable file in the same load")
+    func prunesCorruptBeforeTemporarilyUnavailable() throws {
+        guard geteuid() != 0 else { return } // chmod read-denial is a no-op for root
+        let (queue, dir) = makeQueue()
+        defer {
+            for file in (try? sortedFiles(in: dir)) ?? [] {
+                try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: file.path)
+            }
+            queue.clear()
+            try? FileManager.default.removeItem(at: dir)
+        }
+
+        enqueue(["A", "B", "C"], into: queue)
+        let files = try sortedFiles(in: dir)
+        // present but unreadable: fileExists true, Data(contentsOf:) throws
+        try FileManager.default.removeItem(at: files[0])
+        try FileManager.default.createDirectory(at: files[0], withIntermediateDirectories: false)
+        try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: files[1].path)
+
+        #expect(queue.peek(10).isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: files[0].path))
+        #expect(FileManager.default.fileExists(atPath: files[1].path))
+        #expect(queue.depth == 2)
+
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: files[1].path)
+        #expect(decode(queue.peek(10)) == ["B", "C"])
+    }
+
     @Test("randomized add/vanish/flush interleavings never duplicate a delivered record")
     func randomizedNoDuplicateDelivery() throws {
         var rng = SeededGenerator(seed: 0x00C0_FFEE)


### PR DESCRIPTION
## :bulb: Motivation and Context

Fixes #702.

`PostHogFileBackedQueue` keeps an in-memory `items` list of queued files. `peek(count)` reads files off the head, and the consumer then calls `pop(items.count)`, which deletes that many entries from the front of the list — assuming a 1:1 positional match with what `peek` returned.

But when `peek` skipped a file (missing on disk, or a read that threw) it deleted the file *without removing the entry from `items`*. That shifted the alignment: `pop` removed the wrong entries and left already-sent records in the queue, so they were **re-sent on the next flush** (duplicate delivery).

The realistic trigger is iOS data protection: on a locked device a valid queue file can throw `NSFileReadNoPermission`, which the code treated as corruption — so the same scenario also **deleted valid, unsent events** (related to #213).

## :green_heart: How did you test it?

New `PostHogFileBackedQueueAlignmentTest` (Swift Testing), 9 cases. Each was confirmed to **fail on the pre-fix code and pass after**:

- happy-path FIFO delivery (characterization — unchanged behavior)
- no re-delivery when a missing / corrupt file precedes returned items
- `depth` reflects pruned entries
- a run of corrupt files is deleted and scanned past (no accumulation)
- `delete(index:)` removes a stuck unreadable head (eviction backstop)
- a temporarily-unreadable file (`chmod 000`, same error as data protection) is **kept, not deleted**, and delivers once readable
- a seeded randomized model test over 400 add/vanish/flush interleavings — never double-delivers
- a concurrent add/vanish/flush test that forces the prune path under contention

Verification run locally:

- full `make test` suite passes (no regressions in the existing Quick queue suites)
- the queue suites pass under the **thread sanitizer** (`--sanitize=thread`) with zero data races, including the concurrency test that exercises the new prune path
- SwiftLint clean on the changed files

Not run: on-device verification of the data-protection path (simulated in CI via `chmod`).

## Scope

- **Fixed here:** the duplicate-delivery bug for *any* skip cause, plus the read-side data loss on a locked device.
- **Left to #213:** the write path (`add()` also fails while locked) and deferring queue access until `protectedDataDidBecomeAvailableNotification`. This change is complementary, not a replacement.
- **Other SDKs:** not affected. posthog-android removes files by identity (`deque.removeAll`), not positional count; Flutter delegates to the native SDKs; posthog-js uses a different queue mechanism.

One tradeoff: keeping a temporarily-unreadable file means head-of-line blocking until it becomes readable (benign for data protection — you can't deliver while locked anyway — and bounded by `maxQueueSize` eviction). The fuller cure is identity-based `pop`, noted as a possible follow-up.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated #702 with Claude Code (`/investigate-github-issue`), then implemented and tested the fix under the maintainer's direction.

- Confirmed the bug by static trace and a standalone reproduction, then wrote failing tests before fixing.
- Chose the minimal, self-contained fix (prune skipped entries from `items`) over the larger identity-based `pop` refactor, to keep the change reviewable and low-risk.
- Added permission-error handling (keep-and-retry) after checking that the original code would otherwise delete valid files on a locked device.
- Verified thread safety under TSan because the change touches the queue's shared `items` list.
