### PR TITLE
fix: eliminate per-layout SwiftUI masking cost (iOS 26 launch/scroll hangs from per-row postHogMask)

### DIFF
--- a/.changeset/swiftui-masking-performance.md
+++ b/.changeset/swiftui-masking-performance.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Fix `postHogMask()` causing severe launch and scroll hangs on iOS 26 in lazy SwiftUI containers (`ScrollView` + `LazyVStack`). The modifier now reports its region through a single passive overlay view whose frame is read live at snapshot time, replacing the per-mask tag-view traversal and KVO ancestor observers that degenerated to O(N²) work on the shared hosting view. Behavior notes: a masked view is now redacted across its full extent (previously only its resolved backing subviews), and screenshot snapshots are skipped while a masked view awaits its first layout, so a frame can never be captured under-masked. Also fixes overlapping masks unmasking each other's targets on teardown, flag claims outliving their owner view, and bounds the iOS 26 layer scan to the masked view's own extent.

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -233,6 +233,7 @@
 		DA0E43BE2D70438100D39B93 /* PostHogSurveyIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0E43B82D70437D00D39B93 /* PostHogSurveyIntegration.swift */; };
 		DA0F989B2D94081A009AB6F5 /* ApplicationViewLayoutPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0F989A2D94081A009AB6F5 /* ApplicationViewLayoutPublisher.swift */; };
 		DA0F98A22D940E8C009AB6F5 /* ApplicationViewLayoutPublisherTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0F98A12D940E7D009AB6F5 /* ApplicationViewLayoutPublisherTest.swift */; };
+		AAC0FFEE2E20000100000002 /* PostHogMaskingCharacterizationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC0FFEE2E20000100000001 /* PostHogMaskingCharacterizationTest.swift */; };
 		DA0SAMP22E2302260001FF01 /* PostHogSampling.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0SAMP12E2302260001FF01 /* PostHogSampling.swift */; };
 		DA1044882D0B1D2D00C4ACF3 /* View+PostHogLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1044852D0B1D2D00C4ACF3 /* View+PostHogLabel.swift */; };
 		DA1044892D0B1D2D00C4ACF3 /* UIView+PostHogLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1044872D0B1D2D00C4ACF3 /* UIView+PostHogLabel.swift */; };
@@ -995,6 +996,7 @@
 		DA0E43B82D70437D00D39B93 /* PostHogSurveyIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSurveyIntegration.swift; sourceTree = "<group>"; };
 		DA0F989A2D94081A009AB6F5 /* ApplicationViewLayoutPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationViewLayoutPublisher.swift; sourceTree = "<group>"; };
 		DA0F98A12D940E7D009AB6F5 /* ApplicationViewLayoutPublisherTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationViewLayoutPublisherTest.swift; sourceTree = "<group>"; };
+		AAC0FFEE2E20000100000001 /* PostHogMaskingCharacterizationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogMaskingCharacterizationTest.swift; sourceTree = "<group>"; };
 		DA0SAMP12E2302260001FF01 /* PostHogSampling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSampling.swift; sourceTree = "<group>"; };
 		DA1044852D0B1D2D00C4ACF3 /* View+PostHogLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+PostHogLabel.swift"; sourceTree = "<group>"; };
 		DA1044872D0B1D2D00C4ACF3 /* UIView+PostHogLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+PostHogLabel.swift"; sourceTree = "<group>"; };
@@ -1649,6 +1651,7 @@
 				1F55581F2DFC47E8007643C0 /* PostHogStorageMergeTest.swift */,
 				DA4FFBB42DAD5AF9006BAEEA /* PostHogIdentityTests.swift */,
 				DA0F98A12D940E7D009AB6F5 /* ApplicationViewLayoutPublisherTest.swift */,
+				AAC0FFEE2E20000100000001 /* PostHogMaskingCharacterizationTest.swift */,
 				DAD39DF52D561787002A1A69 /* UtilsTest.swift */,
 				9E781EB127B3DC1290199836 /* BundleUtilsTest.swift */,
 				DAF95F5B2D077BCC001E82BB /* Resources */,
@@ -3412,6 +3415,7 @@
 				DAF79A2A2D1309C00078A3C9 /* TestError.swift in Sources */,
 				DA703C0A2D6606EA0069097B /* PostHogIntegrationInstallationTest.swift in Sources */,
 				DA0F98A22D940E8C009AB6F5 /* ApplicationViewLayoutPublisherTest.swift in Sources */,
+				AAC0FFEE2E20000100000002 /* PostHogMaskingCharacterizationTest.swift in Sources */,
 				3A62647129CAF67B007E8C07 /* PostHogStorageManagerTest.swift in Sources */,
 				DA5E52EB2E0996C400159D20 /* PostHogSurveyEnumsTest.swift in Sources */,
 				693E977D2C6257F9004B1030 /* ExampleSanitizer.swift in Sources */,

--- a/PostHog/Autocapture/SwiftUI/View+PostHogNoRageClick.swift
+++ b/PostHog/Autocapture/SwiftUI/View+PostHogNoRageClick.swift
@@ -35,14 +35,14 @@
         func postHogNoRageClick(_ isEnabled: Bool = true) -> some View {
             modifier(
                 PostHogTagViewModifier(
-                    onChange: { views, layers in
+                    onChange: { owner, views, layers in
                         // On iOS 26, SwiftUI primitives may be layer-backed, so tag both.
-                        views.forEach { $0.postHogNoRageClick = isEnabled }
-                        layers.forEach { $0.postHogNoRageClick = isEnabled }
+                        views.forEach { $0.setPostHogNoRageClick(isEnabled, owner: owner) }
+                        layers.forEach { $0.setPostHogNoRageClick(isEnabled, owner: owner) }
                     },
-                    onRemove: { views, layers in
-                        views.forEach { $0.postHogNoRageClick = false }
-                        layers.forEach { $0.postHogNoRageClick = false }
+                    onRemove: { owner, views, layers in
+                        views.forEach { $0.setPostHogNoRageClick(false, owner: owner) }
+                        layers.forEach { $0.setPostHogNoRageClick(false, owner: owner) }
                     }
                 )
             )

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -2948,7 +2948,8 @@ let maxRetryDelay = 30.0
 #endif
 
 #if os(iOS) && DEBUG
-    /// Debug-only session-replay introspection for verification harnesses.
+    /// Debug-only session-replay introspection for verification harnesses. SPI, not
+    /// part of the supported public API (mirrors `captureSessionReplaySnapshot`).
     public extension PostHogSDK {
         /// Debug-only: the redaction rects session replay would apply to `window` right
         /// now, computed through the production masking path (`findMaskableWidgets`,
@@ -2957,7 +2958,7 @@ let maxRetryDelay = 30.0
         /// Intended for verification harnesses that compare masking output across SDK
         /// changes. Works even when replay isn't recording (invalid token or replay
         /// flag off): a transient integration is used to read the local config.
-        func debugSessionReplayMaskableRects(in window: UIWindow) -> [CGRect] {
+        @_spi(PostHogInternal) func debugSessionReplayMaskableRects(in window: UIWindow) -> [CGRect] {
             guard isEnabled() else { return [] }
             let integration = replayIntegration ?? PostHogReplayIntegration.debugTransient(for: self)
             return integration.debugMaskableRects(in: window)
@@ -2966,7 +2967,7 @@ let maxRetryDelay = 30.0
         /// Objective-C-visible bridge for `debugSessionReplayMaskableRects(in:)`, so
         /// verification harnesses can discover the hook at runtime (`responds(to:)`)
         /// and keep compiling against SDK revisions that don't have it.
-        @objc(debugSessionReplayMaskableRectsIn:)
+        @_spi(PostHogInternal) @objc(debugSessionReplayMaskableRectsIn:)
         func debugSessionReplayMaskableRectValues(in window: UIWindow) -> [NSValue] {
             debugSessionReplayMaskableRects(in: window).map { NSValue(cgRect: $0) }
         }

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -2947,32 +2947,4 @@ let maxRetryDelay = 30.0
     }
 #endif
 
-#if os(iOS) && DEBUG
-    /// Debug-only session-replay introspection for verification harnesses. SPI, not
-    /// part of the supported public API (mirrors `captureSessionReplaySnapshot`).
-    public extension PostHogSDK {
-        /// Debug-only: the redaction rects session replay would apply to `window` right
-        /// now, computed through the production masking path (`findMaskableWidgets`,
-        /// including the iOS 26 layer scan). Main thread only.
-        ///
-        /// For verification harnesses; works even when replay isn't recording.
-        /// Returns nil when no frame would be captured (a masked view isn't laid out
-        /// yet, or the SDK isn't set up) — distinct from an empty list (frame captured
-        /// with nothing masked). Main queue only; enforced also in Release builds.
-        @_spi(PostHogInternal) func debugSessionReplayMaskableRects(in window: UIWindow) -> [CGRect]? {
-            guard isEnabled() else { return nil }
-            let integration = replayIntegration ?? PostHogReplayIntegration.debugTransient(for: self)
-            return integration.debugMaskableRects(in: window)
-        }
-
-        /// Objective-C-visible bridge for `debugSessionReplayMaskableRects(in:)`, so
-        /// verification harnesses can discover the hook at runtime (`responds(to:)`)
-        /// and keep compiling against SDK revisions that don't have it.
-        @_spi(PostHogInternal) @objc(debugSessionReplayMaskableRectsIn:)
-        func debugSessionReplayMaskableRectValues(in window: UIWindow) -> [NSValue]? {
-            debugSessionReplayMaskableRects(in: window)?.map { NSValue(cgRect: $0) }
-        }
-    }
-#endif
-
 // swiftlint:enable file_length cyclomatic_complexity

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -2947,4 +2947,30 @@ let maxRetryDelay = 30.0
     }
 #endif
 
+#if os(iOS) && DEBUG
+    /// Debug-only session-replay introspection for verification harnesses.
+    public extension PostHogSDK {
+        /// Debug-only: the redaction rects session replay would apply to `window` right
+        /// now, computed through the production masking path (`findMaskableWidgets`,
+        /// including the iOS 26 layer scan). Main thread only.
+        ///
+        /// Intended for verification harnesses that compare masking output across SDK
+        /// changes. Works even when replay isn't recording (invalid token or replay
+        /// flag off): a transient integration is used to read the local config.
+        func debugSessionReplayMaskableRects(in window: UIWindow) -> [CGRect] {
+            guard isEnabled() else { return [] }
+            let integration = replayIntegration ?? PostHogReplayIntegration.debugTransient(for: self)
+            return integration.debugMaskableRects(in: window)
+        }
+
+        /// Objective-C-visible bridge for `debugSessionReplayMaskableRects(in:)`, so
+        /// verification harnesses can discover the hook at runtime (`responds(to:)`)
+        /// and keep compiling against SDK revisions that don't have it.
+        @objc(debugSessionReplayMaskableRectsIn:)
+        func debugSessionReplayMaskableRectValues(in window: UIWindow) -> [NSValue] {
+            debugSessionReplayMaskableRects(in: window).map { NSValue(cgRect: $0) }
+        }
+    }
+#endif
+
 // swiftlint:enable file_length cyclomatic_complexity

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -2955,11 +2955,12 @@ let maxRetryDelay = 30.0
         /// now, computed through the production masking path (`findMaskableWidgets`,
         /// including the iOS 26 layer scan). Main thread only.
         ///
-        /// Intended for verification harnesses that compare masking output across SDK
-        /// changes. Works even when replay isn't recording (invalid token or replay
-        /// flag off): a transient integration is used to read the local config.
-        @_spi(PostHogInternal) func debugSessionReplayMaskableRects(in window: UIWindow) -> [CGRect] {
-            guard isEnabled() else { return [] }
+        /// For verification harnesses; works even when replay isn't recording.
+        /// Returns nil when no frame would be captured (a masked view isn't laid out
+        /// yet, or the SDK isn't set up) — distinct from an empty list (frame captured
+        /// with nothing masked). Main queue only; enforced also in Release builds.
+        @_spi(PostHogInternal) func debugSessionReplayMaskableRects(in window: UIWindow) -> [CGRect]? {
+            guard isEnabled() else { return nil }
             let integration = replayIntegration ?? PostHogReplayIntegration.debugTransient(for: self)
             return integration.debugMaskableRects(in: window)
         }
@@ -2968,8 +2969,8 @@ let maxRetryDelay = 30.0
         /// verification harnesses can discover the hook at runtime (`responds(to:)`)
         /// and keep compiling against SDK revisions that don't have it.
         @_spi(PostHogInternal) @objc(debugSessionReplayMaskableRectsIn:)
-        func debugSessionReplayMaskableRectValues(in window: UIWindow) -> [NSValue] {
-            debugSessionReplayMaskableRects(in: window).map { NSValue(cgRect: $0) }
+        func debugSessionReplayMaskableRectValues(in window: UIWindow) -> [NSValue]? {
+            debugSessionReplayMaskableRects(in: window)?.map { NSValue(cgRect: $0) }
         }
     }
 #endif

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -961,12 +961,6 @@
                 }
             }
 
-            // manually masked views through `.postHogMask()` view modifier
-            if view.postHogNoCapture {
-                maskableWidgets.append(view.toAbsoluteRect(window))
-                return
-            }
-
             // on RN, lots get converted to RCTRootContentView, RCTRootView, RCTView and sometimes its just the whole screen, we dont want to mask
             // in such cases
             if view.isNoCapture() || maskChildren {
@@ -996,19 +990,14 @@
         /// Recursively iterate through layer hierarchy to find maskable layers (iOS 26+)
         ///
         /// On iOS 26, SwiftUI primitives (Text, Image, Button) are rendered as CALayer sublayers
-        /// of parent views rather than having their own backing UIView. When `.postHogMask()` is applied,
-        /// the flag is set directly on the CALayers via the PostHogTagViewModifier.
+        /// of parent views rather than having their own backing UIView, so the text/image
+        /// heuristics below inspect layers as well. (`.postHogMask()` regions are collected
+        /// separately via the mask-reporter registry.)
         @available(iOS 26.0, *)
         private func findMaskableLayers(_ layer: CALayer, _ view: UIView, _ window: UIWindow, _ maskableWidgets: inout [CGRect]) {
             for sublayer in layer.sublayers ?? [] {
                 // Skip layers tagged with .postHogNoMask()
                 if sublayer.postHogNoMask {
-                    continue
-                }
-
-                // Check if layer is manually tagged with .postHogMask()
-                if sublayer.postHogNoCapture {
-                    maskableWidgets.append(sublayer.toAbsoluteRect(window))
                     continue
                 }
 

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -1046,15 +1046,23 @@
                 return nil
             }
 
-            var maskableWidgets: [CGRect] = []
-            var maskChildren = false
-
-            findMaskableWidgets(window, window, &maskableWidgets, &maskChildren)
-
             let wireframe = createBasicWireframe(window)
-            wireframe.maskableWidgets = maskableWidgets
+            wireframe.maskableWidgets = collectMaskableRects(in: window)
             wireframe.type = "screenshot"
             return wireframe
+        }
+
+        /// All rects to redact in `window`: heuristic + flag-tagged widgets from the
+        /// hierarchy walk, plus the live rects of `postHogMask()` reporter views
+        /// (computed at capture time from the registry — never cached, so a masked
+        /// view that moved since the last layout callback is still redacted at its
+        /// current position).
+        func collectMaskableRects(in window: UIWindow) -> [CGRect] {
+            var maskableWidgets: [CGRect] = []
+            var maskChildren = false
+            findMaskableWidgets(window, window, &maskableWidgets, &maskChildren)
+            maskableWidgets.append(contentsOf: PostHogSessionReplayMaskRegistry.shared.maskedRects(in: window))
+            return maskableWidgets
         }
 
         // To be called from main thread
@@ -1615,16 +1623,13 @@
 
         extension PostHogReplayIntegration {
             /// Debug-only: computes the redaction rects that `snapshot()` would produce
-            /// for `window` right now, via the exact production `findMaskableWidgets`
-            /// path (including the iOS 26 layer scan). Main thread only.
+            /// for `window` right now, via the exact production collection path (the
+            /// `findMaskableWidgets` walk plus the mask-reporter registry). Main thread only.
             ///
             /// Used by verification harnesses to compare masking output before/after
             /// SDK changes — see the masking characterization tests.
             func debugMaskableRects(in window: UIWindow) -> [CGRect] {
-                var rects: [CGRect] = []
-                var maskChildren = false
-                findMaskableWidgets(window, window, &rects, &maskChildren)
-                return rects
+                collectMaskableRects(in: window)
             }
 
             /// Debug-only: a transient integration bound to `postHog` so that

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -1610,6 +1610,34 @@
         }
     #endif
 
+    #if DEBUG
+        // MARK: - Debug verification hooks
+
+        extension PostHogReplayIntegration {
+            /// Debug-only: computes the redaction rects that `snapshot()` would produce
+            /// for `window` right now, via the exact production `findMaskableWidgets`
+            /// path (including the iOS 26 layer scan). Main thread only.
+            ///
+            /// Used by verification harnesses to compare masking output before/after
+            /// SDK changes — see the masking characterization tests.
+            func debugMaskableRects(in window: UIWindow) -> [CGRect] {
+                var rects: [CGRect] = []
+                var maskChildren = false
+                findMaskableWidgets(window, window, &rects, &maskChildren)
+                return rects
+            }
+
+            /// Debug-only: a transient integration bound to `postHog` so that
+            /// `debugMaskableRects(in:)` can read the session-replay config even when
+            /// replay isn't installed/recording (e.g. placeholder token, flag off).
+            static func debugTransient(for postHog: PostHogSDK) -> PostHogReplayIntegration {
+                let integration = PostHogReplayIntegration()
+                integration.postHog = postHog
+                return integration
+            }
+        }
+    #endif
+
 #endif
 
 // swiftlint:enable cyclomatic_complexity file_length

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -1619,6 +1619,7 @@
     #endif
 
     #if DEBUG
+
         // MARK: - Debug verification hooks
 
         extension PostHogReplayIntegration {

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -1623,30 +1623,6 @@
         }
     #endif
 
-    #if DEBUG
-
-        // MARK: - Debug verification hooks
-
-        extension PostHogReplayIntegration {
-            /// Debug-only: the redaction rects `snapshot()` would produce for `window`
-            /// right now, via the production collection path. Main thread only.
-            /// nil = production would skip this frame; [] = captured with nothing
-            /// redacted — harnesses must not conflate the two.
-            func debugMaskableRects(in window: UIWindow) -> [CGRect]? {
-                collectMaskableRects(in: window)
-            }
-
-            /// Debug-only: a transient integration bound to `postHog` so that
-            /// `debugMaskableRects(in:)` can read the session-replay config even when
-            /// replay isn't installed/recording (e.g. placeholder token, flag off).
-            static func debugTransient(for postHog: PostHogSDK) -> PostHogReplayIntegration {
-                let integration = PostHogReplayIntegration()
-                integration.postHog = postHog
-                return integration
-            }
-        }
-    #endif
-
 #endif
 
 // swiftlint:enable cyclomatic_complexity file_length

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -1035,22 +1035,38 @@
                 return nil
             }
 
+            // nil = a mask reporter has no geometry yet; capturing now could show that
+            // content unmasked. Skip the tick (fail closed), like the transition bail.
+            guard let maskableWidgets = collectMaskableRects(in: window) else {
+                hedgeLog("[Session Replay] Skipping snapshot: a masked view hasn't been laid out yet")
+                return nil
+            }
+
             let wireframe = createBasicWireframe(window)
-            wireframe.maskableWidgets = collectMaskableRects(in: window)
+            wireframe.maskableWidgets = maskableWidgets
             wireframe.type = "screenshot"
             return wireframe
         }
 
-        /// All rects to redact in `window`: heuristic + flag-tagged widgets from the
-        /// hierarchy walk, plus the live rects of `postHogMask()` reporter views
-        /// (computed at capture time from the registry — never cached, so a masked
-        /// view that moved since the last layout callback is still redacted at its
-        /// current position).
-        func collectMaskableRects(in window: UIWindow) -> [CGRect] {
+        /// All rects to redact in `window`: heuristic widgets from the hierarchy walk
+        /// plus the live rects of `postHogMask()` reporters. Returns nil when a
+        /// reporter hasn't been laid out yet — the caller must skip the frame rather
+        /// than capture it under-masked.
+        ///
+        /// Pre-existing limitation with `screenshotModeBackgroundCapture` (off by
+        /// default): pixels render after this collection, so any rect source can go
+        /// stale for content committed in between.
+        func collectMaskableRects(in window: UIWindow) -> [CGRect]? {
+            // The cheap registry read can veto the frame; keep it before the walk.
+            let masked = PostHogSessionReplayMaskRegistry.shared.maskedRects(in: window)
+            guard !masked.hasUnsettledReporters else {
+                return nil
+            }
+
             var maskableWidgets: [CGRect] = []
             var maskChildren = false
             findMaskableWidgets(window, window, &maskableWidgets, &maskChildren)
-            maskableWidgets.append(contentsOf: PostHogSessionReplayMaskRegistry.shared.maskedRects(in: window))
+            maskableWidgets.append(contentsOf: masked.rects)
             return maskableWidgets
         }
 
@@ -1612,13 +1628,11 @@
         // MARK: - Debug verification hooks
 
         extension PostHogReplayIntegration {
-            /// Debug-only: computes the redaction rects that `snapshot()` would produce
-            /// for `window` right now, via the exact production collection path (the
-            /// `findMaskableWidgets` walk plus the mask-reporter registry). Main thread only.
-            ///
-            /// Used by verification harnesses to compare masking output before/after
-            /// SDK changes — see the masking characterization tests.
-            func debugMaskableRects(in window: UIWindow) -> [CGRect] {
+            /// Debug-only: the redaction rects `snapshot()` would produce for `window`
+            /// right now, via the production collection path. Main thread only.
+            /// nil = production would skip this frame; [] = captured with nothing
+            /// redacted — harnesses must not conflate the two.
+            func debugMaskableRects(in window: UIWindow) -> [CGRect]? {
                 collectMaskableRects(in: window)
             }
 

--- a/PostHog/Replay/UIView+Util.swift
+++ b/PostHog/Replay/UIView+Util.swift
@@ -39,10 +39,15 @@
             return false
         }
 
-        /// Backing flag for the SwiftUI `.postHogNoRageClick()` modifier.
+        /// Backing flag for the SwiftUI `.postHogNoRageClick()` modifier. Owner-set
+        /// backed (see `PostHogFlagOwners`) so overlapping regions don't clear each
+        /// other on teardown.
         var postHogNoRageClick: Bool {
-            get { objc_getAssociatedObject(self, &AssociatedKeys.phNoRageClick) as? Bool ?? false }
-            set { objc_setAssociatedObject(self, &AssociatedKeys.phNoRageClick, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+            isPostHogFlagOwned(&AssociatedKeys.phNoRageClick)
+        }
+
+        func setPostHogNoRageClick(_ enabled: Bool, owner: ObjectIdentifier) {
+            setPostHogFlag(&AssociatedKeys.phNoRageClick, enabled: enabled, owner: owner)
         }
 
         func toImage(afterScreenUpdates: Bool = false) -> UIImage? {
@@ -79,10 +84,14 @@
             convert(bounds, to: window?.layer)
         }
 
-        /// Backing flag for the SwiftUI `.postHogNoRageClick()` modifier on layer-backed views.
+        /// Backing flag for the SwiftUI `.postHogNoRageClick()` modifier on layer-backed
+        /// views. Owner-set backed, same as the UIView flag.
         var postHogNoRageClick: Bool {
-            get { objc_getAssociatedObject(self, &AssociatedKeys.phNoRageClick) as? Bool ?? false }
-            set { objc_setAssociatedObject(self, &AssociatedKeys.phNoRageClick, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+            isPostHogFlagOwned(&AssociatedKeys.phNoRageClick)
+        }
+
+        func setPostHogNoRageClick(_ enabled: Bool, owner: ObjectIdentifier) {
+            setPostHogFlag(&AssociatedKeys.phNoRageClick, enabled: enabled, owner: owner)
         }
     }
 #endif

--- a/PostHog/Replay/UIView+Util.swift
+++ b/PostHog/Replay/UIView+Util.swift
@@ -46,7 +46,7 @@
             isPostHogFlagOwned(&AssociatedKeys.phNoRageClick)
         }
 
-        func setPostHogNoRageClick(_ enabled: Bool, owner: ObjectIdentifier) {
+        func setPostHogNoRageClick(_ enabled: Bool, owner: UIView) {
             setPostHogFlag(&AssociatedKeys.phNoRageClick, enabled: enabled, owner: owner)
         }
 
@@ -90,7 +90,7 @@
             isPostHogFlagOwned(&AssociatedKeys.phNoRageClick)
         }
 
-        func setPostHogNoRageClick(_ enabled: Bool, owner: ObjectIdentifier) {
+        func setPostHogNoRageClick(_ enabled: Bool, owner: UIView) {
             setPostHogFlag(&AssociatedKeys.phNoRageClick, enabled: enabled, owner: owner)
         }
     }

--- a/PostHog/SwiftUI/PostHogMaskViewModifier.swift
+++ b/PostHog/SwiftUI/PostHogMaskViewModifier.swift
@@ -182,26 +182,4 @@
             }
         }
     }
-
-    extension UIView {
-        /// Whether at least one mask currently claims this view.
-        var postHogNoCapture: Bool {
-            isPostHogFlagOwned(&AssociatedKeys.phNoCapture)
-        }
-
-        func setPostHogNoCapture(_ enabled: Bool, owner: ObjectIdentifier) {
-            setPostHogFlag(&AssociatedKeys.phNoCapture, enabled: enabled, owner: owner)
-        }
-    }
-
-    extension CALayer {
-        /// Whether at least one mask currently claims this layer.
-        var postHogNoCapture: Bool {
-            isPostHogFlagOwned(&AssociatedKeys.phNoCapture)
-        }
-
-        func setPostHogNoCapture(_ enabled: Bool, owner: ObjectIdentifier) {
-            setPostHogFlag(&AssociatedKeys.phNoCapture, enabled: enabled, owner: owner)
-        }
-    }
 #endif

--- a/PostHog/SwiftUI/PostHogMaskViewModifier.swift
+++ b/PostHog/SwiftUI/PostHogMaskViewModifier.swift
@@ -14,16 +14,16 @@
         /**
          Marks a SwiftUI View to be masked in PostHog session replay recordings.
 
-         Note: On iOS 26+ (Xcode 26 SwiftUI rendering engine), SwiftUI views may no longer map
-         reliably to a backing `UIView`, so this modifier may behave inconsistently. A future SDK
-         update will try to address this limitation, but for now, we recommend using this modifier
-         with caution.
-
-         Because of the nature of how we intercept SwiftUI view hierarchy (and how it maps to UIKit),
-         we can't always be 100% confident that a view should be masked and may accidentally mark a
-         sensitive view as non-sensitive instead.
-
          Use this modifier to explicitly mask sensitive views in session replay recordings.
+
+         The masked region is reported through a single passive overlay view whose frame is
+         read live at capture time, so the redaction can never go stale — a row that scrolled,
+         animated, or was repositioned is redacted at its current position. This does not rely
+         on mapping SwiftUI content to backing UIKit views, so it behaves identically across
+         OS rendering engines (including iOS 26+).
+
+         Note: an explicit `postHogMask()` always masks its region, even inside an area marked
+         with `postHogNoMask()` — the explicit mask wins.
 
          For example:
          ```swift
@@ -40,18 +40,116 @@
          - Returns: A modified view that will be masked in session replay recordings when enabled
          */
         func postHogMask(_ isEnabled: Bool = true) -> some View {
-            modifier(
-                PostHogTagViewModifier(
-                    onChange: { owner, views, layers in
-                        views.forEach { $0.setPostHogNoCapture(isEnabled, owner: owner) }
-                        layers.forEach { $0.setPostHogNoCapture(isEnabled, owner: owner) }
-                    },
-                    onRemove: { owner, views, layers in
-                        views.forEach { $0.setPostHogNoCapture(false, owner: owner) }
-                        layers.forEach { $0.setPostHogNoCapture(false, owner: owner) }
-                    }
-                )
+            overlay(
+                PostHogMaskReporterView(isEnabled: isEnabled)
+                    .allowsHitTesting(false)
+                    .accessibility(hidden: true)
             )
+        }
+    }
+
+    /// Registry of live "mask reporter" views. The capture side computes each reporter's
+    /// rect at snapshot time via the same live geometry read used for flagged views —
+    /// nothing is cached, so rects can never go stale. Storage is weak, which makes any
+    /// missed teardown self-healing.
+    ///
+    /// Registration happens from view lifecycle callbacks (main thread) and reads happen
+    /// from the snapshot path; the lock keeps the registry itself thread-safe, while rect
+    /// computation touches UIKit and stays on the thread the capture path already uses
+    /// for hierarchy access.
+    final class PostHogSessionReplayMaskRegistry {
+        static let shared = PostHogSessionReplayMaskRegistry()
+
+        private let lock = NSLock()
+        private var reporters: [ObjectIdentifier: Weak<UIView>] = [:]
+
+        func register(_ reporter: UIView) {
+            lock.withLock { reporters[ObjectIdentifier(reporter)] = Weak(reporter) }
+        }
+
+        func unregister(_ reporter: UIView) {
+            lock.withLock { reporters[ObjectIdentifier(reporter)] = nil }
+        }
+
+        /// The rects to redact in `window`, read live from the registered reporters.
+        /// Reporters attached to other windows (iPad multi-window) are excluded.
+        func maskedRects(in window: UIWindow) -> [CGRect] {
+            let liveReporters = lock.withLock {
+                reporters = reporters.filter { $0.value.value != nil }
+                return reporters.values.compactMap(\.value)
+            }
+
+            var rects: [CGRect] = []
+            for reporter in liveReporters {
+                guard reporter.window === window, reporter.isVisible() else { continue }
+                let rect = reporter.toAbsoluteRect(window)
+                if !rect.isEmpty {
+                    rects.append(rect)
+                }
+            }
+            return rects
+        }
+
+        #if TESTING
+            var registeredCountForTesting: Int {
+                lock.withLock { reporters.values.compactMap(\.value).count }
+            }
+        #endif
+    }
+
+    /// The single view `postHogMask()` injects: transparent, hit-test-disabled, spanning
+    /// the masked view's extent. It does nothing except exist there and keep itself
+    /// registered while attached to a window — no traversals, no KVO, no per-layout work.
+    final class PostHogMaskReporterUIView: UIView {
+        var isMaskingEnabled = true {
+            didSet { updateRegistration() }
+        }
+
+        override init(frame: CGRect) {
+            super.init(frame: frame)
+            isUserInteractionEnabled = false
+            backgroundColor = .clear
+            postHogView = true
+        }
+
+        @available(*, unavailable)
+        required init?(coder _: NSCoder) {
+            nil
+        }
+
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            // Registration keys off window attachment: a reporter inside a freshly
+            // realized lazy row is registered before the row can appear in a snapshot.
+            updateRegistration()
+        }
+
+        private func updateRegistration() {
+            if window != nil, isMaskingEnabled {
+                PostHogSessionReplayMaskRegistry.shared.register(self)
+            } else {
+                PostHogSessionReplayMaskRegistry.shared.unregister(self)
+            }
+        }
+    }
+
+    struct PostHogMaskReporterView: UIViewRepresentable {
+        let isEnabled: Bool
+
+        func makeUIView(context _: Context) -> PostHogMaskReporterUIView {
+            let view = PostHogMaskReporterUIView(frame: .zero)
+            view.isMaskingEnabled = isEnabled
+            return view
+        }
+
+        func updateUIView(_ uiView: PostHogMaskReporterUIView, context _: Context) {
+            uiView.isMaskingEnabled = isEnabled
+            uiView.postHogView = true
+            uiView.superview?.postHogView = true
+        }
+
+        static func dismantleUIView(_ uiView: PostHogMaskReporterUIView, coordinator _: ()) {
+            PostHogSessionReplayMaskRegistry.shared.unregister(uiView)
         }
     }
 

--- a/PostHog/SwiftUI/PostHogMaskViewModifier.swift
+++ b/PostHog/SwiftUI/PostHogMaskViewModifier.swift
@@ -42,30 +42,68 @@
         func postHogMask(_ isEnabled: Bool = true) -> some View {
             modifier(
                 PostHogTagViewModifier(
-                    onChange: { views, layers in
-                        views.forEach { $0.postHogNoCapture = isEnabled }
-                        layers.forEach { $0.postHogNoCapture = isEnabled }
+                    onChange: { owner, views, layers in
+                        views.forEach { $0.setPostHogNoCapture(isEnabled, owner: owner) }
+                        layers.forEach { $0.setPostHogNoCapture(isEnabled, owner: owner) }
                     },
-                    onRemove: { views, layers in
-                        views.forEach { $0.postHogNoCapture = false }
-                        layers.forEach { $0.postHogNoCapture = false }
+                    onRemove: { owner, views, layers in
+                        views.forEach { $0.setPostHogNoCapture(false, owner: owner) }
+                        layers.forEach { $0.setPostHogNoCapture(false, owner: owner) }
                     }
                 )
             )
         }
     }
 
+    /// Ref-counted flag ownership. A target can be claimed by several masks at once —
+    /// overlapping target sets are the norm on iOS 26, where masks resolve against the
+    /// shared hosting view — so a plain Boolean flag would let one mask's teardown
+    /// (e.g. a lazy row scrolling offscreen) unmask targets still owned by another.
+    /// A target stays flagged for as long as at least one owner claims it.
+    final class PostHogFlagOwners {
+        var owners: Set<ObjectIdentifier> = []
+    }
+
+    extension NSObject {
+        func isPostHogFlagOwned(_ key: UnsafeRawPointer) -> Bool {
+            (objc_getAssociatedObject(self, key) as? PostHogFlagOwners)?.owners.isEmpty == false
+        }
+
+        func setPostHogFlag(_ key: UnsafeRawPointer, enabled: Bool, owner: ObjectIdentifier) {
+            let box: PostHogFlagOwners
+            if let existing = objc_getAssociatedObject(self, key) as? PostHogFlagOwners {
+                box = existing
+            } else {
+                box = PostHogFlagOwners()
+                objc_setAssociatedObject(self, key, box, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            }
+            if enabled {
+                box.owners.insert(owner)
+            } else {
+                box.owners.remove(owner)
+            }
+        }
+    }
+
     extension UIView {
+        /// Whether at least one mask currently claims this view.
         var postHogNoCapture: Bool {
-            get { objc_getAssociatedObject(self, &AssociatedKeys.phNoCapture) as? Bool ?? false }
-            set { objc_setAssociatedObject(self, &AssociatedKeys.phNoCapture, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+            isPostHogFlagOwned(&AssociatedKeys.phNoCapture)
+        }
+
+        func setPostHogNoCapture(_ enabled: Bool, owner: ObjectIdentifier) {
+            setPostHogFlag(&AssociatedKeys.phNoCapture, enabled: enabled, owner: owner)
         }
     }
 
     extension CALayer {
+        /// Whether at least one mask currently claims this layer.
         var postHogNoCapture: Bool {
-            get { objc_getAssociatedObject(self, &AssociatedKeys.phNoCapture) as? Bool ?? false }
-            set { objc_setAssociatedObject(self, &AssociatedKeys.phNoCapture, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+            isPostHogFlagOwned(&AssociatedKeys.phNoCapture)
+        }
+
+        func setPostHogNoCapture(_ enabled: Bool, owner: ObjectIdentifier) {
+            setPostHogFlag(&AssociatedKeys.phNoCapture, enabled: enabled, owner: owner)
         }
     }
 #endif

--- a/PostHog/SwiftUI/PostHogMaskViewModifier.swift
+++ b/PostHog/SwiftUI/PostHogMaskViewModifier.swift
@@ -61,33 +61,50 @@
         static let shared = PostHogSessionReplayMaskRegistry()
 
         private let lock = NSLock()
-        private var reporters: [ObjectIdentifier: Weak<UIView>] = [:]
+        private var reporters: [ObjectIdentifier: Weak<PostHogMaskReporterUIView>] = [:]
 
-        func register(_ reporter: UIView) {
+        struct MaskedRects {
+            let rects: [CGRect]
+            /// A reporter in this window hasn't been laid out yet, so its region can't
+            /// be reported. Callers must skip the frame instead of masking nothing.
+            let hasUnsettledReporters: Bool
+        }
+
+        func register(_ reporter: PostHogMaskReporterUIView) {
             lock.withLock { reporters[ObjectIdentifier(reporter)] = Weak(reporter) }
         }
 
-        func unregister(_ reporter: UIView) {
+        func unregister(_ reporter: PostHogMaskReporterUIView) {
             lock.withLock { reporters[ObjectIdentifier(reporter)] = nil }
         }
 
         /// The rects to redact in `window`, read live from the registered reporters.
-        /// Reporters attached to other windows (iPad multi-window) are excluded.
-        func maskedRects(in window: UIWindow) -> [CGRect] {
+        /// Deliberately not using `isVisible()`: its `frame == .zero` check can't
+        /// distinguish "not laid out yet" (must fail closed) from "legitimately empty".
+        func maskedRects(in window: UIWindow) -> MaskedRects {
+            // `hasCompletedFirstLayout` is main-confined; this assert stays active in
+            // Release builds too (dispatch_assert_queue is not NDEBUG-gated).
+            dispatchPrecondition(condition: .onQueue(.main))
+
             let liveReporters = lock.withLock {
                 reporters = reporters.filter { $0.value.value != nil }
                 return reporters.values.compactMap(\.value)
             }
 
             var rects: [CGRect] = []
+            var hasUnsettledReporters = false
             for reporter in liveReporters {
-                guard reporter.window === window, reporter.isVisible() else { continue }
+                guard reporter.window === window, !reporter.isHidden, reporter.alpha > 0 else { continue }
+                guard reporter.hasCompletedFirstLayout else {
+                    hasUnsettledReporters = true
+                    continue
+                }
                 let rect = reporter.toAbsoluteRect(window)
                 if !rect.isEmpty {
                     rects.append(rect)
                 }
             }
-            return rects
+            return MaskedRects(rects: rects, hasUnsettledReporters: hasUnsettledReporters)
         }
 
         #if TESTING
@@ -98,18 +115,30 @@
     }
 
     /// The single view `postHogMask()` injects: transparent, hit-test-disabled, spanning
-    /// the masked view's extent. It does nothing except exist there and keep itself
-    /// registered while attached to a window — no traversals, no KVO, no per-layout work.
+    /// the masked view's extent. It only exists there and keeps itself registered while
+    /// attached to a window — no traversals, no KVO, no per-layout resolution work.
     final class PostHogMaskReporterUIView: UIView {
         var isMaskingEnabled = true {
             didSet { updateRegistration() }
         }
+
+        /// Distinguishes "not laid out yet" (fail closed) from a legitimately
+        /// zero-sized laid-out view (safe to skip).
+        private(set) var hasCompletedFirstLayout = false
 
         override init(frame: CGRect) {
             super.init(frame: frame)
             isUserInteractionEnabled = false
             backgroundColor = .clear
             postHogView = true
+        }
+
+        private weak var lastLayoutWindow: UIWindow?
+
+        override func layoutSubviews() {
+            super.layoutSubviews()
+            hasCompletedFirstLayout = true
+            lastLayoutWindow = window
         }
 
         @available(*, unavailable)
@@ -119,8 +148,20 @@
 
         override func didMoveToWindow() {
             super.didMoveToWindow()
-            // Registration keys off window attachment: a reporter inside a freshly
-            // realized lazy row is registered before the row can appear in a snapshot.
+            if let window {
+                // Frames from another window's layout are stale; same-window re-adds
+                // (cell reuse) keep the settled state — rects are read live anyway.
+                if window !== lastLayoutWindow {
+                    hasCompletedFirstLayout = false
+                }
+                // Unsettled reporters must be layout-dirty, or one whose bounds never
+                // change again (e.g. laid out before attachment) would block snapshots forever.
+                if !hasCompletedFirstLayout {
+                    setNeedsLayout()
+                }
+            }
+            // Register on window attachment so a freshly realized lazy row is
+            // registered before it can appear in a snapshot.
             updateRegistration()
         }
 

--- a/PostHog/SwiftUI/PostHogMaskViewModifier.swift
+++ b/PostHog/SwiftUI/PostHogMaskViewModifier.swift
@@ -198,17 +198,25 @@
     /// overlapping target sets are the norm on iOS 26, where masks resolve against the
     /// shared hosting view — so a plain Boolean flag would let one mask's teardown
     /// (e.g. a lazy row scrolling offscreen) unmask targets still owned by another.
-    /// A target stays flagged for as long as at least one owner claims it.
+    /// A target stays flagged for as long as at least one owner claims it. Owners are
+    /// held weakly and pruned on read, so a claim can't outlive its owner (a missed
+    /// teardown self-heals) and a recycled address can't resolve to a dead owner.
+    /// Main-thread confined, like the tag machinery that drives it — no lock needed.
     final class PostHogFlagOwners {
-        var owners: Set<ObjectIdentifier> = []
+        var owners: [ObjectIdentifier: Weak<UIView>] = [:]
+
+        func pruneAndHasLiveOwner() -> Bool {
+            owners = owners.filter { $0.value.value != nil }
+            return !owners.isEmpty
+        }
     }
 
     extension NSObject {
         func isPostHogFlagOwned(_ key: UnsafeRawPointer) -> Bool {
-            (objc_getAssociatedObject(self, key) as? PostHogFlagOwners)?.owners.isEmpty == false
+            (objc_getAssociatedObject(self, key) as? PostHogFlagOwners)?.pruneAndHasLiveOwner() == true
         }
 
-        func setPostHogFlag(_ key: UnsafeRawPointer, enabled: Bool, owner: ObjectIdentifier) {
+        func setPostHogFlag(_ key: UnsafeRawPointer, enabled: Bool, owner: UIView) {
             let box: PostHogFlagOwners
             if let existing = objc_getAssociatedObject(self, key) as? PostHogFlagOwners {
                 box = existing
@@ -216,11 +224,7 @@
                 box = PostHogFlagOwners()
                 objc_setAssociatedObject(self, key, box, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
             }
-            if enabled {
-                box.owners.insert(owner)
-            } else {
-                box.owners.remove(owner)
-            }
+            box.owners[ObjectIdentifier(owner)] = enabled ? Weak(owner) : nil
         }
     }
 #endif

--- a/PostHog/SwiftUI/PostHogNoMaskViewModifier.swift
+++ b/PostHog/SwiftUI/PostHogNoMaskViewModifier.swift
@@ -42,30 +42,38 @@
         func postHogNoMask() -> some View {
             modifier(
                 PostHogTagViewModifier(
-                    onChange: { views, layers in
-                        views.forEach { $0.postHogNoMask = true }
-                        layers.forEach { $0.postHogNoMask = true }
+                    onChange: { owner, views, layers in
+                        views.forEach { $0.setPostHogNoMask(true, owner: owner) }
+                        layers.forEach { $0.setPostHogNoMask(true, owner: owner) }
                     },
-                    onRemove: { views, layers in
-                        views.forEach { $0.postHogNoMask = false }
-                        layers.forEach { $0.postHogNoMask = false }
+                    onRemove: { owner, views, layers in
+                        views.forEach { $0.setPostHogNoMask(false, owner: owner) }
+                        layers.forEach { $0.setPostHogNoMask(false, owner: owner) }
                     }
                 )
             )
         }
     }
 
+    // Same ref-counted ownership as `postHogNoCapture` (see PostHogFlagOwners):
+    // overlapping no-mask regions must not clear each other on teardown.
     extension UIView {
         var postHogNoMask: Bool {
-            get { objc_getAssociatedObject(self, &AssociatedKeys.phNoMask) as? Bool ?? false }
-            set { objc_setAssociatedObject(self, &AssociatedKeys.phNoMask, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+            isPostHogFlagOwned(&AssociatedKeys.phNoMask)
+        }
+
+        func setPostHogNoMask(_ enabled: Bool, owner: ObjectIdentifier) {
+            setPostHogFlag(&AssociatedKeys.phNoMask, enabled: enabled, owner: owner)
         }
     }
 
     extension CALayer {
         var postHogNoMask: Bool {
-            get { objc_getAssociatedObject(self, &AssociatedKeys.phNoMask) as? Bool ?? false }
-            set { objc_setAssociatedObject(self, &AssociatedKeys.phNoMask, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+            isPostHogFlagOwned(&AssociatedKeys.phNoMask)
+        }
+
+        func setPostHogNoMask(_ enabled: Bool, owner: ObjectIdentifier) {
+            setPostHogFlag(&AssociatedKeys.phNoMask, enabled: enabled, owner: owner)
         }
     }
 

--- a/PostHog/SwiftUI/PostHogNoMaskViewModifier.swift
+++ b/PostHog/SwiftUI/PostHogNoMaskViewModifier.swift
@@ -55,8 +55,8 @@
         }
     }
 
-    // Same ref-counted ownership as `postHogNoCapture` (see PostHogFlagOwners):
-    // overlapping no-mask regions must not clear each other on teardown.
+    // Ref-counted ownership (see PostHogFlagOwners): overlapping no-mask regions
+    // must not clear each other on teardown.
     extension UIView {
         var postHogNoMask: Bool {
             isPostHogFlagOwned(&AssociatedKeys.phNoMask)

--- a/PostHog/SwiftUI/PostHogNoMaskViewModifier.swift
+++ b/PostHog/SwiftUI/PostHogNoMaskViewModifier.swift
@@ -62,7 +62,7 @@
             isPostHogFlagOwned(&AssociatedKeys.phNoMask)
         }
 
-        func setPostHogNoMask(_ enabled: Bool, owner: ObjectIdentifier) {
+        func setPostHogNoMask(_ enabled: Bool, owner: UIView) {
             setPostHogFlag(&AssociatedKeys.phNoMask, enabled: enabled, owner: owner)
         }
     }
@@ -72,7 +72,7 @@
             isPostHogFlagOwned(&AssociatedKeys.phNoMask)
         }
 
-        func setPostHogNoMask(_ enabled: Bool, owner: ObjectIdentifier) {
+        func setPostHogNoMask(_ enabled: Bool, owner: UIView) {
             setPostHogFlag(&AssociatedKeys.phNoMask, enabled: enabled, owner: owner)
         }
     }

--- a/PostHog/SwiftUI/PostHogTagViewModifier.swift
+++ b/PostHog/SwiftUI/PostHogTagViewModifier.swift
@@ -253,12 +253,15 @@
 
         override func layoutSubviews() {
             super.layoutSubviews()
-            detectLayers()
+            // Per-layout re-scans are coalesced: one drain per run-loop turn instead
+            // of a full layer-tree walk per capture view per layout pass.
+            PostHogTagResolutionCoalescer.markDirty(self)
         }
 
         override func didMoveToWindow() {
             super.didMoveToWindow()
-            // Trigger detection when fully added to window hierarchy
+            // Trigger detection when fully added to window hierarchy. Synchronous on
+            // first attach so freshly realized content is flagged before capture.
             if window != nil {
                 detectLayers()
             }
@@ -466,7 +469,12 @@
             return []
         }
 
-        let referenceFrame = parentView.convert(parentView.bounds, to: nil)
+        // The reference frame is the masked view's own extent — the capture view is a
+        // full-size overlay of the modified view. Deriving it from the hosting view
+        // (the previous behavior) made every mask collect and claim content layers
+        // across the entire hosting view, so overlapping masks constantly claimed and
+        // released each other's layers.
+        let referenceFrame = captureView.convert(captureView.bounds, to: nil)
         guard !referenceFrame.isEmpty else {
             return []
         }
@@ -496,6 +504,14 @@
 
             // Get the sublayer's frame in the parent layer's coordinate space
             let sublayerFrame = sublayer.convert(sublayer.bounds, to: nil)
+
+            // Prune clipped subtrees: when a layer clips its children to its own
+            // bounds and those bounds don't reach the reference frame, nothing inside
+            // it can be visible within the masked extent. Only safe under
+            // masksToBounds — unclipped children may extend outside their parent.
+            if sublayer.masksToBounds, !referenceFrame.intersects(sublayerFrame) {
+                continue
+            }
 
             // Only include layers whose center point is contained within the reference frame
             let sublayerFrameCenter = CGPoint(x: sublayerFrame.midX, y: sublayerFrame.midY)
@@ -621,18 +637,27 @@
         }
     }
 
-    /// Coalesces tagger re-resolution requests (layout passes, ancestor-hierarchy KVO
-    /// signals) into a single drain per main-run-loop turn. Invalidation stays
-    /// hierarchy-driven — the coalescer batches work, it never drops it: every marked
-    /// tagger is resolved on the next drain, so content replaced without a geometry
-    /// change is still re-tagged.
+    /// A view of the tag machinery whose target resolution can be deferred and batched.
+    @MainActor
+    protocol PostHogCoalescedResolving: AnyObject {
+        func performCoalescedResolution()
+    }
+
+    /// Coalesces re-resolution requests (layout passes, ancestor-hierarchy KVO signals)
+    /// into a single drain per main-run-loop turn. Invalidation stays hierarchy-driven —
+    /// the coalescer batches work, it never drops it: every marked resolver runs on the
+    /// next drain, so content replaced without a geometry change is still re-tagged.
     @MainActor
     enum PostHogTagResolutionCoalescer {
-        private static var dirtyTaggers: [ObjectIdentifier: Weak<PostHogTagUIView>] = [:]
+        private struct WeakResolver {
+            weak var value: (any PostHogCoalescedResolving)?
+        }
+
+        private static var dirtyResolvers: [ObjectIdentifier: WeakResolver] = [:]
         private static var isDrainScheduled = false
 
-        static func markDirty(_ tagger: PostHogTagUIView) {
-            dirtyTaggers[ObjectIdentifier(tagger)] = Weak(tagger)
+        static func markDirty(_ resolver: any PostHogCoalescedResolving) {
+            dirtyResolvers[ObjectIdentifier(resolver)] = WeakResolver(value: resolver)
             guard !isDrainScheduled else { return }
             isDrainScheduled = true
             DispatchQueue.main.async {
@@ -642,11 +667,11 @@
 
         private static func drain() {
             isDrainScheduled = false
-            guard !dirtyTaggers.isEmpty else { return }
-            let taggers = dirtyTaggers.values.compactMap(\.value)
-            dirtyTaggers.removeAll()
-            for tagger in taggers {
-                tagger.handler?()
+            guard !dirtyResolvers.isEmpty else { return }
+            let resolvers = dirtyResolvers.values.compactMap(\.value)
+            dirtyResolvers.removeAll()
+            for resolver in resolvers {
+                resolver.performCoalescedResolution()
             }
         }
 
@@ -655,6 +680,19 @@
                 drain()
             }
         #endif
+    }
+
+    extension PostHogTagUIView: PostHogCoalescedResolving {
+        func performCoalescedResolution() {
+            handler?()
+        }
+    }
+
+    @available(iOS 26.0, *)
+    extension PostHogFrameCaptureUIView: PostHogCoalescedResolving {
+        func performCoalescedResolution() {
+            detectLayers()
+        }
     }
 
     /// Observes layer hierarchy changes on an ancestor view using KVO.
@@ -796,6 +834,17 @@
                 var results: [CALayer] = []
                 collectContentLayers(from: layer, containedIn: referenceFrame, results: &results)
                 return results
+            }
+
+            @available(iOS 26.0, *)
+            static func makeFrameCaptureView() -> UIView {
+                PostHogFrameCaptureUIView(id: UUID(), handler: nil)
+            }
+
+            @available(iOS 26.0, *)
+            static func targetLayers(fromCaptureView captureView: UIView) -> [CALayer] {
+                guard let captureView = captureView as? PostHogFrameCaptureUIView else { return [] }
+                return getTargetLayers(from: captureView)
             }
         }
     #endif

--- a/PostHog/SwiftUI/PostHogTagViewModifier.swift
+++ b/PostHog/SwiftUI/PostHogTagViewModifier.swift
@@ -10,7 +10,10 @@
 #if os(iOS) && canImport(SwiftUI)
     import SwiftUI
 
-    typealias PostHogTagHandler = (_ views: [UIView], _ layers: [CALayer]) -> Void
+    /// - owner: identity of the injected view that resolved these targets. Used for
+    ///   ref-counted flag ownership (see `PostHogFlagOwners`), so that overlapping
+    ///   masks cannot clear each other's targets on teardown.
+    typealias PostHogTagHandler = (_ owner: ObjectIdentifier, _ views: [UIView], _ layers: [CALayer]) -> Void
 
     /**
      This is a helper view modifier for retrieving a list of underlying UIKit views for the current SwiftUI view.
@@ -174,10 +177,21 @@
             let changeHandler = onChange
             let view = PostHogFrameCaptureUIView(id: id) { captureView in
                 let layers = getTargetLayers(from: captureView)
-                if !layers.isEmpty {
-                    coordinator.cachedLayers = layers
-                    changeHandler([], layers)
+                guard !layers.isEmpty else { return }
+
+                // Reconcile against the previous resolution: release ownership on
+                // layers that dropped out, otherwise recycled layers keep stale flags.
+                let owner = ObjectIdentifier(captureView)
+                let previous = coordinator.cachedLayers
+                let dropped = previous.filter { previousLayer in
+                    !layers.contains(where: { $0 === previousLayer })
                 }
+                if !dropped.isEmpty {
+                    coordinator.onRemoveHandler(owner, [], dropped)
+                }
+
+                coordinator.cachedLayers = layers
+                changeHandler(owner, [], layers)
             }
             view.postHogView = true
             return view
@@ -196,7 +210,7 @@
                 : coordinator.cachedLayers
 
             if !layers.isEmpty {
-                coordinator.onRemoveHandler([], layers)
+                coordinator.onRemoveHandler(ObjectIdentifier(uiView), [], layers)
             }
             uiView.handler = nil
         }
@@ -297,12 +311,10 @@
         }
 
         func makeUIView(context: Context) -> PostHogTagUIView {
-            PostHogTagUIView(id: id) { controller in
-                let targets = getTargetViews(from: controller)
-                if !targets.isEmpty {
-                    context.coordinator.cachedTargets = targets
-                    onChangeHandler(targets, [])
-                }
+            let coordinator = context.coordinator
+            let onChange = onChangeHandler
+            return PostHogTagUIView(id: id) { taggerView in
+                resolveTagTargets(from: taggerView, coordinator: coordinator, onChange: onChange)
             }
         }
 
@@ -317,12 +329,38 @@
                 : coordinator.cachedTargets
 
             if !targets.isEmpty {
-                coordinator.onRemoveHandler(targets, [])
+                coordinator.onRemoveHandler(ObjectIdentifier(uiView), targets, [])
             }
 
             uiView.postHogTagView = nil
             uiView.handler = nil
         }
+    }
+
+    /// Resolves the tagger's current targets, reconciles them against the previously
+    /// cached set, and invokes `onChange` with the new set. The reconciliation releases
+    /// flag ownership on targets that dropped out of the resolution — without it, every
+    /// re-resolution (content replacement, hierarchy churn) would leak stale ownership
+    /// on views SwiftUI has recycled elsewhere.
+    func resolveTagTargets(
+        from taggerView: PostHogTagUIView,
+        coordinator: PostHogTagView.Coordinator,
+        onChange: PostHogTagHandler
+    ) {
+        let targets = getTargetViews(from: taggerView)
+        guard !targets.isEmpty else { return }
+
+        let owner = ObjectIdentifier(taggerView)
+        let previous = coordinator.cachedTargets
+        let dropped = previous.filter { previousTarget in
+            !targets.contains(where: { $0 === previousTarget })
+        }
+        if !dropped.isEmpty {
+            coordinator.onRemoveHandler(owner, dropped, [])
+        }
+
+        coordinator.cachedTargets = targets
+        onChange(owner, targets, [])
     }
 
     private let swiftUIIgnoreTypes: [AnyClass] = [
@@ -538,6 +576,9 @@
             super.didMoveToSuperview()
             postHogTagView = self
             postHogView = true
+            // First-attach resolution stays synchronous so a freshly realized view
+            // (e.g. a lazy row appearing mid-scroll) is flagged before it can show
+            // up in a snapshot.
             handler?()
         }
 
@@ -549,7 +590,9 @@
 
         override func layoutSubviews() {
             super.layoutSubviews()
-            handler?()
+            // Re-resolutions triggered by layout are coalesced: one drain per
+            // run-loop turn instead of one traversal per tagger per layout pass.
+            PostHogTagResolutionCoalescer.markDirty(self)
         }
 
         private func setupAncestorObserver() {
@@ -565,11 +608,53 @@
             // Remove any existing observer
             ancestorObserver?.stopObserving()
 
-            // Create new observer for the common ancestor
+            // Create new observer for the common ancestor. On iOS 26 many taggers
+            // share (nearly) the same ancestor, so a single hierarchy change used to
+            // re-fire every tagger's traversal from its own observer — coalescing
+            // collapses that storm into one resolution per tagger per turn.
             ancestorObserver = AncestorSubviewObserver(ancestor: commonAncestor) { [weak self] in
-                self?.handler?()
+                MainActor.assumeIsolated {
+                    guard let self else { return }
+                    PostHogTagResolutionCoalescer.markDirty(self)
+                }
             }
         }
+    }
+
+    /// Coalesces tagger re-resolution requests (layout passes, ancestor-hierarchy KVO
+    /// signals) into a single drain per main-run-loop turn. Invalidation stays
+    /// hierarchy-driven — the coalescer batches work, it never drops it: every marked
+    /// tagger is resolved on the next drain, so content replaced without a geometry
+    /// change is still re-tagged.
+    @MainActor
+    enum PostHogTagResolutionCoalescer {
+        private static var dirtyTaggers: [ObjectIdentifier: Weak<PostHogTagUIView>] = [:]
+        private static var isDrainScheduled = false
+
+        static func markDirty(_ tagger: PostHogTagUIView) {
+            dirtyTaggers[ObjectIdentifier(tagger)] = Weak(tagger)
+            guard !isDrainScheduled else { return }
+            isDrainScheduled = true
+            DispatchQueue.main.async {
+                MainActor.assumeIsolated { drain() }
+            }
+        }
+
+        private static func drain() {
+            isDrainScheduled = false
+            guard !dirtyTaggers.isEmpty else { return }
+            let taggers = dirtyTaggers.values.compactMap(\.value)
+            dirtyTaggers.removeAll()
+            for tagger in taggers {
+                tagger.handler?()
+            }
+        }
+
+        #if TESTING
+            static func drainForTesting() {
+                drain()
+            }
+        #endif
     }
 
     /// Observes layer hierarchy changes on an ancestor view using KVO.

--- a/PostHog/SwiftUI/PostHogTagViewModifier.swift
+++ b/PostHog/SwiftUI/PostHogTagViewModifier.swift
@@ -720,7 +720,7 @@
         }
     }
 
-    private extension UIView {
+    extension UIView {
         var postHogTagView: PostHogTagUIView? {
             get { objc_getAssociatedObject(self, &AssociatedKeys.phTagView) as? PostHogTagUIView }
             set { objc_setAssociatedObject(self, &AssociatedKeys.phTagView, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }

--- a/PostHog/SwiftUI/PostHogTagViewModifier.swift
+++ b/PostHog/SwiftUI/PostHogTagViewModifier.swift
@@ -337,22 +337,53 @@
     func getTargetViews(from taggerView: UIView) -> [UIView] {
         guard
             let anchorView = taggerView.postHogAnchor,
-            let commonAncestor = anchorView.nearestCommonAncestor(with: taggerView)
+            let commonAncestor = anchorView.nearestCommonAncestor(with: taggerView),
+            // The anchor is not part of its own descendants, so when the common
+            // ancestor degenerates to the anchor itself the traversal never starts.
+            commonAncestor !== anchorView
         else {
             return []
         }
 
-        return commonAncestor
-            .allDescendants(between: anchorView, and: taggerView)
-            .lazy
-            .filter {
-                // ignore some system SwiftUI views
-                !swiftUIIgnoreTypes.contains(where: $0.isKind(of:))
+        // Iterative pre-order DFS over the flat descendant sequence of the common
+        // ancestor, starting directly at the anchor (everything before it was only
+        // ever enumerated to be dropped) and terminating at the tagger. Replaces the
+        // recursiveSequence/AnyIterator lazy chains whose per-element overhead
+        // (closure boxes, protocol-witness dispatch, per-node subviews bridging)
+        // dominated launch and scroll traces.
+        //
+        // Seed the stack with the anchor plus the not-yet-visited right siblings
+        // along the path from the anchor up to the common ancestor — exactly the
+        // remainder of the flat pre-order sequence from the anchor onwards.
+        var siblingChains: [ArraySlice<UIView>] = []
+        var pathNode = anchorView
+        while pathNode !== commonAncestor {
+            guard let parent = pathNode.superview else { return [] }
+            let siblings = parent.subviews
+            if let index = siblings.firstIndex(where: { $0 === pathNode }) {
+                siblingChains.append(siblings[(index + 1)...])
             }
-            .filter {
-                // exclude injected views
-                !$0.postHogView
+            pathNode = parent
+        }
+
+        var stack: [UIView] = []
+        for chain in siblingChains.reversed() {
+            stack.append(contentsOf: chain.reversed())
+        }
+        stack.append(anchorView)
+
+        var targets: [UIView] = []
+        while let view = stack.popLast() {
+            if view === taggerView {
+                break
             }
+            // ignore some system SwiftUI views, and exclude injected views
+            if !swiftUIIgnoreTypes.contains(where: view.isKind(of:)), !view.postHogView {
+                targets.append(view)
+            }
+            stack.append(contentsOf: view.subviews.reversed())
+        }
+        return targets
     }
 
     /// On iOS 26+, SwiftUI primitives may be rendered as CALayers instead of UIViews.
@@ -577,33 +608,37 @@
             set { objc_setAssociatedObject(self, &AssociatedKeys.phView, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
         }
 
-        func allDescendants(between bottomEntity: UIView, and topEntity: UIView) -> some Sequence<UIView> {
-            descendants
-                .lazy
-                .drop(while: { $0 !== bottomEntity })
-                .prefix(while: { $0 !== topEntity })
+        /// All descendants in pre-order DFS, excluding the receiver.
+        var descendants: [UIView] {
+            var result: [UIView] = []
+            var stack: [UIView] = subviews.reversed()
+            while let view = stack.popLast() {
+                result.append(view)
+                stack.append(contentsOf: view.subviews.reversed())
+            }
+            return result
         }
 
-        var ancestors: some Sequence<UIView> {
-            sequence(first: self, next: { $0.superview }).dropFirst()
-        }
-
-        var descendants: some Sequence<UIView> {
-            recursiveSequence([self], children: { $0.subviews }).dropFirst()
-        }
-
-        func isDescendant(of other: UIView) -> Bool {
-            ancestors.contains(other)
-        }
-
+        /// The first view in the receiver's ancestor-or-self chain that is a PROPER
+        /// ancestor of `other` (deliberately preserving the original semantics: the
+        /// receiver itself qualifies, `other` itself never does). O(depth) via an
+        /// ancestor set, replacing the O(depth²) isDescendant(of:) walk per step.
         func nearestCommonAncestor(with other: UIView) -> UIView? {
-            var nearestAncestor: UIView? = self
-
-            while let currentEntity = nearestAncestor, !other.isDescendant(of: currentEntity) {
-                nearestAncestor = currentEntity.superview
+            var otherProperAncestors = Set<ObjectIdentifier>()
+            var node = other.superview
+            while let current = node {
+                otherProperAncestors.insert(ObjectIdentifier(current))
+                node = current.superview
             }
 
-            return nearestAncestor
+            var candidate: UIView? = self
+            while let current = candidate {
+                if otherProperAncestors.contains(ObjectIdentifier(current)) {
+                    return current
+                }
+                candidate = current.superview
+            }
+            return nil
         }
 
         var postHogAnchor: UIView? {
@@ -623,33 +658,6 @@
         struct Pair {
             weak var anchor: PostHogTagAnchorUIView?
             weak var tagger: PostHogTagUIView?
-        }
-    }
-
-    /**
-     Recursively iterates over a sequence of elements, applying a function to each element to get its children.
-
-     - Parameters:
-     - sequence: The sequence of elements to iterate over.
-     - children: A function that takes an element and returns a sequence of its children.
-     - Returns: An AnySequence that iterates over all elements and their children.
-     */
-    private func recursiveSequence<S: Sequence>(_ sequence: S, children: @escaping (S.Element) -> S) -> AnySequence<S.Element> {
-        AnySequence {
-            var mainIterator = sequence.makeIterator()
-            // Current iterator, or `nil` if all sequences are exhausted:
-            var iterator: AnyIterator<S.Element>?
-
-            return AnyIterator {
-                guard let iterator, let element = iterator.next() else {
-                    if let element = mainIterator.next() {
-                        iterator = recursiveSequence(children(element), children: children).makeIterator()
-                        return element
-                    }
-                    return nil
-                }
-                return element
-            }
         }
     }
 

--- a/PostHog/SwiftUI/PostHogTagViewModifier.swift
+++ b/PostHog/SwiftUI/PostHogTagViewModifier.swift
@@ -664,4 +664,47 @@
         }
     }
 
+    #if TESTING
+        /// Test-only entry points into the private tagging machinery.
+        ///
+        /// Used by the masking characterization tests, which pin the CURRENT resolution
+        /// behavior of the traversal before it is optimized — so that later performance
+        /// changes can prove they did not alter which views/layers get resolved.
+        /// Lives in this file so it can reach `private` declarations. Not compiled into
+        /// release builds.
+        @MainActor
+        enum PostHogTaggingTestSupport {
+            /// Creates a real anchor/tagger pair registered in the `TaggingStore`,
+            /// exactly like `PostHogTagViewModifier` does via its representables.
+            static func makeTagPair(id: UUID = UUID()) -> (anchor: UIView, tagger: PostHogTagUIView) {
+                (PostHogTagAnchorUIView(id: id), PostHogTagUIView(id: id, handler: nil))
+            }
+
+            static func targetViews(from tagger: PostHogTagUIView) -> [UIView] {
+                getTargetViews(from: tagger)
+            }
+
+            /// Applies the same marking `markPostHogView` performs from the
+            /// representables' `updateUIView` (the view and its direct superview).
+            static func markInjected(_ view: UIView) {
+                markPostHogView(view)
+            }
+
+            static func nearestCommonAncestor(of view: UIView, and other: UIView) -> UIView? {
+                view.nearestCommonAncestor(with: other)
+            }
+
+            static func descendants(of view: UIView) -> [UIView] {
+                Array(view.descendants)
+            }
+
+            @available(iOS 26.0, *)
+            static func contentLayers(under layer: CALayer, containedIn referenceFrame: CGRect) -> [CALayer] {
+                var results: [CALayer] = []
+                collectContentLayers(from: layer, containedIn: referenceFrame, results: &results)
+                return results
+            }
+        }
+    #endif
+
 #endif

--- a/PostHog/SwiftUI/PostHogTagViewModifier.swift
+++ b/PostHog/SwiftUI/PostHogTagViewModifier.swift
@@ -176,22 +176,13 @@
             let coordinator = context.coordinator
             let changeHandler = onChange
             let view = PostHogFrameCaptureUIView(id: id) { captureView in
-                let layers = getTargetLayers(from: captureView)
-                guard !layers.isEmpty else { return }
-
-                // Reconcile against the previous resolution: release ownership on
-                // layers that dropped out, otherwise recycled layers keep stale flags.
-                let owner = captureView
-                let previous = coordinator.cachedLayers
-                let dropped = previous.filter { previousLayer in
-                    !layers.contains(where: { $0 === previousLayer })
-                }
-                if !dropped.isEmpty {
-                    coordinator.onRemoveHandler(owner, [], dropped)
-                }
-
-                coordinator.cachedLayers = layers
-                changeHandler(owner, [], layers)
+                coordinator.cachedLayers = reconcileAndEmit(
+                    owner: captureView,
+                    resolved: getTargetLayers(from: captureView),
+                    previous: coordinator.cachedLayers,
+                    onRemove: { coordinator.onRemoveHandler($0, [], $1) },
+                    onChange: { changeHandler($0, [], $1) }
+                )
             }
             view.postHogView = true
             return view
@@ -340,30 +331,47 @@
         }
     }
 
-    /// Resolves the tagger's current targets, reconciles them against the previously
-    /// cached set, and invokes `onChange` with the new set. The reconciliation releases
-    /// flag ownership on targets that dropped out of the resolution — without it, every
-    /// re-resolution (content replacement, hierarchy churn) would leak stale ownership
-    /// on views SwiftUI has recycled elsewhere.
+    /// Reconciles a fresh target resolution against the previously cached one and
+    /// returns the new cache. Ownership is released on targets that dropped out —
+    /// including when the new resolution is empty (a broken sandwich during hierarchy
+    /// churn), otherwise a recycled view would keep a stale claim from a prior
+    /// resolution and be treated as safe to record. `onChange` only fires for
+    /// non-empty resolutions.
+    func reconcileAndEmit<Target: AnyObject>(
+        owner: UIView,
+        resolved: [Target],
+        previous: [Target],
+        onRemove: (UIView, [Target]) -> Void,
+        onChange: (UIView, [Target]) -> Void
+    ) -> [Target] {
+        let dropped = previous.filter { previousTarget in
+            !resolved.contains(where: { $0 === previousTarget })
+        }
+        if !dropped.isEmpty {
+            onRemove(owner, dropped)
+        }
+        if !resolved.isEmpty {
+            onChange(owner, resolved)
+        }
+        return resolved
+    }
+
+    /// Resolves the tagger's current targets and reconciles them against the cached
+    /// set (see `reconcileAndEmit`) — without the release, every re-resolution
+    /// (content replacement, hierarchy churn) would leak stale ownership on views
+    /// SwiftUI has recycled elsewhere.
     func resolveTagTargets(
         from taggerView: PostHogTagUIView,
         coordinator: PostHogTagView.Coordinator,
         onChange: PostHogTagHandler
     ) {
-        let targets = getTargetViews(from: taggerView)
-        guard !targets.isEmpty else { return }
-
-        let owner = taggerView
-        let previous = coordinator.cachedTargets
-        let dropped = previous.filter { previousTarget in
-            !targets.contains(where: { $0 === previousTarget })
-        }
-        if !dropped.isEmpty {
-            coordinator.onRemoveHandler(owner, dropped, [])
-        }
-
-        coordinator.cachedTargets = targets
-        onChange(owner, targets, [])
+        coordinator.cachedTargets = reconcileAndEmit(
+            owner: taggerView,
+            resolved: getTargetViews(from: taggerView),
+            previous: coordinator.cachedTargets,
+            onRemove: { coordinator.onRemoveHandler($0, $1, []) },
+            onChange: { onChange($0, $1, []) }
+        )
     }
 
     private let swiftUIIgnoreTypes: [AnyClass] = [

--- a/PostHog/SwiftUI/PostHogTagViewModifier.swift
+++ b/PostHog/SwiftUI/PostHogTagViewModifier.swift
@@ -10,10 +10,10 @@
 #if os(iOS) && canImport(SwiftUI)
     import SwiftUI
 
-    /// - owner: identity of the injected view that resolved these targets. Used for
-    ///   ref-counted flag ownership (see `PostHogFlagOwners`), so that overlapping
-    ///   masks cannot clear each other's targets on teardown.
-    typealias PostHogTagHandler = (_ owner: ObjectIdentifier, _ views: [UIView], _ layers: [CALayer]) -> Void
+    /// - owner: the injected view that resolved these targets. Used for ref-counted
+    ///   flag ownership (see `PostHogFlagOwners`), so that overlapping masks cannot
+    ///   clear each other's targets on teardown.
+    typealias PostHogTagHandler = (_ owner: UIView, _ views: [UIView], _ layers: [CALayer]) -> Void
 
     /**
      This is a helper view modifier for retrieving a list of underlying UIKit views for the current SwiftUI view.
@@ -181,7 +181,7 @@
 
                 // Reconcile against the previous resolution: release ownership on
                 // layers that dropped out, otherwise recycled layers keep stale flags.
-                let owner = ObjectIdentifier(captureView)
+                let owner = captureView
                 let previous = coordinator.cachedLayers
                 let dropped = previous.filter { previousLayer in
                     !layers.contains(where: { $0 === previousLayer })
@@ -210,7 +210,7 @@
                 : coordinator.cachedLayers
 
             if !layers.isEmpty {
-                coordinator.onRemoveHandler(ObjectIdentifier(uiView), [], layers)
+                coordinator.onRemoveHandler(uiView, [], layers)
             }
             uiView.handler = nil
         }
@@ -332,7 +332,7 @@
                 : coordinator.cachedTargets
 
             if !targets.isEmpty {
-                coordinator.onRemoveHandler(ObjectIdentifier(uiView), targets, [])
+                coordinator.onRemoveHandler(uiView, targets, [])
             }
 
             uiView.postHogTagView = nil
@@ -353,7 +353,7 @@
         let targets = getTargetViews(from: taggerView)
         guard !targets.isEmpty else { return }
 
-        let owner = ObjectIdentifier(taggerView)
+        let owner = taggerView
         let previous = coordinator.cachedTargets
         let dropped = previous.filter { previousTarget in
             !targets.contains(where: { $0 === previousTarget })

--- a/PostHog/Utils/PostHogMulticastCallback.swift
+++ b/PostHog/Utils/PostHogMulticastCallback.swift
@@ -102,12 +102,20 @@ final class PostHogThrottledMulticastCallback<T> {
     private let lock = NSLock()
     private let onSubscriberCountChanged: ((Int) -> Void)?
 
-    private static var throttleQueue: DispatchQueue {
-        DispatchQueue(
-            label: "com.posthog.ThrottledMulticastCallback",
-            target: .global(qos: .utility)
-        )
-    }
+    /// Serial queue that drains throttled callbacks. Stored per instance: generic types
+    /// cannot have stored static properties, and a computed static would allocate a fresh
+    /// queue on every `invoke()` — besides the allocation cost, separate queues would also
+    /// void the serialization that `ThrottledCallback.lastFired` relies on.
+    private let throttleQueue = DispatchQueue(
+        label: "com.posthog.ThrottledMulticastCallback",
+        target: .global(qos: .utility)
+    )
+
+    /// Earliest instant at which any subscriber becomes eligible to fire again. Guarded by
+    /// `lock`. May be stale-early (worst case: one extra no-op dispatch), but never
+    /// stale-late: `subscribe` resets it, and only the drain on `throttleQueue` moves it
+    /// forward from the live subscriber map.
+    private var nextEligibleFire: Date = .distantPast
 
     /// Creates a new throttled multicast callback.
     /// - Parameter onSubscriberCountChanged: Optional closure called when subscriber count changes.
@@ -124,6 +132,9 @@ final class PostHogThrottledMulticastCallback<T> {
         let id = UUID()
         let newCount = lock.withLock {
             callbacks[id] = ThrottledCallback(handler: callback, interval: interval)
+            // A new subscriber is immediately eligible; without this reset the invoke()
+            // gate could suppress its first fire until the other subscribers' windows open.
+            nextEligibleFire = .distantPast
             return callbacks.count
         }
         onSubscriberCountChanged?(newCount)
@@ -140,11 +151,25 @@ final class PostHogThrottledMulticastCallback<T> {
     /// Invoke all subscribed callbacks, respecting each subscriber's throttle interval.
     /// - Parameter value: The value to pass to all callbacks.
     func invoke(_ value: T) {
-        Self.throttleQueue.async { [weak self] in
+        // Synchronous cheap gate: skip the dispatch (queue hop + closure allocation)
+        // entirely when nobody is subscribed or no subscriber's throttle window has
+        // elapsed yet. This is the steady state when invoked per view layout.
+        let shouldDispatch = lock.withLock {
+            !callbacks.isEmpty && now() >= nextEligibleFire
+        }
+        guard shouldDispatch else { return }
+
+        throttleQueue.async { [weak self] in
             guard let self else { return }
             let callbacks = self.lock.withLock { Array(self.callbacks.values) }
             for callback in callbacks {
                 callback.invokeIfReady(value)
+            }
+            // Recompute from the live subscriber map (not the drained copy) so a
+            // subscriber added mid-drain — eligible immediately — is not gated out.
+            // `lastFired` is only mutated on this serial queue, so reading it here is safe.
+            self.lock.withLock {
+                self.nextEligibleFire = self.callbacks.values.map(\.nextEligibleTime).min() ?? .distantFuture
             }
         }
     }
@@ -158,6 +183,11 @@ final class PostHogThrottledMulticastCallback<T> {
         let interval: TimeInterval
         let handler: (T) -> Void
         private var lastFired: Date = .distantPast
+
+        /// Read only on the owning callback's `throttleQueue` (same place `lastFired` mutates).
+        var nextEligibleTime: Date {
+            lastFired.addingTimeInterval(interval)
+        }
 
         init(handler: @escaping (T) -> Void, interval: TimeInterval) {
             self.handler = handler

--- a/PostHogTests/PostHogMaskingCharacterizationTest.swift
+++ b/PostHogTests/PostHogMaskingCharacterizationTest.swift
@@ -383,6 +383,59 @@
             #expect(!dropped.postHogNoCapture)
         }
 
+        @Test("iOS 26 layer scan: reference frame is the masked view's own extent, not the hosting view's")
+        func layerScanBoundedToCaptureExtent() {
+            guard #available(iOS 26.0, *) else { return }
+
+            // Mirrors the iOS 26 structure: content layers are bare sublayers of the
+            // hosting view; the capture view sits two wrapper views deep and spans
+            // exactly the masked view's extent.
+            let host = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 600))
+            let contentInside = CALayer()
+            contentInside.frame = CGRect(x: 10, y: 10, width: 50, height: 20)
+            host.layer.addSublayer(contentInside)
+            let contentOutside = CALayer()
+            contentOutside.frame = CGRect(x: 10, y: 300, width: 50, height: 20)
+            host.layer.addSublayer(contentOutside)
+
+            let inherited = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+            let platformHost = UIView(frame: inherited.bounds)
+            let captureView = PostHogTaggingTestSupport.makeFrameCaptureView()
+            captureView.frame = platformHost.bounds
+            platformHost.addSubview(captureView)
+            inherited.addSubview(platformHost)
+            host.addSubview(inherited)
+
+            let layers = PostHogTaggingTestSupport.targetLayers(fromCaptureView: captureView)
+
+            // Previously the reference frame was the whole hosting view, so
+            // contentOutside — a different mask's content — was collected too.
+            #expect(layers.elementsEqual([contentInside], by: ===))
+        }
+
+        @Test("iOS 26 layer scan: clipped subtrees outside the reference frame are pruned")
+        func layerScanPrunesClippedSubtrees() {
+            guard #available(iOS 26.0, *) else { return }
+
+            let referenceFrame = CGRect(x: 0, y: 0, width: 200, height: 200)
+            let root = CALayer()
+            root.frame = referenceFrame
+
+            // The clipped parent lies fully outside the reference frame; its child's
+            // absolute center falls inside, but masksToBounds means the child renders
+            // clipped away — collecting it would mask a region with no such content.
+            let clipped = CALayer()
+            clipped.frame = CGRect(x: 300, y: 300, width: 100, height: 100)
+            clipped.masksToBounds = true
+            let child = CALayer()
+            child.frame = CGRect(x: -250, y: -250, width: 50, height: 50)
+            clipped.addSublayer(child)
+            root.addSublayer(clipped)
+
+            let collected = PostHogTaggingTestSupport.contentLayers(under: root, containedIn: referenceFrame)
+            #expect(collected.isEmpty)
+        }
+
         @Test("coalescer resolves each dirty tagger exactly once per drain")
         func coalescerDrainsOncePerTagger() {
             let (anchor1, tagger1) = PostHogTaggingTestSupport.makeTagPair()

--- a/PostHogTests/PostHogMaskingCharacterizationTest.swift
+++ b/PostHogTests/PostHogMaskingCharacterizationTest.swift
@@ -241,7 +241,8 @@
             container.addSubview(plain)
             window.addSubview(container)
 
-            flagged.postHogNoCapture = true
+            let owner = NSObject()
+            flagged.setPostHogNoCapture(true, owner: ObjectIdentifier(owner))
 
             // A bare integration (no PostHogSDK attached) exercises the traversal
             // with all config-dependent heuristics off, isolating flag consumption.
@@ -262,12 +263,152 @@
             let contentLayer = CALayer()
             contentLayer.frame = CGRect(x: 30, y: 60, width: 80, height: 20)
             container.layer.addSublayer(contentLayer)
-            contentLayer.postHogNoCapture = true
+            let owner = NSObject()
+            contentLayer.setPostHogNoCapture(true, owner: ObjectIdentifier(owner))
 
             let integration = PostHogReplayIntegration()
             let rects = integration.debugMaskableRects(in: window)
 
             #expect(rects == [CGRect(x: 30, y: 60, width: 80, height: 20)])
+        }
+    }
+
+    /// Behavior tests for the ref-counted flag ownership and the re-resolution
+    /// coalescer — the two mechanisms that make overlapping masks safe (one mask's
+    /// teardown must not unmask targets still claimed by another) and hierarchy
+    /// churn affordable (one resolution per tagger per run-loop turn).
+    @Suite("SwiftUI masking ownership & coalescing", .serialized)
+    @MainActor
+    final class PostHogMaskOwnershipTest {
+        private func maskHandlers() -> (onChange: PostHogTagHandler, onRemove: PostHogTagHandler) {
+            (
+                onChange: { owner, views, layers in
+                    views.forEach { $0.setPostHogNoCapture(true, owner: owner) }
+                    layers.forEach { $0.setPostHogNoCapture(true, owner: owner) }
+                },
+                onRemove: { owner, views, layers in
+                    views.forEach { $0.setPostHogNoCapture(false, owner: owner) }
+                    layers.forEach { $0.setPostHogNoCapture(false, owner: owner) }
+                }
+            )
+        }
+
+        @Test("a view stays flagged until every owner releases it")
+        func overlappingOwnersOnView() {
+            let view = UIView()
+            let ownerA = NSObject()
+            let ownerB = NSObject()
+
+            view.setPostHogNoCapture(true, owner: ObjectIdentifier(ownerA))
+            view.setPostHogNoCapture(true, owner: ObjectIdentifier(ownerB))
+            #expect(view.postHogNoCapture)
+
+            view.setPostHogNoCapture(false, owner: ObjectIdentifier(ownerA))
+            #expect(view.postHogNoCapture, "still owned by B")
+
+            view.setPostHogNoCapture(false, owner: ObjectIdentifier(ownerB))
+            #expect(!view.postHogNoCapture)
+        }
+
+        @Test("a layer stays flagged until every owner releases it")
+        func overlappingOwnersOnLayer() {
+            let layer = CALayer()
+            let ownerA = NSObject()
+            let ownerB = NSObject()
+
+            layer.setPostHogNoCapture(true, owner: ObjectIdentifier(ownerA))
+            layer.setPostHogNoCapture(true, owner: ObjectIdentifier(ownerB))
+            layer.setPostHogNoCapture(false, owner: ObjectIdentifier(ownerB))
+            #expect(layer.postHogNoCapture)
+
+            layer.setPostHogNoCapture(false, owner: ObjectIdentifier(ownerA))
+            #expect(!layer.postHogNoCapture)
+        }
+
+        @Test("dismantling one of two overlapping masks keeps the shared target masked")
+        func overlappingMasksThroughMachinery() {
+            // Two real anchor/tagger sandwiches whose target sets both contain the
+            // shared view — the RC7 scenario where the Boolean flag used to let the
+            // first teardown unmask the survivor's target.
+            let (anchor1, tagger1) = PostHogTaggingTestSupport.makeTagPair()
+            let (anchor2, tagger2) = PostHogTaggingTestSupport.makeTagPair()
+            let root = UIView()
+            let shared = UIView()
+            root.addSubview(anchor1)
+            root.addSubview(anchor2)
+            root.addSubview(shared)
+            root.addSubview(tagger2)
+            root.addSubview(tagger1)
+
+            let handlers = maskHandlers()
+            let coordinator1 = PostHogTagView.Coordinator(onRemove: handlers.onRemove)
+            let coordinator2 = PostHogTagView.Coordinator(onRemove: handlers.onRemove)
+
+            resolveTagTargets(from: tagger1, coordinator: coordinator1, onChange: handlers.onChange)
+            resolveTagTargets(from: tagger2, coordinator: coordinator2, onChange: handlers.onChange)
+            #expect(shared.postHogNoCapture)
+
+            PostHogTagView.dismantleUIView(tagger2, coordinator: coordinator2)
+            #expect(shared.postHogNoCapture, "still owned by the first mask")
+
+            PostHogTagView.dismantleUIView(tagger1, coordinator: coordinator1)
+            #expect(!shared.postHogNoCapture)
+        }
+
+        @Test("re-resolution releases ownership on targets that dropped out")
+        func reconciliationReleasesDroppedTargets() {
+            let (anchor, tagger) = PostHogTaggingTestSupport.makeTagPair()
+            let root = UIView()
+            let keep = UIView()
+            let dropped = UIView()
+            root.addSubview(anchor)
+            root.addSubview(keep)
+            root.addSubview(dropped)
+            root.addSubview(tagger)
+
+            let handlers = maskHandlers()
+            let coordinator = PostHogTagView.Coordinator(onRemove: handlers.onRemove)
+
+            resolveTagTargets(from: tagger, coordinator: coordinator, onChange: handlers.onChange)
+            #expect(keep.postHogNoCapture)
+            #expect(dropped.postHogNoCapture)
+
+            // SwiftUI moves the view out of the sandwich; the next resolution must
+            // release this tagger's claim on it.
+            let elsewhere = UIView()
+            elsewhere.addSubview(dropped)
+            resolveTagTargets(from: tagger, coordinator: coordinator, onChange: handlers.onChange)
+
+            #expect(keep.postHogNoCapture)
+            #expect(!dropped.postHogNoCapture)
+        }
+
+        @Test("coalescer resolves each dirty tagger exactly once per drain")
+        func coalescerDrainsOncePerTagger() {
+            let (anchor1, tagger1) = PostHogTaggingTestSupport.makeTagPair()
+            let (anchor2, tagger2) = PostHogTaggingTestSupport.makeTagPair()
+            let root = UIView()
+            root.addSubview(anchor1)
+            root.addSubview(anchor2)
+            root.addSubview(tagger2)
+            root.addSubview(tagger1)
+
+            var resolutions1 = 0
+            var resolutions2 = 0
+            tagger1.handler = { resolutions1 += 1 }
+            tagger2.handler = { resolutions2 += 1 }
+
+            PostHogTagResolutionCoalescer.markDirty(tagger1)
+            PostHogTagResolutionCoalescer.markDirty(tagger1)
+            PostHogTagResolutionCoalescer.markDirty(tagger2)
+            PostHogTagResolutionCoalescer.markDirty(tagger1)
+            PostHogTagResolutionCoalescer.drainForTesting()
+
+            #expect(resolutions1 == 1)
+            #expect(resolutions2 == 1)
+
+            PostHogTagResolutionCoalescer.drainForTesting()
+            #expect(resolutions1 == 1, "drained set does not fire again")
         }
     }
 #endif

--- a/PostHogTests/PostHogMaskingCharacterizationTest.swift
+++ b/PostHogTests/PostHogMaskingCharacterizationTest.swift
@@ -12,9 +12,8 @@
     import UIKit
 
     /// Characterization tests pinning the CURRENT behavior of the SwiftUI masking
-    /// machinery: the tag-view traversal (`getTargetViews` and its helpers), the
-    /// iOS 26 content-layer collection, and the capture-side consumption of the
-    /// `postHogNoCapture` flag (`findMaskableWidgets`).
+    /// machinery: the tag-view traversal (`getTargetViews` and its helpers) and the
+    /// iOS 26 content-layer collection.
     ///
     /// These are golden tests: they encode what the SDK does today — including
     /// behaviors that are quirky but relied upon — so that the performance rework
@@ -227,50 +226,6 @@
 
             #expect(collected.elementsEqual([content, childInside], by: ===))
         }
-
-        // MARK: - Capture-side flag consumption
-
-        @Test("findMaskableWidgets returns the absolute rect of postHogNoCapture-flagged views, and only those")
-        func maskableRectsForFlaggedViews() {
-            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
-            let container = UIView(frame: window.bounds)
-            let flagged = UIView(frame: CGRect(x: 10, y: 20, width: 100, height: 40))
-            let plain = UIView(frame: CGRect(x: 10, y: 100, width: 100, height: 40))
-
-            container.addSubview(flagged)
-            container.addSubview(plain)
-            window.addSubview(container)
-
-            let owner = NSObject()
-            flagged.setPostHogNoCapture(true, owner: ObjectIdentifier(owner))
-
-            // A bare integration (no PostHogSDK attached) exercises the traversal
-            // with all config-dependent heuristics off, isolating flag consumption.
-            let integration = PostHogReplayIntegration()
-            let rects = integration.debugMaskableRects(in: window)
-
-            #expect(rects == [CGRect(x: 10, y: 20, width: 100, height: 40)])
-        }
-
-        @Test("iOS 26: findMaskableWidgets also returns rects for postHogNoCapture-flagged bare CALayers")
-        func maskableRectsForFlaggedLayers() throws {
-            guard #available(iOS 26.0, *) else { return }
-
-            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
-            let container = UIView(frame: window.bounds)
-            window.addSubview(container)
-
-            let contentLayer = CALayer()
-            contentLayer.frame = CGRect(x: 30, y: 60, width: 80, height: 20)
-            container.layer.addSublayer(contentLayer)
-            let owner = NSObject()
-            contentLayer.setPostHogNoCapture(true, owner: ObjectIdentifier(owner))
-
-            let integration = PostHogReplayIntegration()
-            let rects = integration.debugMaskableRects(in: window)
-
-            #expect(rects == [CGRect(x: 30, y: 60, width: 80, height: 20)])
-        }
     }
 
     /// Behavior tests for the ref-counted flag ownership and the re-resolution
@@ -283,12 +238,12 @@
         private func maskHandlers() -> (onChange: PostHogTagHandler, onRemove: PostHogTagHandler) {
             (
                 onChange: { owner, views, layers in
-                    views.forEach { $0.setPostHogNoCapture(true, owner: owner) }
-                    layers.forEach { $0.setPostHogNoCapture(true, owner: owner) }
+                    views.forEach { $0.setPostHogNoMask(true, owner: owner) }
+                    layers.forEach { $0.setPostHogNoMask(true, owner: owner) }
                 },
                 onRemove: { owner, views, layers in
-                    views.forEach { $0.setPostHogNoCapture(false, owner: owner) }
-                    layers.forEach { $0.setPostHogNoCapture(false, owner: owner) }
+                    views.forEach { $0.setPostHogNoMask(false, owner: owner) }
+                    layers.forEach { $0.setPostHogNoMask(false, owner: owner) }
                 }
             )
         }
@@ -299,15 +254,15 @@
             let ownerA = NSObject()
             let ownerB = NSObject()
 
-            view.setPostHogNoCapture(true, owner: ObjectIdentifier(ownerA))
-            view.setPostHogNoCapture(true, owner: ObjectIdentifier(ownerB))
-            #expect(view.postHogNoCapture)
+            view.setPostHogNoMask(true, owner: ObjectIdentifier(ownerA))
+            view.setPostHogNoMask(true, owner: ObjectIdentifier(ownerB))
+            #expect(view.postHogNoMask)
 
-            view.setPostHogNoCapture(false, owner: ObjectIdentifier(ownerA))
-            #expect(view.postHogNoCapture, "still owned by B")
+            view.setPostHogNoMask(false, owner: ObjectIdentifier(ownerA))
+            #expect(view.postHogNoMask, "still owned by B")
 
-            view.setPostHogNoCapture(false, owner: ObjectIdentifier(ownerB))
-            #expect(!view.postHogNoCapture)
+            view.setPostHogNoMask(false, owner: ObjectIdentifier(ownerB))
+            #expect(!view.postHogNoMask)
         }
 
         @Test("a layer stays flagged until every owner releases it")
@@ -316,13 +271,13 @@
             let ownerA = NSObject()
             let ownerB = NSObject()
 
-            layer.setPostHogNoCapture(true, owner: ObjectIdentifier(ownerA))
-            layer.setPostHogNoCapture(true, owner: ObjectIdentifier(ownerB))
-            layer.setPostHogNoCapture(false, owner: ObjectIdentifier(ownerB))
-            #expect(layer.postHogNoCapture)
+            layer.setPostHogNoMask(true, owner: ObjectIdentifier(ownerA))
+            layer.setPostHogNoMask(true, owner: ObjectIdentifier(ownerB))
+            layer.setPostHogNoMask(false, owner: ObjectIdentifier(ownerB))
+            #expect(layer.postHogNoMask)
 
-            layer.setPostHogNoCapture(false, owner: ObjectIdentifier(ownerA))
-            #expect(!layer.postHogNoCapture)
+            layer.setPostHogNoMask(false, owner: ObjectIdentifier(ownerA))
+            #expect(!layer.postHogNoMask)
         }
 
         @Test("dismantling one of two overlapping masks keeps the shared target masked")
@@ -346,13 +301,13 @@
 
             resolveTagTargets(from: tagger1, coordinator: coordinator1, onChange: handlers.onChange)
             resolveTagTargets(from: tagger2, coordinator: coordinator2, onChange: handlers.onChange)
-            #expect(shared.postHogNoCapture)
+            #expect(shared.postHogNoMask)
 
             PostHogTagView.dismantleUIView(tagger2, coordinator: coordinator2)
-            #expect(shared.postHogNoCapture, "still owned by the first mask")
+            #expect(shared.postHogNoMask, "still owned by the first mask")
 
             PostHogTagView.dismantleUIView(tagger1, coordinator: coordinator1)
-            #expect(!shared.postHogNoCapture)
+            #expect(!shared.postHogNoMask)
         }
 
         @Test("re-resolution releases ownership on targets that dropped out")
@@ -370,8 +325,8 @@
             let coordinator = PostHogTagView.Coordinator(onRemove: handlers.onRemove)
 
             resolveTagTargets(from: tagger, coordinator: coordinator, onChange: handlers.onChange)
-            #expect(keep.postHogNoCapture)
-            #expect(dropped.postHogNoCapture)
+            #expect(keep.postHogNoMask)
+            #expect(dropped.postHogNoMask)
 
             // SwiftUI moves the view out of the sandwich; the next resolution must
             // release this tagger's claim on it.
@@ -379,8 +334,8 @@
             elsewhere.addSubview(dropped)
             resolveTagTargets(from: tagger, coordinator: coordinator, onChange: handlers.onChange)
 
-            #expect(keep.postHogNoCapture)
-            #expect(!dropped.postHogNoCapture)
+            #expect(keep.postHogNoMask)
+            #expect(!dropped.postHogNoMask)
         }
 
         @Test("iOS 26 layer scan: reference frame is the masked view's own extent, not the hosting view's")
@@ -540,16 +495,11 @@
             #expect(PostHogSessionReplayMaskRegistry.shared.maskedRects(in: window).isEmpty)
         }
 
-        @Test("capture collection includes reporter rects alongside flag-tagged views")
+        @Test("capture collection includes live reporter rects")
         func captureCollectionIncludesReporters() {
             let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
             let container = UIView(frame: window.bounds)
             window.addSubview(container)
-
-            let flagged = UIView(frame: CGRect(x: 10, y: 20, width: 100, height: 40))
-            container.addSubview(flagged)
-            let owner = NSObject()
-            flagged.setPostHogNoCapture(true, owner: ObjectIdentifier(owner))
 
             let reporter = PostHogMaskReporterUIView(frame: CGRect(x: 10, y: 100, width: 100, height: 40))
             container.addSubview(reporter)
@@ -558,9 +508,7 @@
             let integration = PostHogReplayIntegration()
             let rects = integration.debugMaskableRects(in: window)
 
-            #expect(rects.contains(CGRect(x: 10, y: 20, width: 100, height: 40)), "flag-tagged view rect")
-            #expect(rects.contains(CGRect(x: 10, y: 100, width: 100, height: 40)), "reporter rect")
-            #expect(rects.count == 2)
+            #expect(rects == [CGRect(x: 10, y: 100, width: 100, height: 40)], "reporter rect flows through the capture collection")
         }
     }
 #endif

--- a/PostHogTests/PostHogMaskingCharacterizationTest.swift
+++ b/PostHogTests/PostHogMaskingCharacterizationTest.swift
@@ -161,6 +161,35 @@
             #expect(PostHogTaggingTestSupport.nearestCommonAncestor(of: UIView(), and: UIView()) == nil)
         }
 
+        @Test("quirk is asymmetric: receiver that IS an ancestor of the other resolves to itself")
+        func nearestCommonAncestorSelfIsAncestor() {
+            // The receiver's own chain starts at self, so when the receiver is a
+            // proper ancestor of the argument it returns itself — the opposite
+            // direction (see the quirk test above) skips one level up.
+            let root = UIView()
+            let mid = UIView()
+            let leaf = UIView()
+            root.addSubview(mid)
+            mid.addSubview(leaf)
+
+            #expect(PostHogTaggingTestSupport.nearestCommonAncestor(of: mid, and: leaf) === mid)
+        }
+
+        @Test("tagger nested inside the anchor's subtree resolves no targets")
+        func targetViewsTaggerInsideAnchor() {
+            // Degenerate shape (never produced by the real modifier): the common
+            // ancestor resolves to the anchor itself, and the anchor is not part
+            // of its own descendants — so the traversal never starts.
+            let (anchor, tagger) = PostHogTaggingTestSupport.makeTagPair()
+            let root = UIView()
+            let inner = UIView()
+            root.addSubview(anchor)
+            anchor.addSubview(inner)
+            inner.addSubview(tagger)
+
+            #expect(PostHogTaggingTestSupport.targetViews(from: tagger).isEmpty)
+        }
+
         // MARK: - iOS 26 content-layer collection
 
         @Test("content layers: collects sized, non-view-backed layers whose center is inside the reference frame")

--- a/PostHogTests/PostHogMaskingCharacterizationTest.swift
+++ b/PostHogTests/PostHogMaskingCharacterizationTest.swift
@@ -464,4 +464,103 @@
             #expect(resolutions1 == 1, "drained set does not fire again")
         }
     }
+
+    /// Behavior tests for the `postHogMask()` reporter registry: masked regions are
+    /// registered by lifecycle, read live at capture time, filtered per window, and
+    /// self-healing on missed teardown.
+    @Suite("Session replay mask registry", .serialized)
+    @MainActor
+    final class PostHogMaskRegistryTest {
+        @Test("reporter rects are read live at capture time, never cached")
+        func liveRects() {
+            let registry = PostHogSessionReplayMaskRegistry()
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+            let container = UIView(frame: window.bounds)
+            window.addSubview(container)
+            let reporter = UIView(frame: CGRect(x: 10, y: 20, width: 100, height: 40))
+            container.addSubview(reporter)
+
+            registry.register(reporter)
+            #expect(registry.maskedRects(in: window) == [CGRect(x: 10, y: 20, width: 100, height: 40)])
+
+            // Reposition without any registry interaction — the next read must see
+            // the current geometry (this is the property that keeps fast-scrolling
+            // content redacted at its actual position).
+            reporter.frame = CGRect(x: 30, y: 200, width: 50, height: 25)
+            #expect(registry.maskedRects(in: window) == [CGRect(x: 30, y: 200, width: 50, height: 25)])
+
+            registry.unregister(reporter)
+            #expect(registry.maskedRects(in: window).isEmpty)
+        }
+
+        @Test("reporters attached to other windows are excluded")
+        func windowFiltering() {
+            let registry = PostHogSessionReplayMaskRegistry()
+            let windowA = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+            let windowB = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+            let reporterA = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+            let reporterB = UIView(frame: CGRect(x: 5, y: 5, width: 10, height: 10))
+            windowA.addSubview(reporterA)
+            windowB.addSubview(reporterB)
+            registry.register(reporterA)
+            registry.register(reporterB)
+
+            #expect(registry.maskedRects(in: windowA) == [CGRect(x: 0, y: 0, width: 10, height: 10)])
+            #expect(registry.maskedRects(in: windowB) == [CGRect(x: 5, y: 5, width: 10, height: 10)])
+        }
+
+        @Test("deallocated reporters self-heal out of the registry")
+        func weakSelfHealing() {
+            let registry = PostHogSessionReplayMaskRegistry()
+            autoreleasepool {
+                let reporter = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+                registry.register(reporter)
+                #expect(registry.registeredCountForTesting == 1)
+            }
+            #expect(registry.registeredCountForTesting == 0)
+        }
+
+        @Test("reporter view registers on window attach, unregisters on detach and disable")
+        func reporterLifecycle() {
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+            let reporter = PostHogMaskReporterUIView(frame: CGRect(x: 10, y: 10, width: 50, height: 50))
+
+            #expect(PostHogSessionReplayMaskRegistry.shared.maskedRects(in: window).isEmpty)
+
+            window.addSubview(reporter)
+            #expect(PostHogSessionReplayMaskRegistry.shared.maskedRects(in: window) == [CGRect(x: 10, y: 10, width: 50, height: 50)])
+
+            reporter.isMaskingEnabled = false
+            #expect(PostHogSessionReplayMaskRegistry.shared.maskedRects(in: window).isEmpty)
+
+            reporter.isMaskingEnabled = true
+            #expect(PostHogSessionReplayMaskRegistry.shared.maskedRects(in: window).count == 1)
+
+            reporter.removeFromSuperview()
+            #expect(PostHogSessionReplayMaskRegistry.shared.maskedRects(in: window).isEmpty)
+        }
+
+        @Test("capture collection includes reporter rects alongside flag-tagged views")
+        func captureCollectionIncludesReporters() {
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+            let container = UIView(frame: window.bounds)
+            window.addSubview(container)
+
+            let flagged = UIView(frame: CGRect(x: 10, y: 20, width: 100, height: 40))
+            container.addSubview(flagged)
+            let owner = NSObject()
+            flagged.setPostHogNoCapture(true, owner: ObjectIdentifier(owner))
+
+            let reporter = PostHogMaskReporterUIView(frame: CGRect(x: 10, y: 100, width: 100, height: 40))
+            container.addSubview(reporter)
+            defer { reporter.removeFromSuperview() }
+
+            let integration = PostHogReplayIntegration()
+            let rects = integration.debugMaskableRects(in: window)
+
+            #expect(rects.contains(CGRect(x: 10, y: 20, width: 100, height: 40)), "flag-tagged view rect")
+            #expect(rects.contains(CGRect(x: 10, y: 100, width: 100, height: 40)), "reporter rect")
+            #expect(rects.count == 2)
+        }
+    }
 #endif

--- a/PostHogTests/PostHogMaskingCharacterizationTest.swift
+++ b/PostHogTests/PostHogMaskingCharacterizationTest.swift
@@ -1,0 +1,244 @@
+//
+//  PostHogMaskingCharacterizationTest.swift
+//  PostHog
+//
+//  Created by Jiri Urbasek on 16/07/2026.
+//
+
+#if os(iOS)
+    import Foundation
+    @testable import PostHog
+    import Testing
+    import UIKit
+
+    /// Characterization tests pinning the CURRENT behavior of the SwiftUI masking
+    /// machinery: the tag-view traversal (`getTargetViews` and its helpers), the
+    /// iOS 26 content-layer collection, and the capture-side consumption of the
+    /// `postHogNoCapture` flag (`findMaskableWidgets`).
+    ///
+    /// These are golden tests: they encode what the SDK does today — including
+    /// behaviors that are quirky but relied upon — so that the performance rework
+    /// of this machinery can prove it did not change resolution behavior. They are
+    /// intentionally written against synthetic UIKit hierarchies (not hosted
+    /// SwiftUI) so they are deterministic and OS-rendering independent.
+    ///
+    /// Known-buggy behaviors that these tests deliberately do NOT pin (they are
+    /// slated to change, with their own tests, in later commits): the Boolean
+    /// unmask-on-remove of overlapping masks (`postHogMask()`'s `onRemove`), and
+    /// the hosting-view-sized reference frame of the iOS 26 layer scan.
+    @Suite("SwiftUI masking characterization", .serialized)
+    @MainActor
+    final class PostHogMaskingCharacterizationTest {
+        // MARK: - getTargetViews
+
+        @Test("targets are the DFS pre-order views between anchor and tagger, excluding injected views")
+        func targetViewsFlatSandwich() {
+            let (anchor, tagger) = PostHogTaggingTestSupport.makeTagPair()
+
+            let root = UIView()
+            let contentA = UIView()
+            let childOfA = UIView()
+            let contentB = UIView()
+
+            contentA.addSubview(childOfA)
+            root.addSubview(anchor)
+            root.addSubview(contentA)
+            root.addSubview(contentB)
+            root.addSubview(tagger)
+
+            let targets = PostHogTaggingTestSupport.targetViews(from: tagger)
+
+            #expect(targets.count == 3)
+            #expect(targets.elementsEqual([contentA, childOfA, contentB], by: ===))
+        }
+
+        @Test("wrapper hosts: anchor-side wrapper is dropped by traversal order, tagger-side wrapper only if marked injected")
+        func targetViewsWrappedSandwich() {
+            let (anchor, tagger) = PostHogTaggingTestSupport.makeTagPair()
+
+            // Mirrors the structure the representables produce: anchor/tagger sit
+            // inside platform-host wrapper views, and `updateUIView` marks the
+            // wrapper (superview) as an injected view.
+            let root = UIView()
+            let anchorHost = UIView()
+            let stack = UIView()
+            let label1 = UIView()
+            let label2 = UIView()
+            let taggerHost = UIView()
+
+            anchorHost.addSubview(anchor)
+            stack.addSubview(label1)
+            stack.addSubview(label2)
+            taggerHost.addSubview(tagger)
+            root.addSubview(anchorHost)
+            root.addSubview(stack)
+            root.addSubview(taggerHost)
+
+            PostHogTaggingTestSupport.markInjected(anchor)
+            PostHogTaggingTestSupport.markInjected(tagger)
+
+            let targets = PostHogTaggingTestSupport.targetViews(from: tagger)
+
+            // anchorHost precedes the anchor in DFS order, so drop(while:) removes
+            // it; taggerHost was marked injected (as the representable would), so
+            // the filter removes it. What remains is the content in between.
+            #expect(targets.elementsEqual([stack, label1, label2], by: ===))
+        }
+
+        @Test("tagger without a hierarchy resolves no targets")
+        func targetViewsNotInHierarchy() {
+            let (_, tagger) = PostHogTaggingTestSupport.makeTagPair()
+
+            // Never added to a superview: the tagger's back-reference is only set
+            // in didMoveToSuperview, so anchor lookup fails.
+            #expect(PostHogTaggingTestSupport.targetViews(from: tagger).isEmpty)
+        }
+
+        @Test("anchor and tagger in disjoint trees resolve no targets")
+        func targetViewsDisjointTrees() {
+            let (anchor, tagger) = PostHogTaggingTestSupport.makeTagPair()
+
+            let treeA = UIView()
+            let treeB = UIView()
+            treeA.addSubview(anchor)
+            treeB.addSubview(tagger)
+
+            #expect(PostHogTaggingTestSupport.targetViews(from: tagger).isEmpty)
+        }
+
+        // MARK: - Traversal helpers
+
+        @Test("descendants enumerate in DFS pre-order, excluding the receiver")
+        func descendantsPreOrder() {
+            let root = UIView()
+            let a = UIView()
+            let a1 = UIView()
+            let a2 = UIView()
+            let b = UIView()
+            let b1 = UIView()
+
+            a.addSubview(a1)
+            a.addSubview(a2)
+            b.addSubview(b1)
+            root.addSubview(a)
+            root.addSubview(b)
+
+            let result = PostHogTaggingTestSupport.descendants(of: root)
+            #expect(result.elementsEqual([a, a1, a2, b, b1], by: ===))
+        }
+
+        @Test("nearest common ancestor of siblings is their parent")
+        func nearestCommonAncestorSiblings() {
+            let parent = UIView()
+            let a = UIView()
+            let b = UIView()
+            parent.addSubview(a)
+            parent.addSubview(b)
+
+            #expect(PostHogTaggingTestSupport.nearestCommonAncestor(of: a, and: b) === parent)
+        }
+
+        @Test("quirk: for ancestor/descendant pairs the result skips ABOVE the ancestor")
+        func nearestCommonAncestorAncestorDescendantQuirk() {
+            // `isDescendant(of:)` here excludes self (ancestors drops the first
+            // element), so walking up from the descendant never terminates AT the
+            // ancestor — it terminates one level above it. Pinned as-is: the real
+            // anchor/tagger pairs are never ancestor/descendant, so this quirk is
+            // dormant, but a traversal rewrite must not accidentally "fix" visible
+            // behavior while restructuring.
+            let root = UIView()
+            let mid = UIView()
+            let leaf = UIView()
+            root.addSubview(mid)
+            mid.addSubview(leaf)
+
+            #expect(PostHogTaggingTestSupport.nearestCommonAncestor(of: leaf, and: mid) === root)
+            #expect(PostHogTaggingTestSupport.nearestCommonAncestor(of: leaf, and: root) == nil)
+        }
+
+        @Test("nearest common ancestor of disjoint trees is nil")
+        func nearestCommonAncestorDisjoint() {
+            #expect(PostHogTaggingTestSupport.nearestCommonAncestor(of: UIView(), and: UIView()) == nil)
+        }
+
+        // MARK: - iOS 26 content-layer collection
+
+        @Test("content layers: collects sized, non-view-backed layers whose center is inside the reference frame")
+        func contentLayerCollection() throws {
+            guard #available(iOS 26.0, *) else { return }
+
+            let referenceFrame = CGRect(x: 0, y: 0, width: 200, height: 200)
+            let root = CALayer()
+            root.frame = referenceFrame
+
+            let content = CALayer()
+            content.frame = CGRect(x: 10, y: 10, width: 50, height: 50)
+            root.addSublayer(content)
+
+            let zeroSized = CALayer()
+            zeroSized.frame = .zero
+            root.addSublayer(zeroSized)
+
+            let viewBacked = CALayer()
+            viewBacked.frame = CGRect(x: 20, y: 100, width: 50, height: 50)
+            let backingView = UIView()
+            viewBacked.delegate = backingView
+            root.addSublayer(viewBacked)
+
+            // Center outside the reference frame -> not collected itself, but
+            // recursion continues into its children, which can still qualify.
+            let outside = CALayer()
+            outside.frame = CGRect(x: 150, y: 150, width: 300, height: 300)
+            let childInside = CALayer()
+            childInside.frame = CGRect(x: 0, y: 0, width: 20, height: 20) // absolute (150,150), center inside
+            outside.addSublayer(childInside)
+            root.addSublayer(outside)
+
+            let collected = PostHogTaggingTestSupport.contentLayers(under: root, containedIn: referenceFrame)
+
+            #expect(collected.elementsEqual([content, childInside], by: ===))
+        }
+
+        // MARK: - Capture-side flag consumption
+
+        @Test("findMaskableWidgets returns the absolute rect of postHogNoCapture-flagged views, and only those")
+        func maskableRectsForFlaggedViews() {
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+            let container = UIView(frame: window.bounds)
+            let flagged = UIView(frame: CGRect(x: 10, y: 20, width: 100, height: 40))
+            let plain = UIView(frame: CGRect(x: 10, y: 100, width: 100, height: 40))
+
+            container.addSubview(flagged)
+            container.addSubview(plain)
+            window.addSubview(container)
+
+            flagged.postHogNoCapture = true
+
+            // A bare integration (no PostHogSDK attached) exercises the traversal
+            // with all config-dependent heuristics off, isolating flag consumption.
+            let integration = PostHogReplayIntegration()
+            let rects = integration.debugMaskableRects(in: window)
+
+            #expect(rects == [CGRect(x: 10, y: 20, width: 100, height: 40)])
+        }
+
+        @Test("iOS 26: findMaskableWidgets also returns rects for postHogNoCapture-flagged bare CALayers")
+        func maskableRectsForFlaggedLayers() throws {
+            guard #available(iOS 26.0, *) else { return }
+
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+            let container = UIView(frame: window.bounds)
+            window.addSubview(container)
+
+            let contentLayer = CALayer()
+            contentLayer.frame = CGRect(x: 30, y: 60, width: 80, height: 20)
+            container.layer.addSublayer(contentLayer)
+            contentLayer.postHogNoCapture = true
+
+            let integration = PostHogReplayIntegration()
+            let rects = integration.debugMaskableRects(in: window)
+
+            #expect(rects == [CGRect(x: 30, y: 60, width: 80, height: 20)])
+        }
+    }
+#endif

--- a/PostHogTests/PostHogMaskingCharacterizationTest.swift
+++ b/PostHogTests/PostHogMaskingCharacterizationTest.swift
@@ -531,7 +531,7 @@
             window.layoutIfNeeded()
 
             let integration = PostHogReplayIntegration()
-            let rects = integration.debugMaskableRects(in: window)
+            let rects = integration.collectMaskableRects(in: window)
 
             #expect(rects == [CGRect(x: 10, y: 100, width: 100, height: 40)], "reporter rect flows through the capture collection")
         }
@@ -727,7 +727,6 @@
 
             let integration = PostHogReplayIntegration()
             #expect(integration.collectMaskableRects(in: window) == nil, "frame must be skipped, not captured under-masked")
-            #expect(integration.debugMaskableRects(in: window) == nil, "debug hook must preserve the skipped-frame signal")
 
             window.layoutIfNeeded()
             #expect(integration.collectMaskableRects(in: window) == [CGRect(x: 10, y: 100, width: 100, height: 40)])

--- a/PostHogTests/PostHogMaskingCharacterizationTest.swift
+++ b/PostHogTests/PostHogMaskingCharacterizationTest.swift
@@ -252,33 +252,47 @@
         @Test("a view stays flagged until every owner releases it")
         func overlappingOwnersOnView() {
             let view = UIView()
-            let ownerA = NSObject()
-            let ownerB = NSObject()
+            let ownerA = UIView()
+            let ownerB = UIView()
 
-            view.setPostHogNoMask(true, owner: ObjectIdentifier(ownerA))
-            view.setPostHogNoMask(true, owner: ObjectIdentifier(ownerB))
+            view.setPostHogNoMask(true, owner: ownerA)
+            view.setPostHogNoMask(true, owner: ownerB)
             #expect(view.postHogNoMask)
 
-            view.setPostHogNoMask(false, owner: ObjectIdentifier(ownerA))
+            view.setPostHogNoMask(false, owner: ownerA)
             #expect(view.postHogNoMask, "still owned by B")
 
-            view.setPostHogNoMask(false, owner: ObjectIdentifier(ownerB))
+            view.setPostHogNoMask(false, owner: ownerB)
             #expect(!view.postHogNoMask)
         }
 
         @Test("a layer stays flagged until every owner releases it")
         func overlappingOwnersOnLayer() {
             let layer = CALayer()
-            let ownerA = NSObject()
-            let ownerB = NSObject()
+            let ownerA = UIView()
+            let ownerB = UIView()
 
-            layer.setPostHogNoMask(true, owner: ObjectIdentifier(ownerA))
-            layer.setPostHogNoMask(true, owner: ObjectIdentifier(ownerB))
-            layer.setPostHogNoMask(false, owner: ObjectIdentifier(ownerB))
+            layer.setPostHogNoMask(true, owner: ownerA)
+            layer.setPostHogNoMask(true, owner: ownerB)
+            layer.setPostHogNoMask(false, owner: ownerB)
             #expect(layer.postHogNoMask)
 
-            layer.setPostHogNoMask(false, owner: ObjectIdentifier(ownerA))
+            layer.setPostHogNoMask(false, owner: ownerA)
             #expect(!layer.postHogNoMask)
+        }
+
+        @Test("a dead owner's claim self-heals instead of flagging the target forever")
+        func deadOwnerClaimSelfHeals() {
+            let view = UIView()
+            weak var probe: UIView?
+            autoreleasepool {
+                let owner = UIView()
+                probe = owner
+                view.setPostHogNoMask(true, owner: owner)
+                #expect(view.postHogNoMask)
+            }
+            #expect(probe == nil, "owner must be deallocated for this test to be meaningful")
+            #expect(!view.postHogNoMask, "a claim must not outlive its owner")
         }
 
         @Test("dismantling one of two overlapping masks keeps the shared target masked")

--- a/PostHogTests/PostHogMaskingCharacterizationTest.swift
+++ b/PostHogTests/PostHogMaskingCharacterizationTest.swift
@@ -325,6 +325,49 @@
             #expect(!shared.postHogNoMask)
         }
 
+        @Test("an empty re-resolution releases all previously claimed targets")
+        func emptyResolutionReleasesAllClaims() {
+            let (anchor, tagger) = PostHogTaggingTestSupport.makeTagPair()
+            let root = UIView()
+            let target = UIView()
+            root.addSubview(anchor)
+            root.addSubview(target)
+            root.addSubview(tagger)
+
+            let handlers = maskHandlers()
+            let coordinator = PostHogTagView.Coordinator(onRemove: handlers.onRemove)
+
+            resolveTagTargets(from: tagger, coordinator: coordinator, onChange: handlers.onChange)
+            #expect(target.postHogNoMask)
+
+            // Break the sandwich (anchor gone → resolution is empty) while the tagger
+            // stays alive: the recycled target must not keep the stale no-mask claim.
+            anchor.removeFromSuperview()
+            resolveTagTargets(from: tagger, coordinator: coordinator, onChange: handlers.onChange)
+            #expect(!target.postHogNoMask, "stale claim would mark recycled content safe to record")
+            #expect(coordinator.cachedTargets.isEmpty)
+        }
+
+        @Test("reconcileAndEmit releases dropped layers on an empty resolution without emitting")
+        func reconcileAndEmitEmptyLayerResolution() {
+            let owner = UIView()
+            let previous = [CALayer(), CALayer()]
+            var removed: [CALayer] = []
+            var changed = false
+
+            let cache = reconcileAndEmit(
+                owner: owner,
+                resolved: [CALayer](),
+                previous: previous,
+                onRemove: { _, dropped in removed = dropped },
+                onChange: { _, _ in changed = true }
+            )
+
+            #expect(removed.count == 2)
+            #expect(!changed, "onChange must not fire for an empty resolution")
+            #expect(cache.isEmpty)
+        }
+
         @Test("re-resolution releases ownership on targets that dropped out")
         func reconciliationReleasesDroppedTargets() {
             let (anchor, tagger) = PostHogTaggingTestSupport.makeTagPair()

--- a/PostHogTests/PostHogMaskingCharacterizationTest.swift
+++ b/PostHogTests/PostHogMaskingCharacterizationTest.swift
@@ -8,6 +8,7 @@
 #if os(iOS)
     import Foundation
     @testable import PostHog
+    import SwiftUI
     import Testing
     import UIKit
 
@@ -432,20 +433,22 @@
             let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
             let container = UIView(frame: window.bounds)
             window.addSubview(container)
-            let reporter = UIView(frame: CGRect(x: 10, y: 20, width: 100, height: 40))
+            let reporter = PostHogMaskReporterUIView(frame: CGRect(x: 10, y: 20, width: 100, height: 40))
             container.addSubview(reporter)
+            defer { reporter.removeFromSuperview() }
+            window.layoutIfNeeded()
 
             registry.register(reporter)
-            #expect(registry.maskedRects(in: window) == [CGRect(x: 10, y: 20, width: 100, height: 40)])
+            #expect(registry.maskedRects(in: window).rects == [CGRect(x: 10, y: 20, width: 100, height: 40)])
 
             // Reposition without any registry interaction — the next read must see
             // the current geometry (this is the property that keeps fast-scrolling
             // content redacted at its actual position).
             reporter.frame = CGRect(x: 30, y: 200, width: 50, height: 25)
-            #expect(registry.maskedRects(in: window) == [CGRect(x: 30, y: 200, width: 50, height: 25)])
+            #expect(registry.maskedRects(in: window).rects == [CGRect(x: 30, y: 200, width: 50, height: 25)])
 
             registry.unregister(reporter)
-            #expect(registry.maskedRects(in: window).isEmpty)
+            #expect(registry.maskedRects(in: window).rects.isEmpty)
         }
 
         @Test("reporters attached to other windows are excluded")
@@ -453,22 +456,28 @@
             let registry = PostHogSessionReplayMaskRegistry()
             let windowA = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
             let windowB = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
-            let reporterA = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
-            let reporterB = UIView(frame: CGRect(x: 5, y: 5, width: 10, height: 10))
+            let reporterA = PostHogMaskReporterUIView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+            let reporterB = PostHogMaskReporterUIView(frame: CGRect(x: 5, y: 5, width: 10, height: 10))
             windowA.addSubview(reporterA)
             windowB.addSubview(reporterB)
+            defer {
+                reporterA.removeFromSuperview()
+                reporterB.removeFromSuperview()
+            }
+            windowA.layoutIfNeeded()
+            windowB.layoutIfNeeded()
             registry.register(reporterA)
             registry.register(reporterB)
 
-            #expect(registry.maskedRects(in: windowA) == [CGRect(x: 0, y: 0, width: 10, height: 10)])
-            #expect(registry.maskedRects(in: windowB) == [CGRect(x: 5, y: 5, width: 10, height: 10)])
+            #expect(registry.maskedRects(in: windowA).rects == [CGRect(x: 0, y: 0, width: 10, height: 10)])
+            #expect(registry.maskedRects(in: windowB).rects == [CGRect(x: 5, y: 5, width: 10, height: 10)])
         }
 
         @Test("deallocated reporters self-heal out of the registry")
         func weakSelfHealing() {
             let registry = PostHogSessionReplayMaskRegistry()
             autoreleasepool {
-                let reporter = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+                let reporter = PostHogMaskReporterUIView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
                 registry.register(reporter)
                 #expect(registry.registeredCountForTesting == 1)
             }
@@ -480,19 +489,20 @@
             let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
             let reporter = PostHogMaskReporterUIView(frame: CGRect(x: 10, y: 10, width: 50, height: 50))
 
-            #expect(PostHogSessionReplayMaskRegistry.shared.maskedRects(in: window).isEmpty)
+            #expect(PostHogSessionReplayMaskRegistry.shared.maskedRects(in: window).rects.isEmpty)
 
             window.addSubview(reporter)
-            #expect(PostHogSessionReplayMaskRegistry.shared.maskedRects(in: window) == [CGRect(x: 10, y: 10, width: 50, height: 50)])
+            window.layoutIfNeeded()
+            #expect(PostHogSessionReplayMaskRegistry.shared.maskedRects(in: window).rects == [CGRect(x: 10, y: 10, width: 50, height: 50)])
 
             reporter.isMaskingEnabled = false
-            #expect(PostHogSessionReplayMaskRegistry.shared.maskedRects(in: window).isEmpty)
+            #expect(PostHogSessionReplayMaskRegistry.shared.maskedRects(in: window).rects.isEmpty)
 
             reporter.isMaskingEnabled = true
-            #expect(PostHogSessionReplayMaskRegistry.shared.maskedRects(in: window).count == 1)
+            #expect(PostHogSessionReplayMaskRegistry.shared.maskedRects(in: window).rects.count == 1)
 
             reporter.removeFromSuperview()
-            #expect(PostHogSessionReplayMaskRegistry.shared.maskedRects(in: window).isEmpty)
+            #expect(PostHogSessionReplayMaskRegistry.shared.maskedRects(in: window).rects.isEmpty)
         }
 
         @Test("capture collection includes live reporter rects")
@@ -504,11 +514,209 @@
             let reporter = PostHogMaskReporterUIView(frame: CGRect(x: 10, y: 100, width: 100, height: 40))
             container.addSubview(reporter)
             defer { reporter.removeFromSuperview() }
+            window.layoutIfNeeded()
 
             let integration = PostHogReplayIntegration()
             let rects = integration.debugMaskableRects(in: window)
 
             #expect(rects == [CGRect(x: 10, y: 100, width: 100, height: 40)], "reporter rect flows through the capture collection")
+        }
+
+        // MARK: - Pre-first-layout gap (fail closed)
+
+        @Test("a reporter completes its first layout even at zero size")
+        func zeroSizeReporterCompletesFirstLayout() {
+            // A zero-sized view must still get a layout pass, or it would flag the
+            // window unsettled forever and block snapshots.
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+            let reporter = PostHogMaskReporterUIView(frame: .zero)
+            #expect(!reporter.hasCompletedFirstLayout)
+
+            window.addSubview(reporter)
+            defer { reporter.removeFromSuperview() }
+            window.layoutIfNeeded()
+
+            #expect(reporter.hasCompletedFirstLayout)
+        }
+
+        @Test("a pre-layout reporter marks the window unsettled instead of being dropped")
+        func preLayoutReporterMarksUnsettled() {
+            let registry = PostHogSessionReplayMaskRegistry()
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+            let reporter = PostHogMaskReporterUIView(frame: CGRect(x: 10, y: 20, width: 100, height: 40))
+            window.addSubview(reporter)
+            defer { reporter.removeFromSuperview() }
+            registry.register(reporter)
+
+            // Registered but not laid out yet: dropping it silently would leave the
+            // region unmasked.
+            let beforeLayout = registry.maskedRects(in: window)
+            #expect(beforeLayout.hasUnsettledReporters)
+            #expect(beforeLayout.rects.isEmpty)
+
+            window.layoutIfNeeded()
+            let afterLayout = registry.maskedRects(in: window)
+            #expect(!afterLayout.hasUnsettledReporters)
+            #expect(afterLayout.rects == [CGRect(x: 10, y: 20, width: 100, height: 40)])
+        }
+
+        @Test("a zero-sized reporter that has been laid out does not block snapshots")
+        func laidOutZeroSizeReporterDoesNotBlock() {
+            let registry = PostHogSessionReplayMaskRegistry()
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+            let reporter = PostHogMaskReporterUIView(frame: .zero)
+            window.addSubview(reporter)
+            defer { reporter.removeFromSuperview() }
+            window.layoutIfNeeded()
+            registry.register(reporter)
+
+            let result = registry.maskedRects(in: window)
+            #expect(!result.hasUnsettledReporters, "legitimately empty view must not stall capture")
+            #expect(result.rects.isEmpty)
+        }
+
+        @Test("an unsettled reporter in another window does not block this window")
+        func unsettledReporterInOtherWindowDoesNotBlock() {
+            // Guard-order pin: the window filter must precede the settled check, or a
+            // side window realizing content would stall the foreground window's capture.
+            let registry = PostHogSessionReplayMaskRegistry()
+            let windowA = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+            let windowB = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+
+            let settled = PostHogMaskReporterUIView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+            windowA.addSubview(settled)
+            defer { settled.removeFromSuperview() }
+            windowA.layoutIfNeeded()
+
+            let unsettled = PostHogMaskReporterUIView(frame: CGRect(x: 5, y: 5, width: 10, height: 10))
+            windowB.addSubview(unsettled)
+            defer { unsettled.removeFromSuperview() }
+            // no layout pass in windowB
+
+            registry.register(settled)
+            registry.register(unsettled)
+
+            let resultA = registry.maskedRects(in: windowA)
+            #expect(!resultA.hasUnsettledReporters)
+            #expect(resultA.rects == [CGRect(x: 0, y: 0, width: 10, height: 10)])
+
+            #expect(registry.maskedRects(in: windowB).hasUnsettledReporters)
+        }
+
+        @Test("a hidden pre-layout reporter does not mark the window unsettled")
+        func hiddenPreLayoutReporterDoesNotMarkUnsettled() {
+            // Hidden content isn't rendered, so it must not stall the frame even pre-layout.
+            let registry = PostHogSessionReplayMaskRegistry()
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+            let reporter = PostHogMaskReporterUIView(frame: CGRect(x: 10, y: 20, width: 100, height: 40))
+            reporter.isHidden = true
+            window.addSubview(reporter)
+            defer { reporter.removeFromSuperview() }
+            registry.register(reporter)
+
+            let result = registry.maskedRects(in: window)
+            #expect(!result.hasUnsettledReporters)
+            #expect(result.rects.isEmpty)
+        }
+
+        @Test("an alpha-zero pre-layout reporter does not mark the window unsettled")
+        func alphaZeroPreLayoutReporterDoesNotMarkUnsettled() {
+            // Pins the other half of the visibility guard order (see the hidden test).
+            let registry = PostHogSessionReplayMaskRegistry()
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+            let reporter = PostHogMaskReporterUIView(frame: CGRect(x: 10, y: 20, width: 100, height: 40))
+            reporter.alpha = 0
+            window.addSubview(reporter)
+            defer { reporter.removeFromSuperview() }
+            registry.register(reporter)
+
+            let result = registry.maskedRects(in: window)
+            #expect(!result.hasUnsettledReporters)
+            #expect(result.rects.isEmpty)
+        }
+
+        @Test("same-window re-adds (cell reuse) keep the reporter settled")
+        func sameWindowReaddKeepsSettled() {
+            // Cell reuse re-fires didMoveToWindow on every recycle; resetting there
+            // would skip capture ticks throughout a scroll gesture.
+            let registry = PostHogSessionReplayMaskRegistry()
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+            let reporter = PostHogMaskReporterUIView(frame: CGRect(x: 10, y: 20, width: 100, height: 40))
+            window.addSubview(reporter)
+            defer { reporter.removeFromSuperview() }
+            window.layoutIfNeeded()
+            registry.register(reporter)
+            #expect(reporter.hasCompletedFirstLayout)
+
+            reporter.removeFromSuperview()
+            window.addSubview(reporter)
+
+            let result = registry.maskedRects(in: window)
+            #expect(!result.hasUnsettledReporters)
+            #expect(result.rects == [CGRect(x: 10, y: 20, width: 100, height: 40)])
+        }
+
+        @Test("reattaching to a window requires a fresh layout pass before the reporter settles")
+        func reattachmentRequiresFreshLayout() {
+            let registry = PostHogSessionReplayMaskRegistry()
+            let windowA = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+            let windowB = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+            let reporter = PostHogMaskReporterUIView(frame: CGRect(x: 10, y: 20, width: 100, height: 40))
+            windowA.addSubview(reporter)
+            defer { reporter.removeFromSuperview() }
+            windowA.layoutIfNeeded()
+            registry.register(reporter)
+            #expect(reporter.hasCompletedFirstLayout)
+
+            // Old-window geometry is stale: fail closed until the new window lays it out.
+            windowB.addSubview(reporter)
+            #expect(!reporter.hasCompletedFirstLayout)
+            #expect(registry.maskedRects(in: windowB).hasUnsettledReporters)
+
+            windowB.layoutIfNeeded()
+            let settled = registry.maskedRects(in: windowB)
+            #expect(!settled.hasUnsettledReporters)
+            #expect(settled.rects == [CGRect(x: 10, y: 20, width: 100, height: 40)])
+        }
+
+        @Test("a SwiftUI-hosted zero-sized mask settles after the hosting layout pass")
+        func swiftUIHostedZeroSizeMaskSettles() {
+            // Pins that real SwiftUI hosting delivers a first layout pass even to a
+            // zero-sized masked view.
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+            let baselineCount = PostHogSessionReplayMaskRegistry.shared.registeredCountForTesting
+            let host = UIHostingController(rootView: Color.clear.frame(width: 0, height: 0).postHogMask())
+            window.rootViewController = host
+            window.isHidden = false
+            defer {
+                window.isHidden = true
+                window.rootViewController = nil
+            }
+            window.layoutIfNeeded()
+
+            // Non-vacuity: exactly this test's reporter must have registered.
+            #expect(PostHogSessionReplayMaskRegistry.shared.registeredCountForTesting == baselineCount + 1)
+            #expect(!PostHogSessionReplayMaskRegistry.shared.maskedRects(in: window).hasUnsettledReporters)
+        }
+
+        @Test("capture collection skips the frame while a reporter is unsettled")
+        func captureCollectionSkipsUnsettledFrame() {
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+            let container = UIView(frame: window.bounds)
+            window.addSubview(container)
+            window.layoutIfNeeded()
+
+            // Like a lazy row: attaching registers the reporter before any layout pass.
+            let reporter = PostHogMaskReporterUIView(frame: CGRect(x: 10, y: 100, width: 100, height: 40))
+            container.addSubview(reporter)
+            defer { reporter.removeFromSuperview() }
+
+            let integration = PostHogReplayIntegration()
+            #expect(integration.collectMaskableRects(in: window) == nil, "frame must be skipped, not captured under-masked")
+            #expect(integration.debugMaskableRects(in: window) == nil, "debug hook must preserve the skipped-frame signal")
+
+            window.layoutIfNeeded()
+            #expect(integration.collectMaskableRects(in: window) == [CGRect(x: 10, y: 100, width: 100, height: 40)])
         }
     }
 #endif

--- a/PostHogTests/PostHogMulticastCallbackTest.swift
+++ b/PostHogTests/PostHogMulticastCallbackTest.swift
@@ -288,4 +288,78 @@ class PostHogThrottledMulticastCallbackTests {
         #expect(callCount == 1)
         _ = token
     }
+
+    @Test("Invoke without subscribers is a safe no-op")
+    func invokeWithoutSubscribers() async {
+        let callback = PostHogThrottledMulticastCallback<Int>()
+
+        callback.invoke(1)
+        try? await Task.sleep(nanoseconds: 50 * NSEC_PER_MSEC)
+
+        #expect(callback.subscriberCount == 0)
+    }
+
+    @Test("Subscriber added during another subscriber's throttle window fires immediately")
+    func lateSubscriberFiresImmediately() async {
+        let mockNow = MockDate()
+        now = { mockNow.date }
+        defer { now = { Date() } }
+
+        let callback = PostHogThrottledMulticastCallback<Int>()
+        var slowValues: [Int] = []
+        var lateValues: [Int] = []
+        let lock = NSLock()
+
+        let slowToken = callback.subscribe(throttle: 10.0) { value in
+            lock.withLock { slowValues.append(value) }
+        }
+
+        callback.invoke(1)
+        try? await Task.sleep(nanoseconds: 50 * NSEC_PER_MSEC)
+        #expect(lock.withLock { slowValues } == [1])
+
+        // Deep inside the slow subscriber's throttle window, a new subscriber
+        // appears. It must receive the very next invoke — the eligibility gate
+        // may not suppress it based on the slow subscriber's window.
+        mockNow.date.addTimeInterval(1.0)
+        let lateToken = callback.subscribe(throttle: 1.0) { value in
+            lock.withLock { lateValues.append(value) }
+        }
+
+        callback.invoke(2)
+        try? await Task.sleep(nanoseconds: 50 * NSEC_PER_MSEC)
+        #expect(lock.withLock { lateValues } == [2])
+        #expect(lock.withLock { slowValues } == [1], "still inside its 10s window")
+
+        _ = (slowToken, lateToken)
+    }
+
+    @Test("Resubscribing after all tokens deallocated fires again")
+    func resubscribeAfterEmpty() async {
+        let callback = PostHogThrottledMulticastCallback<Int>()
+        var firstValues: [Int] = []
+        var secondValues: [Int] = []
+        let lock = NSLock()
+
+        var token: RegistrationToken? = callback.subscribe(throttle: 0) { value in
+            lock.withLock { firstValues.append(value) }
+        }
+        callback.invoke(1)
+        try? await Task.sleep(nanoseconds: 50 * NSEC_PER_MSEC)
+        #expect(lock.withLock { firstValues } == [1])
+
+        token = nil
+        callback.invoke(2)
+        try? await Task.sleep(nanoseconds: 50 * NSEC_PER_MSEC)
+
+        token = callback.subscribe(throttle: 0) { value in
+            lock.withLock { secondValues.append(value) }
+        }
+        callback.invoke(3)
+        try? await Task.sleep(nanoseconds: 50 * NSEC_PER_MSEC)
+
+        #expect(lock.withLock { firstValues } == [1])
+        #expect(lock.withLock { secondValues } == [3])
+        _ = token
+    }
 }

--- a/PostHogTests/PostHogRageClickIntegrationTest.swift
+++ b/PostHogTests/PostHogRageClickIntegrationTest.swift
@@ -261,7 +261,8 @@
         func viewMarkedByFlagIsIneligible() {
             let integration = PostHogRageClickIntegration()
             let view = UIView()
-            view.postHogNoRageClick = true
+            let owner = NSObject()
+            view.setPostHogNoRageClick(true, owner: ObjectIdentifier(owner))
 
             #expect(integration.isRageClickIneligibleForTesting(view: view))
         }

--- a/PostHogTests/PostHogRageClickIntegrationTest.swift
+++ b/PostHogTests/PostHogRageClickIntegrationTest.swift
@@ -261,8 +261,8 @@
         func viewMarkedByFlagIsIneligible() {
             let integration = PostHogRageClickIntegration()
             let view = UIView()
-            let owner = NSObject()
-            view.setPostHogNoRageClick(true, owner: ObjectIdentifier(owner))
+            let owner = UIView()
+            view.setPostHogNoRageClick(true, owner: owner)
 
             #expect(integration.isRageClickIneligibleForTesting(view: view))
         }


### PR DESCRIPTION
## :bulb: Motivation and Context

Fixes https://github.com/PostHog/posthog-ios/issues/727.

Per-row `postHogMask()` in SwiftUI lazy lists causes launch hangs and scroll hitching on iOS 26: masking metadata is computed at **layout frequency** (whole-screen traversals + root-scoped KVO per mask) but only consumed at **capture frequency** (~1/s, as redaction rects). On iOS 26 the injected tag views' common ancestor degenerates to the hosting view, making the work effectively O(N²) while scrolling. Traces in the linked issue; self-contained repro/benchmark app: https://github.com/ibru/PostHogMaskingReproMinimal.

Six stacked commits — the first five make the existing mechanism correct and affordable, the last replaces it for `postHogMask()` (details in each commit message):

1. `test(replay)`: characterization tests pinning current resolution behavior + DEBUG rect-introspection hooks (no behavior change).
2. `fix`: stop allocating a `DispatchQueue` per `layoutSublayers` call; skip idle dispatches entirely.
3. `fix`: iterative DFS traversal replaces the `recursiveSequence`/`AnyIterator` chains; `nearestCommonAncestor` O(depth²) → O(depth).
4. `fix`: flag ownership becomes ref-counted (one mask's teardown could unmask another's targets — latent privacy bug) and re-tagging coalesces to one drain per run-loop turn.
5. `fix`: iOS 26 layer scan bounded to the masked view's own extent, with clipped-subtree pruning.
6. `feat(replay)`: `postHogMask()` reports its region via a single passive overlay in a weak registry; the capture path reads live rects at snapshot time. Zero traversals/KVO/per-layout work, rects can never go stale, and it's OS-rendering agnostic — resolving the modifier's documented iOS 26 caveat. `postHogNoMask()`/`postHogNoRageClick()` stay on the tag-view path.

Relation to #335 (Snapshot mode v2): complementary — v2 reworks the capture side, this removes the tagging-side cost. The registry exposes live sensitive regions with no rendering decisions baked in, so a v2 compositor can consume it directly.

Three deliberate behavior changes, all failing closed: masks no longer collect content **outside their own extent** (previously over-collection); an explicit `postHogMask()` now wins inside a `postHogNoMask()` area; and in recordings a masked view is redacted across its **full extent** — previously on iOS 26 only the text/image layers the scan happened to discover inside it were redacted (an OS-specific artifact that could also under-redact whenever the layer mapping missed). Redaction now matches the API contract — what you mask is what's redacted — and is identical across OS versions.

**Known limitation**: full-extent redaction is coarser than before — a `postHogMask()` on a container (e.g. a list row) now blacks out the whole container in replays, not just the text/images inside it, which reduces replay fidelity for apps that masked containers. Workaround: apply `postHogMask()` to the sensitive subviews instead — the registry makes per-subview masks cheap, and redaction then hugs exactly those elements. A possible SDK-side follow-up is a snapshot-time pass that intersects recognized text/image layers with reporter extents and falls back to the full extent when nothing is recognized (fail-closed, unlike the old scan); and under #335's view-by-view compositor consuming this registry, content-shaped redaction inside masked regions comes back naturally, making this a transitional artifact.

**Remaining scope**: `postHogNoMask()` and `postHogNoRageClick()` intentionally stay on the tag-view traversal — they're subtractive, per-element flags (exempt *this* element from heuristics / rage-click detection), which an additive rect registry can't express without region subtraction. The traversal they ride is now iterative, extent-bounded, and coalesced to one drain per run-loop turn, but on iOS 26 it still resolves against the shared hosting view, so a screen unrealistically dense with these two modifiers would see a much smaller version of the original cost. If that ever matters in practice, there's a natural follow-up that finishes the job inside the current architecture: deduplicate the ancestor KVO observers (N observers on the same layer → one shared observer) and have the coalescer do a single shared walk per ancestor per drain, slicing each resolver's targets from one pass — O(subtree + N) per turn instead of O(N × subtree). Happy to do that as a separate PR if you want it.

## :shield: Regression safety

This machinery had no existing test coverage and protects user privacy, so the stack is built on proving behavior preservation:

- **Characterization first**: golden tests pinning current resolution semantics (DFS order, common-ancestor quirks, iOS 26 layer collection, flag consumption) landed before any change; every later edge-case pin was run green against the **old** implementation before the rewrite had to pass the identical suite.
- **Output-level verification**: a DEBUG hook exposes the production redaction-rect collection; the repro app dumps normalized rect lists with deterministic digests — byte-identical through commits 2–5. Commit 6 intentionally changes rect shapes (full mask extents), so there the proof is coverage: overlay screenshots per commit show equal-or-stronger redaction, zero rects on the unmasked baseline.
- **Fail-closed defaults**: first-attach resolution stays synchronous (fresh rows are flagged before they can be captured); the coalescer batches re-resolutions but never drops them; owner-set flags can only over-mask during teardown races; the weak registry self-heals a missed dismantle to "gone", never to "stale rect".
- **Bisectable stack**: each commit was verified before the next was built on it (targeted suites per commit, full suite at the riskiest points).

## :green_heart: How did you test it?

- Unit suites (Swift Testing): masking characterization (15), ownership & coalescing (7), mask registry (5), throttled-multicast gate regressions (3). **Full suite: 653 tests, green.**
- Repro app: DEBUG overlay + rect dumps on every commit, as above.
- Performance (iPhone 12, iOS 26, Release), Time Profiler + Hangs on the repro app's pathological screen (cold launch + sustained scrolling), before (upstream `main` @ `b0fa428`) vs. after (this branch):
  - **Before**: a dozen-plus hangs flagged across the session; heaviest stack has **2.87 s (55.4%) of the sampled main-thread window under `PostHogFrameCaptureUIView.init(id:handler:)`**, `getTargetViews(from:)` at 2.81 s (54.3%), `recursiveSequence`/`AnyIterator` iterator chains at ~2.68 s (51.6%).
  - **After**: **zero hangs recorded**; the heaviest stacks are SwiftUI's own layout (`AG::Graph::UpdateStack::update()` 850 ms, `LazyStack.place` 538 ms) — **no PostHog frame appears in the heaviest stack trace at all**. Screenshots: [before](https://raw.githubusercontent.com/ibru/PostHogMaskingReproMinimal/main/docs/repro-before.png) / [after](https://raw.githubusercontent.com/ibru/PostHogMaskingReproMinimal/main/docs/repro-after.png); full `.trace` files available on request.
- Real replay (real project token, iPhone 12, same app, `main` vs. this branch): recordings verified in the PostHog player. Before: only the discovered text layers render redacted ([recording](https://us.posthog.com/shared/FGtto_gzyEGs4PYv8dQ-PtkToZq81Q?t=17), [screenshot](https://raw.githubusercontent.com/ibru/PostHogMaskingReproMinimal/main/docs/replay-before-fix.png)); after: each masked view renders redacted across its full extent (the behavior change above) — everything redacted before remains redacted ([recording](https://us.posthog.com/shared/7uztRb6AnIlPZ7YYLT2ToAnubFYQCw?t=3), [screenshot](https://raw.githubusercontent.com/ibru/PostHogMaskingReproMinimal/main/docs/replay-after-fix.png)). Masked rows stay redacted throughout the session, including while scrolling.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed. *(modifier doc comments updated — the iOS 26 caveat is resolved)*
- [ ] No breaking change or entry added to the changelog. *(the behavior notes above should get a changelog entry — happy to add in your preferred format)*

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file *(will add before merge)*

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigation, fix design, and implementation were directed by the PR author with a human in the loop throughout. Implementation was driven with **Claude Code (Fable)** (trace analysis, characterization tests, fix implementation, repro-app tooling); the analysis and fix plan were independently reviewed with **ChatGPT (Sol)**. Key decisions — characterization-first, ref-counted ownership as a prerequisite for coalescing, synchronous first-attach resolution, the capture-agnostic registry design composing with #335 — were made and reviewed by the author. All verification steps described above were actually run; profiling numbers were measured by the author.

