### PR TITLE
feat(flags): minimize $feature_flag_called events for non-experiment flags

### DIFF
--- a/.changeset/minimal-flag-called-events.md
+++ b/.changeset/minimal-flag-called-events.md
@@ -2,4 +2,4 @@
 "posthog-ios": minor
 ---
 
-Send minimal `$feature_flag_called` events when the server opts the project in (top-level `minimalFlagCalledEvents` in the flags response) and the evaluated flag has no experiment. Minimal events keep only a strict allowlist of flag-evaluation and linkage properties; the device/OS context envelope, super properties, `$active_feature_flags`, and the `$feature/<key>` enumeration are stripped. Experiment-linked flags, ungated projects, and any response missing the signals keep sending the full event.
+Send minimal `$feature_flag_called` events when the server opts the project in (top-level `minimalFlagCalledEvents` in the flags response) and the evaluated flag has no experiment. Minimal events keep only a strict allowlist of flag-evaluation and linkage properties plus `$os_name`, `$os_version`, and `$app_version` for OS- and version-segmented insights; the rest of the device/OS context envelope, super properties, `$active_feature_flags`, and the `$feature/<key>` enumeration are stripped. Experiment-linked flags, ungated projects, and any response missing the signals keep sending the full event.

--- a/.changeset/minimal-flag-called-events.md
+++ b/.changeset/minimal-flag-called-events.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": minor
+---
+
+Send minimal `$feature_flag_called` events when the server opts the project in (top-level `minimalFlagCalledEvents` in the flags response) and the evaluated flag has no experiment. Minimal events keep only a strict allowlist of flag-evaluation and linkage properties; the device/OS context envelope, super properties, `$active_feature_flags`, and the `$feature/<key>` enumeration are stripped. Experiment-linked flags, ungated projects, and any response missing the signals keep sending the full event.

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -39,6 +39,7 @@ class PostHogRemoteConfig {
     private var featureFlagPayloads: [String: Any]?
     private var requestId: String?
     private var evaluatedAt: Int?
+    private var minimalFlagCalledEvents: Bool?
 
     /// Copies of `config.bootstrap`, retained for `$feature_flag_called` enrichment and cleared by
     /// `clear()` (on `reset()`) so bootstrap never re-applies to a different user. Under `featureFlagsLock`.
@@ -72,6 +73,15 @@ class PostHogRemoteConfig {
     var lastEvaluatedAt: Int? {
         featureFlagsLock.withLock {
             getCachedValue(\.evaluatedAt, key: .evaluatedAt) { storage.getInt(forKey: $0) }
+        }
+    }
+
+    /// Whether the server gated this project into minimal `$feature_flag_called` events
+    /// (top-level `minimalFlagCalledEvents` of the v2 `/flags` response). Absent from the
+    /// response or cache means `false`, so the SDK fails safe to full events.
+    var sendMinimalFlagCalledEvents: Bool {
+        featureFlagsLock.withLock {
+            getCachedValue(\.minimalFlagCalledEvents, key: .minimalFlagCalledEvents) { storage.getBool(forKey: $0) } ?? false
         }
     }
 
@@ -432,6 +442,10 @@ class PostHogRemoteConfig {
                     if let evaluatedAt {
                         self.setCachedEvaluatedAt(evaluatedAt)
                     }
+
+                    // Persist the minimal $feature_flag_called gate alongside the cached flags so it
+                    // survives restarts. Set unconditionally: an absent field means the gate is off.
+                    self.setCachedMinimalFlagCalledEvents(data["minimalFlagCalledEvents"] as? Bool)
 
                     if errorsWhileComputingFlags {
                         let cachedFlags = self.getCachedFlags() ?? [:]
@@ -921,6 +935,13 @@ class PostHogRemoteConfig {
         }
     }
 
+    // To be called after acquiring `featureFlagsLock`
+    private func setCachedMinimalFlagCalledEvents(_ value: Bool?) {
+        setCachedValue(value, cache: \.minimalFlagCalledEvents, key: .minimalFlagCalledEvents) { key, value in
+            storage.setBool(forKey: key, contents: value)
+        }
+    }
+
     private func getCachedValue<T>(
         _ cache: KeyPath<PostHogRemoteConfig, T?>,
         key: PostHogStorage.StorageKey,
@@ -989,6 +1010,7 @@ class PostHogRemoteConfig {
         setCachedFeatureFlagPayload([:])
         setCachedRequestId(nil) // requestId no longer valid
         setCachedEvaluatedAt(nil) // evaluatedAt no longer valid
+        setCachedMinimalFlagCalledEvents(nil) // gate travels with the cached flags; re-arms on the next /flags
     }
 
     /// Clears all cached feature flags, remote config state, and user-specific properties.

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -943,11 +943,14 @@ class PostHogRemoteConfig {
     }
 
     private func getCachedValue<T>(
-        _ cache: KeyPath<PostHogRemoteConfig, T?>,
+        _ cache: ReferenceWritableKeyPath<PostHogRemoteConfig, T?>,
         key: PostHogStorage.StorageKey,
         load: (PostHogStorage.StorageKey) -> T?
     ) -> T? {
-        self[keyPath: cache] ?? load(key)
+        if self[keyPath: cache] == nil {
+            self[keyPath: cache] = load(key)
+        }
+        return self[keyPath: cache]
     }
 
     private func setCachedValue<T>(

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -1274,7 +1274,8 @@ let maxRetryDelay = 30.0
         userPropertiesSetOnce: [String: Any]? = nil,
         groups: [String: String]? = nil,
         timestamp: Date? = nil,
-        skipBuildProperties: Bool = false
+        skipBuildProperties: Bool = false,
+        propertyAllowlist: Set<String>? = nil
     ) {
         if !isEnabled() {
             return
@@ -1327,6 +1328,14 @@ let maxRetryDelay = 30.0
                 appendSharedProps: !isSnapshotEvent,
                 timestamp: timestamp
             )
+        }
+
+        // Filtering after the full build stays robust as new context properties are added later:
+        // anything not explicitly allowlisted is stripped. beforeSend hooks and the legacy
+        // propertiesSanitizer run later (in buildEvent) and may re-add keys — an accepted
+        // escape hatch, codified in the minimal-event contract.
+        if let propertyAllowlist {
+            finalProperties = finalProperties.filter { propertyAllowlist.contains($0.key) }
         }
 
         // Attach the session-scoped step buffer to a `$exception` unless the caller provided their own.
@@ -2171,6 +2180,29 @@ let maxRetryDelay = 30.0
         }
     }
 
+    /// The strict property allowlist for minimal `$feature_flag_called` events. Everything else —
+    /// registered super properties, the device/OS context envelope, `$active_feature_flags`, the
+    /// `$feature/<key>` enumeration, bootstrap enrichment — is stripped. Kept in sync with the
+    /// cross-SDK minimal `$feature_flag_called` contract.
+    private static let minimalFeatureFlagCalledProperties: Set<String> = [
+        "$feature_flag",
+        "$feature_flag_response",
+        "$feature_flag_has_experiment",
+        "$feature_flag_id",
+        "$feature_flag_version",
+        "$feature_flag_reason",
+        "$feature_flag_request_id",
+        "$feature_flag_evaluated_at",
+        "$feature_flag_error",
+        "$groups",
+        "$process_person_profile",
+        "$session_id",
+        "$window_id",
+        "$lib",
+        "$lib_version",
+        "$device_id",
+    ]
+
     private func reportFeatureFlagCalled(flagKey: String, flagValue: Any?) {
         if remoteConfig == nil {
             return
@@ -2197,6 +2229,8 @@ let maxRetryDelay = 30.0
             let requestId = remoteConfig?.lastRequestId ?? ""
             let evaluatedAt = remoteConfig?.lastEvaluatedAt
             let details = remoteConfig?.getFeatureFlagDetails(flagKey)
+            // Unknown until the flags response explicitly reports it; any missing signal → full event.
+            var hasExperiment: Bool?
 
             var properties: [String: Any] = [
                 "$feature_flag": flagKey,
@@ -2216,8 +2250,9 @@ let maxRetryDelay = 30.0
                 if let metadata = details["metadata"] as? [String: Any] {
                     properties["$feature_flag_id"] = metadata["id"] ?? NSNull()
                     properties["$feature_flag_version"] = metadata["version"] ?? NSNull()
-                    if let hasExperiment = metadata["has_experiment"] as? Bool {
-                        properties["$feature_flag_has_experiment"] = hasExperiment
+                    if let flagHasExperiment = metadata["has_experiment"] as? Bool {
+                        properties["$feature_flag_has_experiment"] = flagHasExperiment
+                        hasExperiment = flagHasExperiment
                     }
                 }
             }
@@ -2232,7 +2267,15 @@ let maxRetryDelay = 30.0
                 properties["$used_bootstrap_value"] = bootstrapMetadata.usedBootstrapValue
             }
 
-            capture("$feature_flag_called", properties: properties)
+            // Emit the minimal shape only when the server gate is on and the flag verifiably has no
+            // experiment. Experiment-linked flags keep the full envelope for exposure analysis.
+            let sendMinimalEvent = remoteConfig?.sendMinimalFlagCalledEvents == true && hasExperiment == false
+
+            captureInternal(
+                "$feature_flag_called",
+                properties: properties,
+                propertyAllowlist: sendMinimalEvent ? PostHogSDK.minimalFeatureFlagCalledProperties : nil
+            )
         }
     }
 

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -2193,13 +2193,17 @@ let maxRetryDelay = 30.0
         "$feature_flag_reason",
         "$feature_flag_request_id",
         "$feature_flag_evaluated_at",
-        "$feature_flag_error",
         "$groups",
         "$process_person_profile",
         "$session_id",
-        "$window_id",
         "$lib",
         "$lib_version",
+        // Forward-looking cross-SDK contract entries: not produced by buildProperties for
+        // $feature_flag_called on iOS today ($device_id is added later by PostHogApi on the
+        // /flags request only; $window_id is snapshot-only; $feature_flag_error isn't emitted
+        // by this SDK yet). Kept so the allowlist matches the shared contract as those signals land.
+        "$feature_flag_error",
+        "$window_id",
         "$device_id",
     ]
 

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -2181,9 +2181,9 @@ let maxRetryDelay = 30.0
     }
 
     /// The strict property allowlist for minimal `$feature_flag_called` events. Everything else —
-    /// registered super properties, the device/OS context envelope, `$active_feature_flags`, the
-    /// `$feature/<key>` enumeration, bootstrap enrichment — is stripped. Kept in sync with the
-    /// cross-SDK minimal `$feature_flag_called` contract.
+    /// registered super properties, `$active_feature_flags`, the `$feature/<key>` enumeration,
+    /// bootstrap enrichment — is stripped. Kept in sync with the cross-SDK minimal
+    /// `$feature_flag_called` contract.
     private static let minimalFeatureFlagCalledProperties: Set<String> = [
         "$feature_flag",
         "$feature_flag_response",
@@ -2198,6 +2198,11 @@ let maxRetryDelay = 30.0
         "$session_id",
         "$lib",
         "$lib_version",
+        // Mobile's debug/breakdown analog to python's $os/$os_version/$python_runtime and browser
+        // JS's $current_url/$pathname: kept so OS- and app-version-segmented insights still work.
+        "$os_name",
+        "$os_version",
+        "$app_version",
         // Forward-looking cross-SDK contract entries: not produced by buildProperties for
         // $feature_flag_called on iOS today ($device_id is added later by PostHogApi on the
         // /flags request only; $window_id is snapshot-only; $feature_flag_error isn't emitted

--- a/PostHog/PostHogStorage.swift
+++ b/PostHog/PostHogStorage.swift
@@ -248,6 +248,7 @@ class PostHogStorage {
         case lastSeenSurveyDate = "posthog.lastSeenSurveyDate"
         case requestId = "posthog.requestId"
         case evaluatedAt = "posthog.evaluatedAt"
+        case minimalFlagCalledEvents = "posthog.minimalFlagCalledEvents"
         case personPropertiesForFlags = "posthog.personPropertiesForFlags"
         case groupPropertiesForFlags = "posthog.groupPropertiesForFlags"
         case errorTracking = "posthog.errorTracking"
@@ -414,6 +415,7 @@ class PostHogStorage {
         deleteSafely(url(forKey: .surveySeen))
         deleteSafely(url(forKey: .lastSeenSurveyDate))
         deleteSafely(url(forKey: .requestId))
+        deleteSafely(url(forKey: .minimalFlagCalledEvents))
         deleteSafely(url(forKey: .personPropertiesForFlags))
         deleteSafely(url(forKey: .groupPropertiesForFlags))
         // legacy slices, no longer written (config now lives in .remoteConfig); drop stragglers from older SDKs

--- a/PostHogTests/PostHogRemoteConfigTest.swift
+++ b/PostHogTests/PostHogRemoteConfigTest.swift
@@ -1078,4 +1078,81 @@ enum PostHogRemoteConfigTest {
             #expect(sut.getRemoteConfig()?["capturePerformance"] != nil)
         }
     }
+
+    @Suite("Test minimal flag called events gate")
+    class TestMinimalFlagCalledEventsGate: BaseTestClass {
+        private func makeIsolatedConfig() -> PostHogConfig {
+            let config = PostHogConfig(projectToken: "\(testProjectToken)-\(UUID().uuidString)", host: "http://localhost:9001")
+            config.disableRemoteConfigForTesting = true
+            return config
+        }
+
+        @Test("gate is off by default and stays off when the response omits the field")
+        func gateOffWhenFieldAbsent() async {
+            let config = makeIsolatedConfig()
+            let storage = PostHogStorage(config)
+            defer { storage.reset() }
+
+            let sut = getSut(storage: storage, config: config)
+
+            #expect(sut.sendMinimalFlagCalledEvents == false)
+
+            await loadFeatureFlags(sut)
+
+            #expect(sut.sendMinimalFlagCalledEvents == false)
+        }
+
+        @Test("gate persists alongside cached flags across a simulated restart")
+        func gatePersistsAcrossRestart() async {
+            server.minimalFlagCalledEvents = true
+            let config = makeIsolatedConfig()
+            let storage = PostHogStorage(config)
+            defer { storage.reset() }
+
+            let sut = getSut(storage: storage, config: config)
+            await loadFeatureFlags(sut)
+
+            #expect(sut.sendMinimalFlagCalledEvents == true)
+
+            // a fresh instance on the same storage re-reads the persisted gate
+            let restarted = getSut(storage: storage, config: config)
+
+            #expect(restarted.sendMinimalFlagCalledEvents == true)
+        }
+
+        @Test("gate turns off when a later response no longer carries it")
+        func gateClearsWhenFieldDisappears() async {
+            server.minimalFlagCalledEvents = true
+            let config = makeIsolatedConfig()
+            let storage = PostHogStorage(config)
+            defer { storage.reset() }
+
+            let sut = getSut(storage: storage, config: config)
+            await loadFeatureFlags(sut)
+
+            #expect(sut.sendMinimalFlagCalledEvents == true)
+
+            server.minimalFlagCalledEvents = false
+            await loadFeatureFlags(sut)
+
+            #expect(sut.sendMinimalFlagCalledEvents == false)
+        }
+
+        @Test("clear() drops the persisted gate")
+        func clearDropsGate() async {
+            server.minimalFlagCalledEvents = true
+            let config = makeIsolatedConfig()
+            let storage = PostHogStorage(config)
+            defer { storage.reset() }
+
+            let sut = getSut(storage: storage, config: config)
+            await loadFeatureFlags(sut)
+
+            #expect(sut.sendMinimalFlagCalledEvents == true)
+
+            sut.clear()
+
+            #expect(sut.sendMinimalFlagCalledEvents == false)
+        }
+    }
 }

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -515,6 +515,146 @@ class PostHogSDKTest: QuickSpec {
             sut.close()
         }
 
+        it("sends minimal feature flag event when gated and flag has no experiment") {
+            server.minimalFlagCalledEvents = true
+            let sut = self.getSut(preloadFeatureFlags: true, sendFeatureFlagEvent: true)
+
+            waitForFeatureFlagsLoaded(server, sut)
+            expect(sut.isFeatureEnabled("string-value")) == true
+
+            let events = getBatchedEvents(server)
+
+            expect(events.count) == 1
+
+            let event = events.first!
+            expect(event.event) == "$feature_flag_called"
+            // Strict allowlist: everything else (context envelope, super properties,
+            // $active_feature_flags, $feature/<key>, $is_identified) is stripped.
+            expect(Set(event.properties.keys)) == Set([
+                "$feature_flag",
+                "$feature_flag_response",
+                "$feature_flag_has_experiment",
+                "$feature_flag_id",
+                "$feature_flag_version",
+                "$feature_flag_reason",
+                "$feature_flag_request_id",
+                "$feature_flag_evaluated_at",
+                "$process_person_profile",
+                "$session_id",
+                "$lib",
+                "$lib_version",
+            ])
+            expect(event.properties["$feature_flag"] as? String) == "string-value"
+            expect(event.properties["$feature_flag_response"] as? String) == "test"
+            expect(event.properties["$feature_flag_has_experiment"] as? Bool) == false
+
+            sut.reset()
+            sut.close()
+        }
+
+        it("keeps $groups on minimal feature flag events") {
+            server.minimalFlagCalledEvents = true
+            // flushAt 2 so the $groupidentify and $feature_flag_called events share one batch
+            let sut = self.getSut(preloadFeatureFlags: true, sendFeatureFlagEvent: true, flushAt: 2)
+
+            waitForFeatureFlagsLoaded(server, sut)
+
+            sut.group(type: "some-type", key: "some-key")
+
+            expect(sut.isFeatureEnabled("string-value")) == true
+
+            let events = getBatchedEvents(server)
+
+            expect(events.count) == 2
+
+            let event = events.last!
+            expect(event.event) == "$feature_flag_called"
+            // $groups is correctness-required (ingestion dedup key + personful routing for group
+            // flags), so it must survive minimization when groups are registered.
+            expect(Set(event.properties.keys)) == Set([
+                "$feature_flag",
+                "$feature_flag_response",
+                "$feature_flag_has_experiment",
+                "$feature_flag_id",
+                "$feature_flag_version",
+                "$feature_flag_reason",
+                "$feature_flag_request_id",
+                "$feature_flag_evaluated_at",
+                "$groups",
+                "$process_person_profile",
+                "$session_id",
+                "$lib",
+                "$lib_version",
+            ])
+            let groups = event.properties["$groups"] as? [String: String]
+            expect(groups?["some-type"]) == "some-key"
+
+            sut.reset()
+            sut.close()
+        }
+
+        it("sends full feature flag event when gated but flag has an experiment") {
+            server.minimalFlagCalledEvents = true
+            let sut = self.getSut(preloadFeatureFlags: true, sendFeatureFlagEvent: true)
+
+            waitForFeatureFlagsLoaded(server, sut)
+            expect(sut.isFeatureEnabled("bool-value")) == true
+
+            let events = getBatchedEvents(server)
+
+            expect(events.count) == 1
+
+            let event = events.first!
+            expect(event.event) == "$feature_flag_called"
+            expect(event.properties["$feature_flag_has_experiment"] as? Bool) == true
+            expect(event.properties["$feature/bool-value"] as? Bool) == true
+            expect(event.properties["$active_feature_flags"]).toNot(beNil())
+            expect(event.properties["$is_identified"]).toNot(beNil())
+
+            sut.reset()
+            sut.close()
+        }
+
+        it("sends full feature flag event when gated but has_experiment is unknown") {
+            server.minimalFlagCalledEvents = true
+            let sut = self.getSut(preloadFeatureFlags: true, sendFeatureFlagEvent: true)
+
+            waitForFeatureFlagsLoaded(server, sut)
+            expect(sut.isFeatureEnabled("number-value")) == true
+
+            let events = getBatchedEvents(server)
+
+            expect(events.count) == 1
+
+            let event = events.first!
+            expect(event.event) == "$feature_flag_called"
+            expect(event.properties["$feature_flag_has_experiment"]).to(beNil())
+            expect(event.properties["$active_feature_flags"]).toNot(beNil())
+
+            sut.reset()
+            sut.close()
+        }
+
+        it("sends full feature flag event when the server does not gate minimal events") {
+            let sut = self.getSut(preloadFeatureFlags: true, sendFeatureFlagEvent: true)
+
+            waitForFeatureFlagsLoaded(server, sut)
+            expect(sut.isFeatureEnabled("string-value")) == true
+
+            let events = getBatchedEvents(server)
+
+            expect(events.count) == 1
+
+            let event = events.first!
+            expect(event.event) == "$feature_flag_called"
+            expect(event.properties["$feature_flag_has_experiment"] as? Bool) == false
+            expect(event.properties["$feature/string-value"] as? String) == "test"
+            expect(event.properties["$active_feature_flags"]).toNot(beNil())
+
+            sut.reset()
+            sut.close()
+        }
+
         it("send feature flag event for getFeatureFlag when enabled") {
             let sut = self.getSut(preloadFeatureFlags: true, sendFeatureFlagEvent: true)
 

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -528,8 +528,9 @@ class PostHogSDKTest: QuickSpec {
 
             let event = events.first!
             expect(event.event) == "$feature_flag_called"
-            // Strict allowlist: everything else (context envelope, super properties,
-            // $active_feature_flags, $feature/<key>, $is_identified) is stripped.
+            // Strict allowlist: everything else (super properties, $active_feature_flags,
+            // $feature/<key>, $is_identified) is stripped; $os_name/$os_version/$app_version
+            // survive as mobile's OS- and app-version-breakdown analog.
             expect(Set(event.properties.keys)) == Set([
                 "$feature_flag",
                 "$feature_flag_response",
@@ -543,6 +544,9 @@ class PostHogSDKTest: QuickSpec {
                 "$session_id",
                 "$lib",
                 "$lib_version",
+                "$os_name",
+                "$os_version",
+                "$app_version",
             ])
             expect(event.properties["$feature_flag"] as? String) == "string-value"
             expect(event.properties["$feature_flag_response"] as? String) == "test"
@@ -585,6 +589,9 @@ class PostHogSDKTest: QuickSpec {
                 "$session_id",
                 "$lib",
                 "$lib_version",
+                "$os_name",
+                "$os_version",
+                "$app_version",
             ])
             let groups = event.properties["$groups"] as? [String: String]
             expect(groups?["some-type"]) == "some-key"

--- a/PostHogTests/TestUtils/MockPostHogServer.swift
+++ b/PostHogTests/TestUtils/MockPostHogServer.swift
@@ -84,6 +84,7 @@ class MockPostHogServer {
     var flagsSkipReplayVariantName = false
     var replayVariantValue: Any = true
     var quotaLimitFeatureFlags: Bool = false
+    var minimalFlagCalledEvents: Bool = false
     var remoteConfigSurveys: String?
     var hasFeatureFlags: Bool? = true
     var featureFlags: [String: Any]?
@@ -294,6 +295,10 @@ class MockPostHogServer {
                     "requestId": "0f801b5b-0776-42ca-b0f7-8375c95730bf",
                     "evaluatedAt": 1234567890,
                 ]
+            }
+
+            if self.minimalFlagCalledEvents {
+                obj["minimalFlagCalledEvents"] = true
             }
 
             if self.returnReplay {


### PR DESCRIPTION
## :bulb: Motivation and Context

`$feature_flag_called` events carry the full enriched properties (context envelope, super properties, `$active_feature_flags`, the `$feature/<key>` enumeration) on every flag call, even for flags not linked to an experiment. This PR trims those events to a strict allowlist **iff** the server-controlled gate is on (top-level `minimalFlagCalledEvents` in the v2 `/flags` response) **and** the flag's `has_experiment` is exactly `false`. Any missing signal (legacy response, cached/bootstrap state without the field, `has_experiment` unknown) sends the full legacy shape unchanged. Server-gated because rolling this out unconditionally could break existing insights; announcement/comms come before enablement.

iOS specifics:

- The gate is persisted alongside the cached flags in storage (`posthog.minimalFlagCalledEvents`), so it survives app restarts; it is removed when a response omits the field and cleared on `reset()`.
- The allowlist is applied after `buildProperties()` builds the full property set, so the strip is structural — new context properties added later are stripped automatically. `beforeSend` hooks and the legacy `propertiesSanitizer` run after the filter and may re-add keys (accepted escape hatch, codified in the contract).
- Experiment-linked flags always send the full envelope — experiment exposure analysis reads it.
- `sendMinimalFlagCalledEvents`, `lastRequestId`, and `lastEvaluatedAt` all memoize their value in memory after the first disk read, so a flag check only touches storage once per process instead of on every call.

Part of a cross-SDK rollout; reference implementation and fuller context: PostHog/posthog-python#748

## :green_heart: How did you test it?

New test suites were authored but could **not** be executed in the authoring environment (no Xcode available — only `swift build -Xswiftc -DTESTING` type-checking and `swiftformat --lint` were run), so **CI is the validation gate for this PR**:

- `PostHogSDKTest` (Quick/Nimble): gated + no experiment → event's key set equals the exact expected minimal set; gated + registered group → `$groups` survives minimization and carries the group; gated + experiment → full event; gated + unknown `has_experiment` → full event; ungated → full event.
- `PostHogRemoteConfigTest` (swift-testing): gate defaults to false when absent; persists across a simulated restart (fresh instance re-reads it from storage); clears when a later response omits the field; `clear()` drops it.

Behavioral note: the v4 flag details (including `metadata.has_experiment`) persist with the cached flags, so minimization resumes from cache after a cold start once a gated response has been seen. Caches written before this change (or responses without flag details) lack `has_experiment`, so events stay full until the first fresh `/flags` response — fail-safe.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*