### PR TITLE
feat(replay): internal session-replay snapshot hook for out-of-engine capture

### DIFF
--- a/.changeset/native-replay-snapshot-hook.md
+++ b/.changeset/native-replay-snapshot-hook.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": minor
+---
+
+Add `PostHogSDK.captureSessionReplaySnapshot(afterScreenUpdates:)`, an SPI session-replay hook (`@_spi(PostHogInternal)`) that lets first-party PostHog wrapper SDKs (e.g. posthog-flutter) capture the current native window on their own cadence — used to record native screens that cover an out-of-engine UI. Not a public API: it requires an `@_spi(PostHogInternal) import` and carries no stability guarantees.

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -2378,11 +2378,12 @@ let maxRetryDelay = 30.0
         /// timer-driven capture. Returns false if no frame was captured, so the
         /// caller can retry.
         ///
-        /// Pass [afterScreenUpdates] until the episode's first frame has been
-        /// *captured* (returned true) — not just on the first attempt: it also
-        /// re-arms the per-window meta and dedup hash, so a retried opening
-        /// frame keeps its reset. Drop it for steady-state frames (it flickers
-        /// secure fields).
+        /// Pass [episodeFirstFrame] until the episode's first frame has been
+        /// *captured* (returned true) — not just on the first attempt: it
+        /// renders with `afterScreenUpdates` so a freshly-presented screen
+        /// isn't captured black, and re-arms the per-window meta and dedup
+        /// hash, so a retried opening frame keeps its reset. Drop it for
+        /// steady-state frames (it flickers secure fields).
         ///
         /// Prefer the main thread. An off-main call blocks on a synchronous
         /// main-queue hop for the duration of the capture, so it must not come
@@ -2390,13 +2391,13 @@ let maxRetryDelay = 30.0
         ///
         /// SPI, not public API: no stability guarantees.
         @_spi(PostHogInternal) @discardableResult public func captureSessionReplaySnapshot(
-            afterScreenUpdates: Bool
+            episodeFirstFrame: Bool
         ) -> Bool {
             if !isEnabled() {
                 return false
             }
 
-            return replayIntegration?.captureBridgeSnapshot(settlePresentation: afterScreenUpdates) ?? false
+            return replayIntegration?.captureBridgeSnapshot(episodeFirstFrame: episodeFirstFrame) ?? false
         }
     #endif
 

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -2375,9 +2375,18 @@ let maxRetryDelay = 30.0
         /// Captures the current native window for a first-party wrapper SDK
         /// (e.g. posthog-flutter) that drives session-replay capture on its own
         /// cadence. Not for app use — it shares snapshot state with the normal
-        /// timer-driven capture. Pass [afterScreenUpdates] only for an episode's
-        /// first frame (it flickers secure fields). Returns false if no frame
-        /// was captured, so the caller can retry.
+        /// timer-driven capture. Returns false if no frame was captured, so the
+        /// caller can retry.
+        ///
+        /// Pass [afterScreenUpdates] until the episode's first frame has been
+        /// *captured* (returned true) — not just on the first attempt: it also
+        /// re-arms the per-window meta and dedup hash, so a retried opening
+        /// frame keeps its reset. Drop it for steady-state frames (it flickers
+        /// secure fields).
+        ///
+        /// Prefer the main thread. An off-main call blocks on a synchronous
+        /// main-queue hop for the duration of the capture, so it must not come
+        /// from a queue the main thread can be waiting on.
         ///
         /// SPI, not public API: no stability guarantees.
         @_spi(PostHogInternal) @discardableResult public func captureSessionReplaySnapshot(

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -2371,6 +2371,24 @@ let maxRetryDelay = 30.0
 
             replayIntegration.stop()
         }
+
+        /// Captures the current native window for a first-party wrapper SDK
+        /// (e.g. posthog-flutter) that drives session-replay capture on its own
+        /// cadence. Not for app use — it shares snapshot state with the normal
+        /// timer-driven capture. Pass [afterScreenUpdates] only for an episode's
+        /// first frame (it flickers secure fields). Returns false if no frame
+        /// was captured, so the caller can retry.
+        ///
+        /// SPI, not public API: no stability guarantees.
+        @_spi(PostHogInternal) @discardableResult public func captureSessionReplaySnapshot(
+            afterScreenUpdates: Bool
+        ) -> Bool {
+            if !isEnabled() {
+                return false
+            }
+
+            return replayIntegration?.captureBridgeSnapshot(settlePresentation: afterScreenUpdates) ?? false
+        }
     #endif
 
     /// Creates and sets up an additional SDK instance.

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -701,13 +701,22 @@
             windowSize: CGSize,
             screenName: String?,
             postHog: PostHogSDK,
-            timestampDate: Date
+            timestampDate: Date,
+            isFirstFrame: Bool = false
         ) {
             var hasChanges = false
             let timestamp = timestampDate.toMillis()
 
             let snapshotStatus = windowViewsLock.withLock {
                 windowViews.object(forKey: window) ?? ViewTreeSnapshotStatus()
+            }
+
+            // An episode's first frame re-arms the meta (so every bridged
+            // episode opens with a meta carrying the covering screen's name,
+            // mirroring the Android bridge) — a stale latched meta would keep
+            // the previous screen's name for the whole episode.
+            if isFirstFrame {
+                snapshotStatus.sentMetaEvent = false
             }
 
             var snapshotsData: [Any] = []
@@ -746,6 +755,11 @@
                 wireframe.image = nil
                 wireframe.maskableWidgets = nil
 
+                // Re-arm the hash on an episode's first frame so a recurring
+                // native screen always re-sends its opening frame.
+                if isFirstFrame {
+                    snapshotStatus.lastImageHash = nil
+                }
                 let imageHash = (wireframeDict["base64"] as? String)?.hashValue
                 if PostHogReplayIntegration.shouldSkipUnchangedScreenshot(
                     imageHash: imageHash,
@@ -1054,34 +1068,43 @@
             return (wireframe, window.bounds.size, Date())
         }
 
+        @discardableResult
         private func renderAndEnqueueScreenshot(
             _ wireframe: RRWireframe,
             window: UIWindow,
             windowSize: CGSize,
             screenName: String?,
             postHog: PostHogSDK,
-            timestampDate: Date
-        ) {
+            timestampDate: Date,
+            afterScreenUpdates: Bool = false
+        ) -> Bool {
             autoreleasepool {
-                if let image = window.toImage(), image.size.hasSize() {
-                    wireframe.image = image
-                    captureSnapshot(
-                        wireframe,
-                        window: window,
-                        windowSize: windowSize,
-                        screenName: screenName,
-                        postHog: postHog,
-                        timestampDate: timestampDate
-                    )
+                guard let image = window.toImage(afterScreenUpdates: afterScreenUpdates),
+                      image.size.hasSize()
+                else {
+                    return false
                 }
+                wireframe.image = image
+                captureSnapshot(
+                    wireframe,
+                    window: window,
+                    windowSize: windowSize,
+                    screenName: screenName,
+                    postHog: postHog,
+                    timestampDate: timestampDate,
+                    isFirstFrame: afterScreenUpdates
+                )
+                return true
             }
         }
 
+        @discardableResult
         private func performScreenshotCapture(
             window: UIWindow,
             screenName: String?,
-            postHog: PostHogSDK
-        ) {
+            postHog: PostHogSDK,
+            afterScreenUpdates: Bool = false
+        ) -> Bool {
             defer { finishScreenshotRender() }
 
             let screenshotCapture: (wireframe: RRWireframe, windowSize: CGSize, timestampDate: Date)?
@@ -1092,16 +1115,17 @@
             }
 
             guard let screenshotCapture, postHog.isSessionReplayActive() else {
-                return
+                return false
             }
 
-            renderAndEnqueueScreenshot(
+            return renderAndEnqueueScreenshot(
                 screenshotCapture.wireframe,
                 window: window,
                 windowSize: screenshotCapture.windowSize,
                 screenName: screenName,
                 postHog: postHog,
-                timestampDate: screenshotCapture.timestampDate
+                timestampDate: screenshotCapture.timestampDate,
+                afterScreenUpdates: afterScreenUpdates
             )
         }
 
@@ -1345,6 +1369,48 @@
             }
 
             return wireframe
+        }
+
+        /// Captures the current native window for the native-screen bridge.
+        /// [settlePresentation] renders with `afterScreenUpdates` so a
+        /// freshly-presented screen isn't captured black — pass it only for an
+        /// episode's first frame (it flickers secure fields). Returns false if
+        /// no frame was captured, so the caller can retry.
+        @discardableResult
+        func captureBridgeSnapshot(settlePresentation: Bool) -> Bool {
+            guard Thread.isMainThread else {
+                return DispatchQueue.main.sync {
+                    captureBridgeSnapshot(settlePresentation: settlePresentation)
+                }
+            }
+            guard let postHog, postHog.isSessionReplayActive() else {
+                return false
+            }
+            guard let window = UIApplication.getCurrentWindow() else {
+                return false
+            }
+            // A mid-transition capture renders black; the next tick gets it.
+            if isAnimatingTransition(window) {
+                return false
+            }
+            guard tryStartScreenshotRender() else {
+                return false
+            }
+            // Name the covering screen, not the window's root: bridged frames
+            // show the presented native screen, and the replay meta should say
+            // so. Falls back to the root for SDK-owned windows that install
+            // their screen as rootViewController directly.
+            var coveringController = window.rootViewController
+            while let presented = coveringController?.presentedViewController {
+                coveringController = presented
+            }
+            let screenName = coveringController.flatMap(UIViewController.getViewControllerName)
+            return performScreenshotCapture(
+                window: window,
+                screenName: screenName,
+                postHog: postHog,
+                afterScreenUpdates: settlePresentation
+            )
         }
 
         @objc private func snapshot() {

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -1373,9 +1373,11 @@
 
         /// Captures the current native window for the native-screen bridge.
         /// [settlePresentation] renders with `afterScreenUpdates` so a
-        /// freshly-presented screen isn't captured black — pass it only for an
-        /// episode's first frame (it flickers secure fields). Returns false if
-        /// no frame was captured, so the caller can retry.
+        /// freshly-presented screen isn't captured black — pass it until the
+        /// episode's first frame has been captured (it also carries the
+        /// meta/hash re-arm, so a retried opening frame keeps its reset), and
+        /// drop it afterwards (it flickers secure fields). Returns false if no
+        /// frame was captured, so the caller can retry.
         @discardableResult
         func captureBridgeSnapshot(settlePresentation: Bool) -> Bool {
             guard Thread.isMainThread else {

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -702,7 +702,7 @@
             screenName: String?,
             postHog: PostHogSDK,
             timestampDate: Date,
-            isFirstFrame: Bool = false
+            episodeFirstFrame: Bool = false
         ) {
             var hasChanges = false
             let timestamp = timestampDate.toMillis()
@@ -715,7 +715,7 @@
             // episode opens with a meta carrying the covering screen's name,
             // mirroring the Android bridge) — a stale latched meta would keep
             // the previous screen's name for the whole episode.
-            if isFirstFrame {
+            if episodeFirstFrame {
                 snapshotStatus.sentMetaEvent = false
             }
 
@@ -757,7 +757,7 @@
 
                 // Re-arm the hash on an episode's first frame so a recurring
                 // native screen always re-sends its opening frame.
-                if isFirstFrame {
+                if episodeFirstFrame {
                     snapshotStatus.lastImageHash = nil
                 }
                 let imageHash = (wireframeDict["base64"] as? String)?.hashValue
@@ -1076,10 +1076,10 @@
             screenName: String?,
             postHog: PostHogSDK,
             timestampDate: Date,
-            afterScreenUpdates: Bool = false
+            episodeFirstFrame: Bool = false
         ) -> Bool {
             autoreleasepool {
-                guard let image = window.toImage(afterScreenUpdates: afterScreenUpdates),
+                guard let image = window.toImage(afterScreenUpdates: episodeFirstFrame),
                       image.size.hasSize()
                 else {
                     return false
@@ -1092,7 +1092,7 @@
                     screenName: screenName,
                     postHog: postHog,
                     timestampDate: timestampDate,
-                    isFirstFrame: afterScreenUpdates
+                    episodeFirstFrame: episodeFirstFrame
                 )
                 return true
             }
@@ -1103,7 +1103,7 @@
             window: UIWindow,
             screenName: String?,
             postHog: PostHogSDK,
-            afterScreenUpdates: Bool = false
+            episodeFirstFrame: Bool = false
         ) -> Bool {
             defer { finishScreenshotRender() }
 
@@ -1125,7 +1125,7 @@
                 screenName: screenName,
                 postHog: postHog,
                 timestampDate: screenshotCapture.timestampDate,
-                afterScreenUpdates: afterScreenUpdates
+                episodeFirstFrame: episodeFirstFrame
             )
         }
 
@@ -1372,17 +1372,17 @@
         }
 
         /// Captures the current native window for the native-screen bridge.
-        /// [settlePresentation] renders with `afterScreenUpdates` so a
-        /// freshly-presented screen isn't captured black — pass it until the
-        /// episode's first frame has been captured (it also carries the
-        /// meta/hash re-arm, so a retried opening frame keeps its reset), and
-        /// drop it afterwards (it flickers secure fields). Returns false if no
-        /// frame was captured, so the caller can retry.
+        /// [episodeFirstFrame] renders with `afterScreenUpdates` so a
+        /// freshly-presented screen isn't captured black, and re-arms the
+        /// meta/hash so a retried opening frame keeps its reset — pass it
+        /// until the episode's first frame has been captured, and drop it
+        /// afterwards (it flickers secure fields). Returns false if no frame
+        /// was captured, so the caller can retry.
         @discardableResult
-        func captureBridgeSnapshot(settlePresentation: Bool) -> Bool {
+        func captureBridgeSnapshot(episodeFirstFrame: Bool) -> Bool {
             guard Thread.isMainThread else {
                 return DispatchQueue.main.sync {
-                    captureBridgeSnapshot(settlePresentation: settlePresentation)
+                    captureBridgeSnapshot(episodeFirstFrame: episodeFirstFrame)
                 }
             }
             guard let postHog, postHog.isSessionReplayActive() else {
@@ -1398,20 +1398,17 @@
             guard tryStartScreenshotRender() else {
                 return false
             }
-            // Name the covering screen, not the window's root: bridged frames
-            // show the presented native screen, and the replay meta should say
-            // so. Falls back to the root for SDK-owned windows that install
-            // their screen as rootViewController directly.
-            var coveringController = window.rootViewController
-            while let presented = coveringController?.presentedViewController {
-                coveringController = presented
-            }
-            let screenName = coveringController.flatMap(UIViewController.getViewControllerName)
+            // Name the visible covering screen, not the window's root:
+            // bridged frames show the presented native screen, and the replay
+            // meta should say so. ph_topViewController also descends nav/tab
+            // containers to their visible child.
+            let screenName = UIViewController.ph_topViewController(base: window.rootViewController)
+                .flatMap(UIViewController.getViewControllerName)
             return performScreenshotCapture(
                 window: window,
                 screenName: screenName,
                 postHog: postHog,
-                afterScreenUpdates: settlePresentation
+                episodeFirstFrame: episodeFirstFrame
             )
         }
 

--- a/PostHog/Replay/UIView+Util.swift
+++ b/PostHog/Replay/UIView+Util.swift
@@ -45,7 +45,7 @@
             set { objc_setAssociatedObject(self, &AssociatedKeys.phNoRageClick, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
         }
 
-        func toImage() -> UIImage? {
+        func toImage(afterScreenUpdates: Bool = false) -> UIImage? {
             let bounds = self.bounds
             let size = bounds.size
 
@@ -60,9 +60,10 @@
 
             return autoreleasepool {
                 renderer.image { _ in
-                    /// Note: Always `false` for `afterScreenUpdates` since this will cause the screen to flicker when a sensitive text field is visible on screen
+                    /// Note: Default `false` for `afterScreenUpdates` since this will cause the screen to flicker when a sensitive text field is visible on screen
                     /// This can potentially affect capturing a snapshot during a screen transition but we want the lesser of the two evils here
-                    drawHierarchy(in: bounds, afterScreenUpdates: false)
+                    /// The bridge capture passes `true`: a freshly-presented native VC renders black otherwise.
+                    drawHierarchy(in: bounds, afterScreenUpdates: afterScreenUpdates)
                 }
             }
         }


### PR DESCRIPTION
## :bulb: Motivation and Context

First-party wrapper SDKs (starting with posthog-flutter) need to record native screens that cover their engine-rendered UI — paywalls and other view controllers presented on top of a Flutter surface. The wrapper runs its own out-of-engine occlusion detection and needs to drive a one-shot capture of the current native window on its own cadence.

This adds an SPI (`@_spi(PostHogInternal)`) hook for that. It is **not public API**: it carries no source/binary stability guarantees and shares snapshot state with the normal timer-driven capture, so only a coordinating first-party SDK should call it.

Consumed by PostHog/posthog-flutter#473. PostHog/posthog-flutter#151 is the end-user issue this enables fixing.

## :hammer: Changes

- `PostHogSDK.captureSessionReplaySnapshot(afterScreenUpdates:)` — SPI entry point; callable from any thread, hops to main for the capture, returns whether a frame was captured so the caller can retry.
- `PostHogReplayIntegration.captureBridgeSnapshot(settlePresentation:)` — renders and enqueues the current key window's screenshot. `settlePresentation` passes `afterScreenUpdates: true` (used only on an episode's first frame — it flickers secure text fields, so steady-state ticks avoid it).
- Bridged frames carry the covering screen's name: the capture resolves the window's topmost presented view controller and passes its name as the meta `href`, and an episode's first frame re-arms the meta event so every episode opens with one. Native (non-bridge) capture is unaffected — the re-arm is gated on the bridge-only first-frame flag.
- `renderAndEnqueueScreenshot` now returns `Bool` and bails (`return false`) on a failed capture, so nothing is enqueued and the caller can retry.
- First-frame re-arm also resets `lastImageHash`, so a recurring native screen always re-sends its opening frame under the always-on screenshot dedup (#711).

## :green_heart: How did you test it?

- Exercised end-to-end from posthog-flutter's example app on the iOS simulator: native paywall presented over Flutter, both standard presentation and Superwall-style own-window presentation. The episode held for the full duration and captured the native screen.
- swiftformat clean; compiled via the posthog-flutter example app build against this branch.
- There is no unit coverage for the bridge path (it needs a host window); the driving logic is tested on the Flutter side (`native_occlusion_episode_test.dart` over there).

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Implemented with Claude Code (Opus 4.8 and Fable 5 sessions) driven by @turnipdabeets, alongside the matching posthog-android hook and the posthog-flutter feature that consumes both.
- Design decisions: SPI over public API (no stability commitment for a wrapper-only hook); reuse of the existing screenshot path + masking rather than a parallel pipeline; `afterScreenUpdates` only on episode-first frames because it visibly flickers secure text fields; per-episode meta re-arm added after review so replay names the covering native screen instead of keeping the stale wrapper screen name.
- A multi-agent review pass over the combined feature verified the episode/dedup interactions and confirmed the meta re-arm cannot affect native (non-bridge) capture.

