### PR TITLE
fix(error-tracking): enforce ignoredExceptionTypes on the generic capture path

### DIFF
--- a/.changeset/ignored-types-generic-capture.md
+++ b/.changeset/ignored-types-generic-capture.md
@@ -1,0 +1,10 @@
+---
+"posthog-ios": patch
+---
+
+fix: enforce `errorTrackingConfig.ignoredExceptionTypes` on the generic capture path
+
+`$exception` events sent through the generic `capture(...)` overloads (e.g. hybrid
+SDK bridges forwarding a pre-serialized `$exception_list`) bypassed the filter, which
+only ran in `captureException` and the crash-report path. The check now lives in
+`captureInternal`, the chokepoint every `$exception` path funnels through.

--- a/.changeset/ignored-types-generic-capture.md
+++ b/.changeset/ignored-types-generic-capture.md
@@ -2,9 +2,4 @@
 "posthog-ios": patch
 ---
 
-fix: enforce `errorTrackingConfig.ignoredExceptionTypes` on the generic capture path
-
-`$exception` events sent through the generic `capture(...)` overloads (e.g. hybrid
-SDK bridges forwarding a pre-serialized `$exception_list`) bypassed the filter, which
-only ran in `captureException` and the crash-report path. The check now lives in
-`captureInternal`, the chokepoint every `$exception` path funnels through.
+Fix `errorTrackingConfig.ignoredExceptionTypes` not being applied to `$exception` events sent through the generic `capture()` API (e.g. hybrid SDK bridges forwarding pre-serialized exceptions); previously only `captureException` and crash-report autocapture honored it.

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -1233,6 +1233,17 @@ let maxRetryDelay = 30.0
             return
         }
 
+        // $exception_list only ever comes from the caller, so raw properties are sufficient here
+        if event == "$exception" {
+            let ignored = config.errorTrackingConfig.ignoredExceptionTypes
+            if !ignored.isEmpty,
+               PostHogErrorTrackingAutoCaptureIntegration.exceptionListMatchesIgnoredTypes(properties ?? [:], ignoredTypes: ignored)
+            {
+                hedgeLog("$exception skipped: exception type is in errorTrackingConfig.ignoredExceptionTypes")
+                return
+            }
+        }
+
         var isSnapshotEvent = event == "$snapshot"
         let eventTimestamp = timestamp ?? now()
         let eventDistinctId = distinctId ?? getDistinctId()
@@ -2600,19 +2611,7 @@ let maxRetryDelay = 30.0
         var mergedProperties = exceptionProperties
         additionalProperties?.forEach { mergedProperties[$0.key] = $0.value }
 
-        // Honor `errorTrackingConfig.ignoredExceptionTypes` on the manual
-        // capture path too — not just the crash-report autocapture path.
-        // React Native bridges that surface RCTFatalException via
-        // `captureException(_:)` would otherwise still duplicate the JS-side
-        // `$exception` event. Mirrors posthog-android's behavior.
-        let ignored = config.errorTrackingConfig.ignoredExceptionTypes
-        if !ignored.isEmpty,
-           PostHogErrorTrackingAutoCaptureIntegration.exceptionListMatchesIgnoredTypes(mergedProperties, ignoredTypes: ignored)
-        {
-            hedgeLog("captureException skipped: exception type is in errorTrackingConfig.ignoredExceptionTypes")
-            return
-        }
-
+        // ignoredExceptionTypes is enforced in captureInternal, the chokepoint for every $exception path
         capture("$exception", properties: mergedProperties)
     }
 

--- a/PostHogTests/PostHogErrorTrackingIgnoredTypesTest.swift
+++ b/PostHogTests/PostHogErrorTrackingIgnoredTypesTest.swift
@@ -103,4 +103,82 @@ import Testing
         }
     }
 
+    @Suite("ErrorTracking ignoredExceptionTypes capture paths", .serialized)
+    class ErrorTrackingIgnoredTypesCaptureTest {
+        let server: MockPostHogServer
+
+        init() {
+            server = MockPostHogServer(version: 4)
+            server.start()
+        }
+
+        deinit {
+            server.stop()
+        }
+
+        private enum TestError: Error {
+            case boom
+        }
+
+        private func getSut(ignoredExceptionTypes: [String]? = nil) -> PostHogSDK {
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
+            config.flushAt = 1
+            config.captureApplicationLifecycleEvents = false
+            config.disableReachabilityForTesting = true
+            config.disableQueueTimerForTesting = true
+            config.disableFlushOnBackgroundForTesting = true
+            if let ignoredExceptionTypes {
+                config.errorTrackingConfig.ignoredExceptionTypes = ignoredExceptionTypes
+            }
+
+            let storage = PostHogStorage(config)
+            storage.reset()
+
+            return PostHogSDK.with(config)
+        }
+
+        @Test("generic capture drops $exception whose list contains an ignored type")
+        func genericCaptureDropsIgnoredType() {
+            let sut = getSut()
+
+            sut.capture("$exception", properties: ["$exception_list": [["type": "RCTFatalException", "value": "boom"]]])
+            sut.capture("marker")
+
+            let events = getBatchedEvents(server)
+            #expect(events.filter { $0.event == "$exception" }.isEmpty)
+            #expect(events.contains { $0.event == "marker" })
+
+            sut.reset()
+            sut.close()
+        }
+
+        @Test("generic capture keeps $exception whose list has no ignored type")
+        func genericCaptureKeepsOtherTypes() {
+            let sut = getSut()
+
+            sut.capture("$exception", properties: ["$exception_list": [["type": "SomeOtherError", "value": "boom"]]])
+
+            let events = getBatchedEvents(server).filter { $0.event == "$exception" }
+            #expect(events.count == 1)
+
+            sut.reset()
+            sut.close()
+        }
+
+        @Test("captureException still drops ignored types after the gate moved to captureInternal")
+        func captureExceptionStillDropsIgnoredType() {
+            let sut = getSut(ignoredExceptionTypes: ["TestError"])
+
+            sut.captureException(TestError.boom)
+            sut.capture("marker")
+
+            let events = getBatchedEvents(server)
+            #expect(events.filter { $0.event == "$exception" }.isEmpty)
+            #expect(events.contains { $0.event == "marker" })
+
+            sut.reset()
+            sut.close()
+        }
+    }
+
 #endif


### PR DESCRIPTION
## :bulb: Motivation and Context

Completes #666. `errorTrackingConfig.ignoredExceptionTypes` was only enforced in `captureException` and the crash-report path, so `$exception` events sent through the generic `capture(...)` overloads — e.g. hybrid SDK bridges forwarding a pre-serialized `$exception_list` — bypassed the filter entirely.

The gap surfaced during review of the Android counterpart (PostHog/posthog-android#608, [ioannisj's comment](https://github.com/PostHog/posthog-android/pull/608#discussion_r3560027314)), which does gate its generic capture path.

The check now lives in `captureInternal`, the chokepoint every `$exception` path funnels through. `captureException`'s own check became provably redundant (it passes its merged properties unchanged into `capture("$exception", ...)`) and was removed; the crash-report path keeps its early check since it avoids crash-processing work before the drop.

## :green_heart: How did you test it?

`swift test --no-parallel -Xswiftc -DTESTING --filter "Exception"` — 61 tests in 17 suites pass, including three new end-to-end cases: generic capture drops an ignored type, generic capture keeps non-ignored types, and `captureException` still drops after the gate moved. `make swiftFormatCheck`/`swiftlint` clean on changed files.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session directed by @turnipdabeets, following up the Android review thread above. The change was deliberately kept to the single chokepoint gate + tests; the crash-report path check was left in place as it short-circuits crash processing before the drop.
