### PR TITLE
feat: POSTHOG_DOTENV_FILE support in upload-symbols.sh

### DIFF
--- a/.changeset/dsym-dotenv-file.md
+++ b/.changeset/dsym-dotenv-file.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+`upload-symbols.sh` supports `POSTHOG_DOTENV_FILE=<path>` to pass `--dotenv-file` to `posthog-cli`, so the dSYM upload can read `POSTHOG_CLI_*` credentials from a gitignored dotenv file instead of requiring them in the build environment (requires posthog-cli >= 0.7.18)

--- a/build-tools/upload-symbols.sh
+++ b/build-tools/upload-symbols.sh
@@ -12,6 +12,7 @@
 #   Basic:          "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
 #   With source:    POSTHOG_INCLUDE_SOURCE=1 "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
 #   Skip conflicts: POSTHOG_SKIP_ON_CONFLICT=1 "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
+#   With .env:      POSTHOG_DOTENV_FILE="${SRCROOT}/.env" "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
 #
 # Build Settings (required):
 #   DEBUG_INFORMATION_FORMAT = DWARF with dSYM File
@@ -22,6 +23,9 @@
 #   POSTHOG_INCLUDE_SOURCE - Set to "1" to include source files in dSYM upload
 #   POSTHOG_SKIP_ON_CONFLICT - Set to "1" to skip symbol sets that already exist
 #                              with different content instead of failing the build
+#   POSTHOG_DOTENV_FILE - Path to a dotenv-style file providing POSTHOG_CLI_API_KEY /
+#                         POSTHOG_CLI_PROJECT_ID / POSTHOG_CLI_HOST (forwarded to
+#                         posthog-cli as --dotenv-file; requires posthog-cli >= 0.7.18)
 #
 
 # Skip non-Release builds.
@@ -48,6 +52,14 @@ fi
 if [ -z "$(find "${DWARF_DSYM_FOLDER_PATH}" -name '*.dSYM' -type d 2>/dev/null)" ]; then
     echo "info: No dSYM bundles found in ${DWARF_DSYM_FOLDER_PATH}"
     exit 0
+fi
+
+# Fail fast when the requested dotenv file is missing. posthog-cli itself only
+# warns and falls back to other credential sources (login session), which can
+# upload to the wrong project instead of surfacing the misconfiguration.
+if [ -n "${POSTHOG_DOTENV_FILE}" ] && [ ! -f "${POSTHOG_DOTENV_FILE}" ]; then
+    echo "error: POSTHOG_DOTENV_FILE not found: ${POSTHOG_DOTENV_FILE}"
+    exit 1
 fi
 
 # Find posthog-cli (Xcode doesn't load shell profiles)
@@ -85,6 +97,9 @@ fi
 MIN_POSTHOG_CLI_VERSION="0.7.7"
 if [ "${POSTHOG_SKIP_ON_CONFLICT}" = "1" ]; then
     MIN_POSTHOG_CLI_VERSION="0.7.12"
+fi
+if [ -n "${POSTHOG_DOTENV_FILE}" ]; then
+    MIN_POSTHOG_CLI_VERSION="0.7.18"
 fi
 PH_CLI_VERSION=$("$PH_CLI_PATH" --version 2>/dev/null | grep -oE '[0-9]+(\.[0-9]+)+' | head -n1)
 
@@ -126,4 +141,10 @@ if [ "${POSTHOG_SKIP_ON_CONFLICT}" = "1" ]; then
     CLI_ARGS+=(--skip-on-conflict)
 fi
 
-"${PH_CLI_PATH}" dsym upload "${CLI_ARGS[@]}" || exit 1
+# Global CLI arguments (must precede the subcommand)
+GLOBAL_ARGS=()
+if [ -n "${POSTHOG_DOTENV_FILE}" ]; then
+    GLOBAL_ARGS+=(--dotenv-file "${POSTHOG_DOTENV_FILE}")
+fi
+
+"${PH_CLI_PATH}" ${GLOBAL_ARGS[@]+"${GLOBAL_ARGS[@]}"} dsym upload "${CLI_ARGS[@]}" || exit 1


### PR DESCRIPTION
## :bulb: Motivation and Context

The PostHog wizard is moving iOS dSYM-upload credentials from a gitignored `.xcconfig` (wired as `baseConfigurationReference`, which needs fragile pbxproj surgery and CocoaPods `#include?` chaining) to a plain gitignored `.env` — the same flow every other platform uses. `posthog-cli` already reads dotenv files via the global `--dotenv-file` flag (>= 0.7.18); this teaches `upload-symbols.sh` to forward one:

```
POSTHOG_DOTENV_FILE="${SRCROOT}/.env" "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
```

Follows the script's existing conventions: env-var feature toggle (like `POSTHOG_INCLUDE_SOURCE` / `POSTHOG_SKIP_ON_CONFLICT`) and a per-feature `MIN_POSTHOG_CLI_VERSION` bump (0.7.18, where the `--dotenv-file` spelling shipped).

A missing file is a **hard error** rather than a pass-through: the CLI itself only warns and falls back to its other credential sources (e.g. a `~/.posthog` login session), which can silently upload to the wrong project instead of surfacing the misconfiguration.

## :green_heart: How did you test it?

`bash -n` plus a scripted smoke test with a fake dSYM tree and posthog-cli 0.7.18:

- `POSTHOG_DOTENV_FILE` pointing at a missing file → `error: POSTHOG_DOTENV_FILE not found: …`, exit 1
- Valid file + `POSTHOG_CLI_DRY_RUN=true` → CLI accepts `--dotenv-file` before the subcommand, run completes
- Variable unset → behavior unchanged (Debug skip, arg list identical)

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Claude Fable 5) in an interactive session directed by @ablaszkiewicz, alongside matching changes in the wizard and context-mill repos.
- Chose an env var over a positional/flag argument to match the script's existing toggles, and a script-side hard error on a missing file because the CLI deliberately warns-and-falls-back (posthog#61567) — acceptable for direct CLI use, but in a build phase it masks misconfiguration as a wrong-project upload.
- Introducing CLI version verified from the posthog monorepo history: `--env-file` landed in posthog#60465, renamed to `--dotenv-file` in posthog#61443-era 0.7.18 (Node's built-in `--env-file` intercepts the old spelling under the npm wrapper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)