### PR TITLE
docs: reword 3.64.7 skip-on-conflict changelog entry for SDK users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Set `POSTHOG_SKIP_ON_CONFLICT=1` on the debug-symbols upload build phase to keep release builds going when a dSYM with the same UUID but different content already exists in PostHog: the upload is skipped and the existing symbols are kept, instead of the build failing. Requires posthog-cli >= 0.7.12.
+- 2f1e1c3: Set `POSTHOG_SKIP_ON_CONFLICT=1` on the debug-symbols upload build phase to keep release builds going when a dSYM with the same UUID but different content already exists in PostHog: the upload is skipped and the existing symbols are kept, instead of the build failing. Requires posthog-cli >= 0.7.12.
 
 ## 3.64.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- 2f1e1c3: `upload-symbols.sh` supports `POSTHOG_SKIP_ON_CONFLICT=1` to pass `--skip-on-conflict` to `posthog-cli dsym upload`, so dSYM content conflicts skip the upload instead of failing the build (requires posthog-cli >= 0.7.12)
+- 2f1e1c3: Set `POSTHOG_SKIP_ON_CONFLICT=1` on the debug-symbols upload build phase to keep release builds going when a dSYM with the same UUID but different content already exists in PostHog: the upload is skipped and the existing symbols are kept, instead of the build failing. Requires posthog-cli >= 0.7.12.
 
 ## 3.64.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- 2f1e1c3: Set `POSTHOG_SKIP_ON_CONFLICT=1` on the debug-symbols upload build phase to keep release builds going when a dSYM with the same UUID but different content already exists in PostHog: the upload is skipped and the existing symbols are kept, instead of the build failing. Requires posthog-cli >= 0.7.12.
+- Set `POSTHOG_SKIP_ON_CONFLICT=1` on the debug-symbols upload build phase to keep release builds going when a dSYM with the same UUID but different content already exists in PostHog: the upload is skipped and the existing symbols are kept, instead of the build failing. Requires posthog-cli >= 0.7.12.
 
 ## 3.64.6
 


### PR DESCRIPTION
## :bulb: Motivation and Context

The 3.64.7 changelog entry for `POSTHOG_SKIP_ON_CONFLICT` (from #716) described the implementation (which flag gets passed to which CLI command) rather than what changes for an app developer. This rewords it around the outcome: builds keep going on dSYM content conflicts, existing symbols are kept.

## :green_heart: How did you test it?

Docs-only change; CHANGELOG renders as expected.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file (not needed: edits an already-released entry)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up to #716: the reworded changeset was pushed minutes after the PR merged and v3.64.7 released, so the published CHANGELOG kept the implementation-focused wording. This applies the intended developer-facing wording to the released entry.