### PR TITLE
fix: support POSTHOG_SKIP_ON_CONFLICT in upload-symbols.sh

### DIFF
--- a/.changeset/dsym-skip-on-conflict.md
+++ b/.changeset/dsym-skip-on-conflict.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+`upload-symbols.sh` supports `POSTHOG_SKIP_ON_CONFLICT=1` to pass `--skip-on-conflict` to `posthog-cli dsym upload`, so dSYM content conflicts skip the upload instead of failing the build (requires posthog-cli >= 0.7.12)

--- a/build-tools/upload-symbols.sh
+++ b/build-tools/upload-symbols.sh
@@ -9,8 +9,9 @@
 #
 #
 # Usage Examples:
-#   Basic:       "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
-#   With source: POSTHOG_INCLUDE_SOURCE=1 "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
+#   Basic:          "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
+#   With source:    POSTHOG_INCLUDE_SOURCE=1 "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
+#   Skip conflicts: POSTHOG_SKIP_ON_CONFLICT=1 "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
 #
 # Build Settings (required):
 #   DEBUG_INFORMATION_FORMAT = DWARF with dSYM File
@@ -19,6 +20,8 @@
 # Environment Variables (optional):
 #   POSTHOG_CLI_INSTALL_DIR - Custom directory containing posthog-cli binary
 #   POSTHOG_INCLUDE_SOURCE - Set to "1" to include source files in dSYM upload
+#   POSTHOG_SKIP_ON_CONFLICT - Set to "1" to skip symbol sets that already exist
+#                              with different content instead of failing the build
 #
 
 # Skip non-Release builds.
@@ -80,6 +83,10 @@ fi
 
 # Enforce minimum posthog-cli version (required for --release-name / --release-version flags)
 MIN_POSTHOG_CLI_VERSION="0.7.7"
+# --skip-on-conflict needs a newer CLI (older versions reject the unknown flag)
+if [ "${POSTHOG_SKIP_ON_CONFLICT}" = "1" ]; then
+    MIN_POSTHOG_CLI_VERSION="0.7.12"
+fi
 PH_CLI_VERSION=$("$PH_CLI_PATH" --version 2>/dev/null | awk '{print $NF}' | tr -d 'v')
 
 if [ -z "$PH_CLI_VERSION" ]; then
@@ -115,6 +122,10 @@ fi
 # Include source if requested via env var
 if [ "${POSTHOG_INCLUDE_SOURCE}" = "1" ]; then
     CLI_ARGS+=(--include-source)
+fi
+# Skip symbol sets that already exist with different content if requested via env var
+if [ "${POSTHOG_SKIP_ON_CONFLICT}" = "1" ]; then
+    CLI_ARGS+=(--skip-on-conflict)
 fi
 
 "${PH_CLI_PATH}" dsym upload "${CLI_ARGS[@]}" || exit 1

--- a/build-tools/upload-symbols.sh
+++ b/build-tools/upload-symbols.sh
@@ -86,7 +86,7 @@ MIN_POSTHOG_CLI_VERSION="0.7.7"
 if [ "${POSTHOG_SKIP_ON_CONFLICT}" = "1" ]; then
     MIN_POSTHOG_CLI_VERSION="0.7.12"
 fi
-PH_CLI_VERSION=$("$PH_CLI_PATH" --version 2>/dev/null | awk '{print $NF}' | tr -d 'v')
+PH_CLI_VERSION=$("$PH_CLI_PATH" --version 2>/dev/null | grep -oE '[0-9]+(\.[0-9]+)+' | head -n1)
 
 if [ -z "$PH_CLI_VERSION" ]; then
     echo "error: could not determine posthog-cli version. Upgrade: npm install -g @posthog/cli@latest"

--- a/build-tools/upload-symbols.sh
+++ b/build-tools/upload-symbols.sh
@@ -83,7 +83,6 @@ fi
 
 # Enforce minimum posthog-cli version (required for --release-name / --release-version flags)
 MIN_POSTHOG_CLI_VERSION="0.7.7"
-# --skip-on-conflict needs a newer CLI (older versions reject the unknown flag)
 if [ "${POSTHOG_SKIP_ON_CONFLICT}" = "1" ]; then
     MIN_POSTHOG_CLI_VERSION="0.7.12"
 fi
@@ -123,7 +122,6 @@ fi
 if [ "${POSTHOG_INCLUDE_SOURCE}" = "1" ]; then
     CLI_ARGS+=(--include-source)
 fi
-# Skip on conflict if requested via env var
 if [ "${POSTHOG_SKIP_ON_CONFLICT}" = "1" ]; then
     CLI_ARGS+=(--skip-on-conflict)
 fi

--- a/build-tools/upload-symbols.sh
+++ b/build-tools/upload-symbols.sh
@@ -123,7 +123,7 @@ fi
 if [ "${POSTHOG_INCLUDE_SOURCE}" = "1" ]; then
     CLI_ARGS+=(--include-source)
 fi
-# Skip symbol sets that already exist with different content if requested via env var
+# Skip on conflict if requested via env var
 if [ "${POSTHOG_SKIP_ON_CONFLICT}" = "1" ]; then
     CLI_ARGS+=(--skip-on-conflict)
 fi


### PR DESCRIPTION
## :bulb: Motivation and Context

Reported in PostHog/posthog-js#4142: when PostHog already has a dSYM with the same UUID but different content, `posthog-cli dsym upload` fails with `content_hash_mismatch` and the whole build (e.g. EAS iOS) fails, with no way to opt out through this script. The CLI has supported `dsym upload --skip-on-conflict` since 0.7.12, but `upload-symbols.sh` builds the CLI argument list internally and doesn't forward script arguments, so consumers can't reach the flag.

This adds a `POSTHOG_SKIP_ON_CONFLICT=1` environment variable — the same channel `POSTHOG_INCLUDE_SOURCE` already uses — that appends `--skip-on-conflict` to the `dsym upload` invocation, so conflicting symbol sets are skipped (existing symbols preserved) instead of failing the build. When the variable is set, the minimum-CLI-version gate is raised from 0.7.7 to 0.7.12, since older CLIs reject the unknown flag with a confusing error.

Companion PR wiring the Expo config plugin's `skipOnConflict` option to this variable: PostHog/posthog-js#4148. The two are order-independent — this change is a no-op unless the variable is set.

## :green_heart: How did you test it?

- `bash -n` and `shellcheck` pass.
- Exercised the script against a stub `posthog-cli` recording its arguments, covering: default (no flag appended, unchanged behavior), `POSTHOG_SKIP_ON_CONFLICT=1` (appends `--skip-on-conflict`), combined with `POSTHOG_INCLUDE_SOURCE=1` (both flags), CLI 0.7.8 with the variable set (fails with the min-version error), and CLI 0.7.8 without it (unchanged behavior).

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code while investigating PostHog/posthog-js#4142. Rejected forwarding raw script arguments (`"$@"`) in favor of the env-var channel to match the existing `POSTHOG_INCLUDE_SOURCE` pattern and keep the Expo plugin version-decoupled from posthog-ios.
- Bisected `@posthog/cli` npm releases to pin the flag's introduction to 0.7.12, hence the conditional min-version bump.
- "Tests" above are the stub-CLI script runs described in the testing section; the repo has no shell test harness.
