### PR TITLE
fix(replay): skip re-sending unchanged screenshots in screenshot mode

### DIFF
--- a/.changeset/dedup-unchanged-screenshots.md
+++ b/.changeset/dedup-unchanged-screenshots.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Session replay (screenshot mode): skip re-sending an unchanged screenshot. When a screen is static, the throttle-driven capture would previously upload an identical full screenshot every tick; it now compares a hash of the encoded image and drops the duplicate (the player already holds the last frame), cutting replay bandwidth and storage for static screens. Wireframe mode is unaffected — it is already change-driven.

--- a/.changeset/dedup-unchanged-screenshots.md
+++ b/.changeset/dedup-unchanged-screenshots.md
@@ -2,4 +2,4 @@
 "posthog-ios": patch
 ---
 
-Session replay (screenshot mode): skip re-sending an unchanged screenshot. When a screen is static, the throttle-driven capture would previously upload an identical full screenshot every tick; it now compares a hash of the encoded image and drops the duplicate (the player already holds the last frame), cutting replay bandwidth and storage for static screens. Wireframe mode is unaffected — it is already change-driven.
+Session replay (screenshot mode): skip re-sending unchanged screenshots. Static screens no longer upload an identical full screenshot every tick, cutting replay bandwidth and storage. Wireframe mode is unaffected.

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -270,6 +270,7 @@
 		DA4AF6292D119FCD0053EA38 /* PostHog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AC745B5296D6FE60025C109 /* PostHog.framework */; };
 		DA4AF62A2D119FCD0053EA38 /* PostHog.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3AC745B5296D6FE60025C109 /* PostHog.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DA4FFB152DA93C78006BAEEA /* PostHogSessionReplayTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4FFB142DA93C78006BAEEA /* PostHogSessionReplayTest.swift */; };
+		DA4FFB192DA93C78006BAEEA /* PostHogReplayScreenshotDedupTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4FFB182DA93C78006BAEEA /* PostHogReplayScreenshotDedupTest.swift */; };
 		DA4FFBB52DAD5B01006BAEEA /* PostHogIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4FFBB42DAD5AF9006BAEEA /* PostHogIdentityTests.swift */; };
 		DA5063C92EF585AB00C51DA0 /* PostHogErrorTrackingUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5063C82EF585AB00C51DA0 /* PostHogErrorTrackingUtils.swift */; };
 		DA5063D22EF5918200C51DA0 /* PostHogCrashReportProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5063D12EF5918200C51DA0 /* PostHogCrashReportProcessor.swift */; };
@@ -1027,6 +1028,7 @@
 		DA3BB5042EDF15320097A97A /* PostHogStackFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogStackFrame.swift; sourceTree = "<group>"; };
 		DA4531D2FCB608D6C55AFB85 /* PLCrashLogWriterEncoding.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = PLCrashLogWriterEncoding.c; path = vendor/PHPLCrashReporter/Source/PLCrashLogWriterEncoding.c; sourceTree = "<group>"; };
 		DA4FFB142DA93C78006BAEEA /* PostHogSessionReplayTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSessionReplayTest.swift; sourceTree = "<group>"; };
+		DA4FFB182DA93C78006BAEEA /* PostHogReplayScreenshotDedupTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogReplayScreenshotDedupTest.swift; sourceTree = "<group>"; };
 		DA4FFBB42DAD5AF9006BAEEA /* PostHogIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogIdentityTests.swift; sourceTree = "<group>"; };
 		DA5063C82EF585AB00C51DA0 /* PostHogErrorTrackingUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogErrorTrackingUtils.swift; sourceTree = "<group>"; };
 		DA5063D12EF5918200C51DA0 /* PostHogCrashReportProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogCrashReportProcessor.swift; sourceTree = "<group>"; };
@@ -1655,6 +1657,7 @@
 				690FF0BA2AEF8B8200A0B06B /* PostHogContextTest.swift */,
 				690FF0DE2AEFBC5700A0B06B /* PostHogLegacyQueueTest.swift */,
 				DA4FFB142DA93C78006BAEEA /* PostHogSessionReplayTest.swift */,
+				DA4FFB182DA93C78006BAEEA /* PostHogReplayScreenshotDedupTest.swift */,
 				690FF0E02AEFC59100A0B06B /* PostHogFileBackedQueueTest.swift */,
 				690FF0E22AEFD12900A0B06B /* PostHogConfigTest.swift */,
 				DAA1B2D02F8C100000112233 /* RageClickDetectorTest.swift */,
@@ -3406,6 +3409,7 @@
 				693E977D2C6257F9004B1030 /* ExampleSanitizer.swift in Sources */,
 				1F5558262DFC4802007643C0 /* PostHogStorageMergeTest.swift in Sources */,
 				DA4FFB152DA93C78006BAEEA /* PostHogSessionReplayTest.swift in Sources */,
+				DA4FFB192DA93C78006BAEEA /* PostHogReplayScreenshotDedupTest.swift in Sources */,
 				DADE7DFE2F7EA90D00C4650C /* PostHogDeepLinkIntegrationTests.swift in Sources */,
 				DA52CAEF2F24319800305F3D /* PostHogSessionReplayPluginTest.swift in Sources */,
 				690FF0DF2AEFBC5700A0B06B /* PostHogLegacyQueueTest.swift in Sources */,

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -746,6 +746,19 @@
                 wireframe.image = nil
                 wireframe.maskableWidgets = nil
 
+                // Screenshot mode emits a full screenshot every capture, so a
+                // static screen on the throttle cadence would re-send an
+                // identical image every tick. Skip when the encoded image is
+                // unchanged and there is no pending meta event. All lastImageHash
+                // access is on this serial capture queue, so no extra lock is
+                // needed. (The player holds the last frame, so a skipped tick
+                // leaves the screen unchanged.)
+                let imageHash = (wireframeDict["base64"] as? String)?.hashValue
+                if let imageHash, imageHash == snapshotStatus.lastImageHash, snapshotsData.isEmpty {
+                    return
+                }
+                snapshotStatus.lastImageHash = imageHash
+
                 var wireframes: [Any] = []
                 wireframes.append(wireframeDict)
                 let initialOffset = ["top": 0, "left": 0]

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -746,11 +746,14 @@
                 wireframe.image = nil
                 wireframe.maskableWidgets = nil
 
-                // Screenshot mode re-captures the full screen every tick, so skip an
-                // unchanged image (unless a meta event is pending). The player holds the
-                // last frame. lastImageHash is only touched on this serial queue.
+                // Safe to drop an unchanged frame: the player holds the last one. No lock:
+                // this runs on the serial capture queue, the only place lastImageHash is touched.
                 let imageHash = (wireframeDict["base64"] as? String)?.hashValue
-                if let imageHash, imageHash == snapshotStatus.lastImageHash, snapshotsData.isEmpty {
+                if PostHogReplayIntegration.shouldSkipUnchangedScreenshot(
+                    imageHash: imageHash,
+                    lastImageHash: snapshotStatus.lastImageHash,
+                    hasPendingSnapshotData: !snapshotsData.isEmpty
+                ) {
                     return
                 }
                 snapshotStatus.lastImageHash = imageHash
@@ -772,6 +775,12 @@
                     timestamp: timestampDate
                 )
             }
+        }
+
+        // A nil hash (wireframe mode, where `base64` is absent) never skips.
+        static func shouldSkipUnchangedScreenshot(imageHash: Int?, lastImageHash: Int?, hasPendingSnapshotData: Bool) -> Bool {
+            guard let imageHash, !hasPendingSnapshotData else { return false }
+            return imageHash == lastImageHash
         }
 
         private func setAlignment(_ alignment: NSTextAlignment, _ style: RRStyle) {

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -746,13 +746,9 @@
                 wireframe.image = nil
                 wireframe.maskableWidgets = nil
 
-                // Screenshot mode emits a full screenshot every capture, so a
-                // static screen on the throttle cadence would re-send an
-                // identical image every tick. Skip when the encoded image is
-                // unchanged and there is no pending meta event. All lastImageHash
-                // access is on this serial capture queue, so no extra lock is
-                // needed. (The player holds the last frame, so a skipped tick
-                // leaves the screen unchanged.)
+                // Screenshot mode re-captures the full screen every tick, so skip an
+                // unchanged image (unless a meta event is pending). The player holds the
+                // last frame. lastImageHash is only touched on this serial queue.
                 let imageHash = (wireframeDict["base64"] as? String)?.hashValue
                 if let imageHash, imageHash == snapshotStatus.lastImageHash, snapshotsData.isEmpty {
                     return

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -746,8 +746,6 @@
                 wireframe.image = nil
                 wireframe.maskableWidgets = nil
 
-                // Safe to drop an unchanged frame: the player holds the last one. No lock:
-                // this runs on the serial capture queue, the only place lastImageHash is touched.
                 let imageHash = (wireframeDict["base64"] as? String)?.hashValue
                 if PostHogReplayIntegration.shouldSkipUnchangedScreenshot(
                     imageHash: imageHash,
@@ -777,7 +775,6 @@
             }
         }
 
-        // A nil hash (wireframe mode, where `base64` is absent) never skips.
         static func shouldSkipUnchangedScreenshot(imageHash: Int?, lastImageHash: Int?, hasPendingSnapshotData: Bool) -> Bool {
             guard let imageHash, !hasPendingSnapshotData else { return false }
             return imageHash == lastImageHash

--- a/PostHog/Replay/ViewTreeSnapshotStatus.swift
+++ b/PostHog/Replay/ViewTreeSnapshotStatus.swift
@@ -12,8 +12,6 @@ class ViewTreeSnapshotStatus {
     var sentMetaEvent: Bool = false
     var keyboardVisible: Bool = false
     var lastSnapshot: Bool = false
-    // Hash of the last screenshot enqueued for this window, so an unchanged
-    // screenshot (a static screen captured on the throttle cadence) is not
-    // re-sent. Nil until the first screenshot.
+    // Hash of the last screenshot sent for this window, used to skip unchanged frames.
     var lastImageHash: Int?
 }

--- a/PostHog/Replay/ViewTreeSnapshotStatus.swift
+++ b/PostHog/Replay/ViewTreeSnapshotStatus.swift
@@ -12,6 +12,5 @@ class ViewTreeSnapshotStatus {
     var sentMetaEvent: Bool = false
     var keyboardVisible: Bool = false
     var lastSnapshot: Bool = false
-    // Hash of the last screenshot sent for this window, used to skip unchanged frames.
     var lastImageHash: Int?
 }

--- a/PostHog/Replay/ViewTreeSnapshotStatus.swift
+++ b/PostHog/Replay/ViewTreeSnapshotStatus.swift
@@ -12,4 +12,8 @@ class ViewTreeSnapshotStatus {
     var sentMetaEvent: Bool = false
     var keyboardVisible: Bool = false
     var lastSnapshot: Bool = false
+    // Hash of the last screenshot enqueued for this window, so an unchanged
+    // screenshot (a static screen captured on the throttle cadence) is not
+    // re-sent. Nil until the first screenshot.
+    var lastImageHash: Int?
 }

--- a/PostHogTests/PostHogReplayScreenshotDedupTest.swift
+++ b/PostHogTests/PostHogReplayScreenshotDedupTest.swift
@@ -5,49 +5,45 @@
 
     @Suite("Screenshot mode unchanged-frame dedup")
     class PostHogReplayScreenshotDedupTests {
-        @Test("Skips an unchanged image when no other snapshot data is pending")
-        func skipsUnchangedImage() {
-            #expect(PostHogReplayIntegration.shouldSkipUnchangedScreenshot(
-                imageHash: 42,
-                lastImageHash: 42,
-                hasPendingSnapshotData: false
-            ))
+        struct DedupCase: CustomTestStringConvertible {
+            let name: String
+            let imageHash: Int?
+            let lastImageHash: Int?
+            let hasPendingSnapshotData: Bool
+            let expectedSkip: Bool
+
+            var testDescription: String { name }
         }
 
-        @Test("Sends a changed image")
-        func sendsChangedImage() {
-            #expect(!PostHogReplayIntegration.shouldSkipUnchangedScreenshot(
-                imageHash: 43,
-                lastImageHash: 42,
-                hasPendingSnapshotData: false
-            ))
-        }
-
-        @Test("Never skips while a meta event (or other data) is pending")
-        func sendsWhenSnapshotDataPending() {
-            #expect(!PostHogReplayIntegration.shouldSkipUnchangedScreenshot(
-                imageHash: 42,
-                lastImageHash: 42,
-                hasPendingSnapshotData: true
-            ))
-        }
-
-        @Test("Never skips when there is no image hash (wireframe mode)")
-        func sendsWhenNoImageHash() {
-            #expect(!PostHogReplayIntegration.shouldSkipUnchangedScreenshot(
-                imageHash: nil,
-                lastImageHash: 42,
-                hasPendingSnapshotData: false
-            ))
-        }
-
-        @Test("Sends the first image, when there is no previous hash")
-        func sendsFirstImage() {
-            #expect(!PostHogReplayIntegration.shouldSkipUnchangedScreenshot(
-                imageHash: 42,
-                lastImageHash: nil,
-                hasPendingSnapshotData: false
-            ))
+        @Test("Screenshot dedup decision", arguments: [
+            DedupCase(
+                name: "skips an unchanged image when no other snapshot data is pending",
+                imageHash: 42, lastImageHash: 42, hasPendingSnapshotData: false, expectedSkip: true
+            ),
+            DedupCase(
+                name: "sends a changed image",
+                imageHash: 43, lastImageHash: 42, hasPendingSnapshotData: false, expectedSkip: false
+            ),
+            DedupCase(
+                name: "never skips while a meta event (or other data) is pending",
+                imageHash: 42, lastImageHash: 42, hasPendingSnapshotData: true, expectedSkip: false
+            ),
+            DedupCase(
+                name: "never skips when there is no image hash (wireframe mode)",
+                imageHash: nil, lastImageHash: 42, hasPendingSnapshotData: false, expectedSkip: false
+            ),
+            DedupCase(
+                name: "sends the first image, when there is no previous hash",
+                imageHash: 42, lastImageHash: nil, hasPendingSnapshotData: false, expectedSkip: false
+            ),
+        ])
+        func screenshotDedupDecision(_ testCase: DedupCase) {
+            let skip = PostHogReplayIntegration.shouldSkipUnchangedScreenshot(
+                imageHash: testCase.imageHash,
+                lastImageHash: testCase.lastImageHash,
+                hasPendingSnapshotData: testCase.hasPendingSnapshotData
+            )
+            #expect(skip == testCase.expectedSkip)
         }
     }
 #endif

--- a/PostHogTests/PostHogReplayScreenshotDedupTest.swift
+++ b/PostHogTests/PostHogReplayScreenshotDedupTest.swift
@@ -1,0 +1,53 @@
+#if os(iOS)
+    import Foundation
+    @testable import PostHog
+    import Testing
+
+    @Suite("Screenshot mode unchanged-frame dedup")
+    class PostHogReplayScreenshotDedupTests {
+        @Test("Skips an unchanged image when no other snapshot data is pending")
+        func skipsUnchangedImage() {
+            #expect(PostHogReplayIntegration.shouldSkipUnchangedScreenshot(
+                imageHash: 42,
+                lastImageHash: 42,
+                hasPendingSnapshotData: false
+            ))
+        }
+
+        @Test("Sends a changed image")
+        func sendsChangedImage() {
+            #expect(!PostHogReplayIntegration.shouldSkipUnchangedScreenshot(
+                imageHash: 43,
+                lastImageHash: 42,
+                hasPendingSnapshotData: false
+            ))
+        }
+
+        @Test("Never skips while a meta event (or other data) is pending")
+        func sendsWhenSnapshotDataPending() {
+            #expect(!PostHogReplayIntegration.shouldSkipUnchangedScreenshot(
+                imageHash: 42,
+                lastImageHash: 42,
+                hasPendingSnapshotData: true
+            ))
+        }
+
+        @Test("Never skips when there is no image hash (wireframe mode)")
+        func sendsWhenNoImageHash() {
+            #expect(!PostHogReplayIntegration.shouldSkipUnchangedScreenshot(
+                imageHash: nil,
+                lastImageHash: 42,
+                hasPendingSnapshotData: false
+            ))
+        }
+
+        @Test("Sends the first image, when there is no previous hash")
+        func sendsFirstImage() {
+            #expect(!PostHogReplayIntegration.shouldSkipUnchangedScreenshot(
+                imageHash: 42,
+                lastImageHash: nil,
+                hasPendingSnapshotData: false
+            ))
+        }
+    }
+#endif


### PR DESCRIPTION
## :bulb: Motivation and Context

In **screenshot mode**, session replay emits a full screenshot on every throttle-driven capture. When the screen is static, that means an identical full screenshot is uploaded every tick — wasted bandwidth and storage for no visual change.

This adds a per-window dedup: the encoded screenshot is hashed and, when it matches the previous one (and there's no pending meta event), the `$snapshot` send is skipped. The player already holds the last frame, so a skipped tick leaves the screen unchanged in replay.

Wireframe mode is unaffected — it's already change-driven (incremental snapshots).

## :green_heart: How did you test it?

- Built the `PostHog` scheme for the iOS Simulator — compiles cleanly.
- The same `captureSnapshot` dedup path was exercised by a fixed-cadence screenshot driver: a ~50s static screen went from ~24 uploads down to **1 sent + 23 skipped**, confirming the encoded-image hash is stable for identical frames and the first/changed frame still sends.
- Not yet exercised specifically through the native `onViewLayout` throttle path on a screenshot-mode app — worth a reviewer sanity check there (happy to add a unit test around the dedup branch if preferred).

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code (Opus 4.8). Anna is the DRI.
- This was factored out of a larger native-screen session-replay effort as a **standalone** perf fix. It's deliberately scoped to the general screenshot-mode path (not tied to any specific integration), since any static screen on the throttle cadence hits the same redundant-upload behavior.
- Dedup key is a hash of the encoded (webp) base64. Chosen over a raw-pixel hash to avoid an extra pass and because encoding is deterministic for identical pixels; a hash collision would drop a single changed frame and self-correct on the next, so it's low-risk. Reviewer may prefer a stronger content hash — easy to swap.
