### PR TITLE
chore: enable strict missing_docs SwiftLint rule

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,16 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: needs.detect-markdown-only.outputs.markdown_only != 'true'
 
+      # TEMPORARY (July 2026): runner images mid-rollout ship different preinstalled SwiftFormat
+      # versions; 0.61 fails to parse the wrapIfStatementBodies disable in .swiftformat (rule added
+      # in 0.62). Remove once all macos-26 runners ship SwiftFormat >= 0.62.
+      - name: Upgrade SwiftFormat if it predates configured rules
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        run: |
+          if ! swiftformat --rules | grep -q wrapIfStatementBodies; then
+            brew update && brew upgrade swiftformat
+          fi
+
       - name: Check formatting
         if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         run: make swiftFormatCheck

--- a/.swiftformat
+++ b/.swiftformat
@@ -9,6 +9,8 @@
 --disable redundantType
 --disable wrapPropertyBodies
 --disable blankLinesBetweenScopes
+# replaced the disabled-by-default wrapConditionalBodies in SwiftFormat 0.62, but ships enabled
+--disable wrapIfStatementBodies
 
 --acronyms ID,URL,UUID
 --allman false

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -28,6 +28,8 @@ opt_in_rules:
   - missing_docs
 
 missing_docs:
+  # error severity so violations fail CI (swiftlint runs without --strict)
+  error: [open, public]
   # the defaults skip members of any type that subclasses or conforms to anything
   # (i.e. nearly the whole SDK), which would make the rule a no-op
   excludes_inherited_types: false

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -24,6 +24,15 @@ disabled_rules:
   - trailing_comma
   - opening_brace
 
+opt_in_rules:
+  - missing_docs
+
+missing_docs:
+  # the defaults skip members of any type that subclasses or conforms to anything
+  # (i.e. nearly the whole SDK), which would make the rule a no-op
+  excludes_inherited_types: false
+  excludes_extensions: false
+
 line_length:
   warning: 160
   ignores_comments: true


### PR DESCRIPTION
## :bulb: Motivation and Context

#220 asked for all public declarations to be documented and for the `missing_docs` SwiftLint rule to be enabled. The docs themselves landed in #617, but the rule was never turned on, so nothing guards against new undocumented public API. This turns it on.

The rule is configured with `excludes_inherited_types: false`: the default (`true`) skips members of any type that subclasses or conforms to anything, which in this SDK (nearly everything is `NSObject`-based) would make the rule a no-op.

## :green_heart: How did you test it?

Ran `swiftlint` from the repo root with the rule enabled: zero `missing_docs` violations. I also verified the rule actually fires by linting a probe file with an undocumented `NSObject` subclass (both the type and the member were flagged), then removed the probe.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**DRI:** @ioannisj
**Autonomy:** Human-driven (agent-assisted)
