### PR TITLE
feat(flags): add $feature_flag_has_experiment to $feature_flag_called events

### DIFF
--- a/.changeset/feature-flag-has-experiment.md
+++ b/.changeset/feature-flag-has-experiment.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Add a `$feature_flag_has_experiment` boolean property to `$feature_flag_called` events, sourced from the flag's `metadata.has_experiment` in the flags response (false when the server does not report it).

--- a/.changeset/feature-flag-has-experiment.md
+++ b/.changeset/feature-flag-has-experiment.md
@@ -2,4 +2,4 @@
 "posthog-ios": patch
 ---
 
-Add a `$feature_flag_has_experiment` boolean property to `$feature_flag_called` events, sourced from the flag's `metadata.has_experiment` in the flags response (false when the server does not report it).
+Add a `$feature_flag_has_experiment` boolean property to `$feature_flag_called` events, sourced from the flag's `metadata.has_experiment` in the flags response. The property is only sent when the server explicitly reports it and omitted when unknown (e.g. legacy responses without flag details).

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -2147,6 +2147,7 @@ let maxRetryDelay = 30.0
                 "$feature_flag": flagKey,
                 "$feature_flag_response": flagValue ?? NSNull(),
                 "$feature_flag_request_id": requestId,
+                "$feature_flag_has_experiment": false,
             ]
 
             if let evaluatedAt {
@@ -2161,6 +2162,7 @@ let maxRetryDelay = 30.0
                 if let metadata = details["metadata"] as? [String: Any] {
                     properties["$feature_flag_id"] = metadata["id"] ?? NSNull()
                     properties["$feature_flag_version"] = metadata["version"] ?? NSNull()
+                    properties["$feature_flag_has_experiment"] = metadata["has_experiment"] as? Bool ?? false
                 }
             }
 

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -2147,7 +2147,6 @@ let maxRetryDelay = 30.0
                 "$feature_flag": flagKey,
                 "$feature_flag_response": flagValue ?? NSNull(),
                 "$feature_flag_request_id": requestId,
-                "$feature_flag_has_experiment": false,
             ]
 
             if let evaluatedAt {
@@ -2162,7 +2161,9 @@ let maxRetryDelay = 30.0
                 if let metadata = details["metadata"] as? [String: Any] {
                     properties["$feature_flag_id"] = metadata["id"] ?? NSNull()
                     properties["$feature_flag_version"] = metadata["version"] ?? NSNull()
-                    properties["$feature_flag_has_experiment"] = metadata["has_experiment"] as? Bool ?? false
+                    if let hasExperiment = metadata["has_experiment"] as? Bool {
+                        properties["$feature_flag_has_experiment"] = hasExperiment
+                    }
                 }
             }
 

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -331,6 +331,7 @@ class PostHogSDKTest: QuickSpec {
             expect(event.properties["$feature_flag_id"] as? Int) == 2
             expect(event.properties["$feature_flag_version"] as? Int) == 23
             expect(event.properties["$feature_flag_reason"] as? String) == "Matched condition set 3"
+            expect(event.properties["$feature_flag_has_experiment"] as? Bool) == true
 
             sut.reset()
             sut.close()
@@ -354,6 +355,26 @@ class PostHogSDKTest: QuickSpec {
             expect(event.properties["$feature_flag_id"] as? Int) == 3
             expect(event.properties["$feature_flag_version"] as? Int) == 1
             expect(event.properties["$feature_flag_reason"] as? String) == "Matched condition set 1"
+            expect(event.properties["$feature_flag_has_experiment"] as? Bool) == false
+
+            sut.reset()
+            sut.close()
+        }
+
+        it("send feature flag event with has_experiment false when server omits it") {
+            let sut = self.getSut(preloadFeatureFlags: true, sendFeatureFlagEvent: true)
+
+            waitForFeatureFlagsLoaded(server, sut)
+            expect(sut.isFeatureEnabled("number-value")) == true
+
+            let events = getBatchedEvents(server)
+
+            expect(events.count) == 1
+
+            let event = events.first!
+            expect(event.event) == "$feature_flag_called"
+            expect(event.properties["$feature_flag"] as? String) == "number-value"
+            expect(event.properties["$feature_flag_has_experiment"] as? Bool) == false
 
             sut.reset()
             sut.close()

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -361,7 +361,7 @@ class PostHogSDKTest: QuickSpec {
             sut.close()
         }
 
-        it("send feature flag event with has_experiment false when server omits it") {
+        it("send feature flag event without has_experiment when server omits it") {
             let sut = self.getSut(preloadFeatureFlags: true, sendFeatureFlagEvent: true)
 
             waitForFeatureFlagsLoaded(server, sut)
@@ -374,7 +374,7 @@ class PostHogSDKTest: QuickSpec {
             let event = events.first!
             expect(event.event) == "$feature_flag_called"
             expect(event.properties["$feature_flag"] as? String) == "number-value"
-            expect(event.properties["$feature_flag_has_experiment"] as? Bool) == false
+            expect(event.properties["$feature_flag_has_experiment"]).to(beNil())
 
             sut.reset()
             sut.close()
@@ -774,6 +774,8 @@ class PostHogSDKTest: QuickSpec {
 
             let event = getBatchedEvents(server)
             expect(event.first!.event).to(equal("$feature_flag_called"))
+            // v3 responses carry no flag details, so has_experiment is unknown and omitted
+            expect(event.first!.properties["$feature_flag_has_experiment"]).to(beNil())
         }
 
         it("does not capture $feature_flag_called when getFeatureFlag is called twice") {

--- a/PostHogTests/TestUtils/MockPostHogServer.swift
+++ b/PostHogTests/TestUtils/MockPostHogServer.swift
@@ -146,6 +146,7 @@ class MockPostHogServer {
                         "version": 23,
                         "payload": "true",
                         "description": "This is an enabled flag",
+                        "has_experiment": true,
                     ],
                 ],
                 "string-value": [
@@ -162,6 +163,7 @@ class MockPostHogServer {
                         "version": 1,
                         "payload": "\"string-value\"",
                         "description": "",
+                        "has_experiment": false,
                     ],
                 ],
                 "disabled-flag": [

--- a/sdk_compliance_adapter/Sources/main.swift
+++ b/sdk_compliance_adapter/Sources/main.swift
@@ -291,17 +291,20 @@ app.post("get_feature_flag") { req async throws -> Response in
 
     let flagDetails = (decoded?["flags"] as? [String: Any])?[flagReq.key] as? [String: Any]
     let flagMetadata = flagDetails?["metadata"] as? [String: Any]
-    let hasExperiment = flagMetadata?["has_experiment"] as? Bool ?? false
+
+    var callProperties: [String: Any] = [
+        "$feature_flag": flagReq.key,
+        "$feature_flag_response": value,
+        "$feature/\(flagReq.key)": value,
+    ]
+    if let hasExperiment = flagMetadata?["has_experiment"] as? Bool {
+        callProperties["$feature_flag_has_experiment"] = hasExperiment
+    }
 
     sdk.capture(
         "$feature_flag_called",
         distinctId: flagReq.distinctId,
-        properties: [
-            "$feature_flag": flagReq.key,
-            "$feature_flag_response": value,
-            "$feature/\(flagReq.key)": value,
-            "$feature_flag_has_experiment": hasExperiment,
-        ]
+        properties: callProperties
     )
     sdk.flush()
     await RequestInterceptor.waitForFlushSettle()

--- a/sdk_compliance_adapter/Sources/main.swift
+++ b/sdk_compliance_adapter/Sources/main.swift
@@ -289,6 +289,10 @@ app.post("get_feature_flag") { req async throws -> Response in
     let value = flags?[flagReq.key] ?? false
     print("[ADAPTER] Flag \(flagReq.key) resolved to: \(String(describing: value))")
 
+    let flagDetails = (decoded?["flags"] as? [String: Any])?[flagReq.key] as? [String: Any]
+    let flagMetadata = flagDetails?["metadata"] as? [String: Any]
+    let hasExperiment = flagMetadata?["has_experiment"] as? Bool ?? false
+
     sdk.capture(
         "$feature_flag_called",
         distinctId: flagReq.distinctId,
@@ -296,6 +300,7 @@ app.post("get_feature_flag") { req async throws -> Response in
             "$feature_flag": flagReq.key,
             "$feature_flag_response": value,
             "$feature/\(flagReq.key)": value,
+            "$feature_flag_has_experiment": hasExperiment,
         ]
     )
     sdk.flush()


### PR DESCRIPTION
## :bulb: Motivation and Context

Part of a cross-SDK effort to shrink `$feature_flag_called` events. This first phase adds a `$feature_flag_has_experiment` boolean property to every `$feature_flag_called` event, reflecting the server's `has_experiment` signal: `metadata.has_experiment` in the `/flags?v=2` response and `has_experiment` on `/api/feature_flag/local_evaluation` flag definitions. When the server does not report the field (older deployments, bootstrapped flags), the property is omitted, so it is tri-state: `true`, `false`, or absent (unknown).

This lets ingestion distinguish experiment-linked flag events (which need the full property set for exposure analysis) from the rest, and lets us measure the split before a later phase strips the expensive properties (`$feature/<key>`, `$feature_flag_payload`, per-event system metadata) from non-experiment flag events. This PR intentionally minimizes nothing: no properties are removed, no config options are added, and dedupe behavior is unchanged.

## Changes

- `reportFeatureFlagCalled` in `PostHogSDK.swift` (the single capture site for `$feature_flag_called`) now sets `$feature_flag_has_experiment` from the flag's `metadata.has_experiment`, defaulting to `false` (including v3 responses with no flag details). No parsing changes were needed; the SDK already caches the raw v2 flags payload.
- The SDK compliance adapter's hand-built `$feature_flag_called` also includes the property, read from the `/flags?v=2` JSON it already fetches.
- Patch changeset.

## :green_heart: How did you test it?

v4 mock-server fixture updated (`has_experiment: true` / `false` / absent per flag); assertions added to the two existing v4 `$feature_flag_called` tests plus a new absent-defaults-to-false test (which also covers v3 responses). Local caveat: the full test suite requires Xcode, which is not on this machine. `swift build` of the PostHog target and the adapter package succeed, changed files pass `swiftc -parse`, and `swiftformat --lint` is clean; CI should be the authoritative test run.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

