### PR TITLE
docs(changelog): note 3.64.3 is SPM-only, CocoaPods use 3.64.4+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## 3.64.3
 
+> **Note:** Version 3.64.3 is available through Swift Package Manager only. CocoaPods users should use **3.64.4** or later.
+
 ### Patch Changes
 
 - 5ed8fd6: Fix event-queue peek/pop misalignment that could re-send already-delivered events when a file was skipped, and stop deleting valid queue files that are only temporarily unreadable (e.g. iOS data protection on a locked device).


### PR DESCRIPTION
## Motivation and Context

Version 3.64.3 was tagged and released to Swift Package Manager, but the CocoaPods publish step did not complete, so `3.64.3` never landed on the CocoaPods trunk. The follow-up `3.64.4` was released successfully to both SPM and CocoaPods.

Verified against the CocoaPods trunk API (`3.64.0`, `3.64.1`, `3.64.2`, `3.64.4` present; `3.64.3` absent) and the git tags / GitHub releases (both `3.64.3` and `3.64.4` tagged). This adds a note to the changelog so CocoaPods users pinning to `3.64.3` know to move to `3.64.4` or later.

## How did you test it?

Documentation-only change. Confirmed the CocoaPods trunk is missing `3.64.3` but has `3.64.4`, and that both versions exist as git tags / SPM releases.

## Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## Agent context

**DRI:** @ioannisj
**Autonomy:** Human-driven (agent-assisted)
