### PR TITLE
fix(api): don't crash when a flags/remote-config response isn't HTTPURLResponse

### DIFF
--- a/.changeset/brave-apis-guard.md
+++ b/.changeset/brave-apis-guard.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': patch
+---
+
+Avoid a crash in the flags and remote-config API handlers when the URL response is not an `HTTPURLResponse` (previously force-cast); the SDK now logs and returns gracefully instead.

--- a/PostHog/PostHogApi.swift
+++ b/PostHog/PostHogApi.swift
@@ -322,7 +322,10 @@ class PostHogApi {
                 return completion(nil, nil)
             }
 
-            let httpResponse = response as! HTTPURLResponse
+            guard let httpResponse = response as? HTTPURLResponse else {
+                hedgeLog("Error parsing the flags response: unexpected response type")
+                return completion(nil, nil)
+            }
 
             if !(200 ... 299 ~= httpResponse.statusCode) {
                 let jsonBody = fromJSONData(data, options: .allowFragments)
@@ -409,7 +412,10 @@ class PostHogApi {
                 return completion(nil, nil)
             }
 
-            let httpResponse = response as! HTTPURLResponse
+            guard let httpResponse = response as? HTTPURLResponse else {
+                hedgeLog("Error parsing the remote config response: unexpected response type")
+                return completion(nil, nil)
+            }
 
             if !(200 ... 299 ~= httpResponse.statusCode) {
                 let jsonBody = fromJSONData(data, options: .allowFragments)

--- a/PostHogTests/PostHogApiTest.swift
+++ b/PostHogTests/PostHogApiTest.swift
@@ -579,6 +579,68 @@ enum PostHogApiTests {
             try await testFlagsEndpoint(forHost: "http://localhost:9000/api/v1/")
         }
     }
+
+    @Suite("Non-HTTPURLResponse handling", .serialized)
+    final class TestNonHTTPResponseHandling {
+        private func getSut() -> PostHogApi {
+            let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost")
+            let sessionConfig = URLSessionConfiguration.ephemeral
+            sessionConfig.protocolClasses = [NonHTTPResponseURLProtocol.self]
+            config.urlSessionConfiguration = sessionConfig
+            return PostHogApi(config)
+        }
+
+        @Test("flags completes gracefully when the response is not an HTTPURLResponse")
+        func flagsHandlesNonHTTPResponse() async {
+            let sut = getSut()
+
+            let resp: ([String: Any]?, Error?) = await withCheckedContinuation { continuation in
+                sut.flags(distinctId: "x", anonymousId: nil, groups: [:], personProperties: [:]) { data, error in
+                    continuation.resume(returning: (data, error))
+                }
+            }
+
+            #expect(resp.0 == nil)
+            #expect(resp.1 == nil)
+        }
+
+        @Test("remote config completes gracefully when the response is not an HTTPURLResponse")
+        func remoteConfigHandlesNonHTTPResponse() async {
+            let sut = getSut()
+
+            let resp: ([String: Any]?, Error?) = await withCheckedContinuation { continuation in
+                sut.remoteConfig { data, error in
+                    continuation.resume(returning: (data, error))
+                }
+            }
+
+            #expect(resp.0 == nil)
+            #expect(resp.1 == nil)
+        }
+    }
+}
+
+/// Replies to every request with a plain `URLResponse` (not `HTTPURLResponse`),
+/// the case that used to hit a force-cast crash in the flags/remote config handlers.
+private final class NonHTTPResponseURLProtocol: URLProtocol {
+    override class func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let url = request.url else { return }
+        let data = Data("{}".utf8)
+        let response = URLResponse(url: url, mimeType: "application/json", expectedContentLength: data.count, textEncodingName: nil)
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
 }
 
 private final class CapturedRequestBox {


### PR DESCRIPTION
## :bulb: Motivation and Context

`PostHogApi` force-casts the URL response in two handlers:

```swift
let httpResponse = response as! HTTPURLResponse
```

- `PostHog/PostHogApi.swift:325` — feature flags handler
- `PostHog/PostHogApi.swift:412` — remote config handler

If `response` is ever `nil` (or not an `HTTPURLResponse`), the force-cast **crashes the host app** with `Fatal error: Unexpectedly found nil while unwrapping an Optional value`. An SDK must never crash the app that embeds it. This surfaced as an intermittent crash in the flags handler during CI (`PostHogApi.swift:325`).

## :green_heart: How did you test it?

- `swift build -Xswiftc -DTESTING` compiles cleanly.
- SwiftLint / SwiftFormat clean on the changed files.
- The existing `PostHogApi` suites (flags, remote config, request headers, content-encoding, host-scoping) exercise the happy path and continue to pass.
- Added regression tests (`PostHogApiTests` → "Non-HTTPURLResponse handling"): a custom `URLProtocol` injected through the public `config.urlSessionConfiguration` seam replies with a plain `URLResponse`, and both `flags` and `remoteConfig` now complete gracefully with `(nil, nil)`. Verified the flags test crashes the test runner when the force-cast is reinstated.

## Changes

Both sites now guard instead of force-cast, logging and returning gracefully:

```swift
guard let httpResponse = response as? HTTPURLResponse else {
    hedgeLog("Error parsing the flags response: unexpected response type")
    return completion(nil, nil)
}
```

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Spun out of a review of the #702 queue fix, where CI surfaced this pre-existing force-unwrap crash in the networking layer. Kept as its own PR (not folded into #702) since it is an unrelated crash-safety fix. Grepped the file for every `as!`, found both response force-casts, and replaced them with graceful guards matching the existing error-handling style.

