### PR TITLE
feat(surveys): add displaySurvey to show a survey on demand

### DIFF
--- a/.changeset/display-survey-manual-api.md
+++ b/.changeset/display-survey-manual-api.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": minor
+---
+
+Add `PostHogSDK.shared.displaySurvey(surveyId)` to display a survey on demand, bypassing display conditions (targeting flags, event triggers, and seen/wait-period checks). This is the mobile counterpart of the web SDK's `posthog.displaySurvey()` and also enables API-type surveys, which are never auto-displayed.

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -551,6 +551,7 @@
 		DAB9F6C42D6C49BB00A988A1 /* ApplicationEventPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB9F6C32D6C49B300A988A1 /* ApplicationEventPublisher.swift */; };
 		DABDF9C32E02994000C7E498 /* PostHogDisplaySurvey.swift in Sources */ = {isa = PBXBuildFile; fileRef = DABDF9C22E02994000C7E498 /* PostHogDisplaySurvey.swift */; };
 		DABF95052E8FEB6F0029CBBB /* PostHogSurveyEventsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DABF95042E8FEB6F0029CBBB /* PostHogSurveyEventsTest.swift */; };
+		DAD15E022F1AB2AA00A1B2C3 /* PostHogSurveyDisplaySurveyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD15E012F1AB2AA00A1B2C3 /* PostHogSurveyDisplaySurveyTest.swift */; };
 		DAC0A2BF2F2C419400BAA602 /* PostHogDebugImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3BB4DE2ED992780097A97A /* PostHogDebugImageProvider.swift */; };
 		DAC699D62CC790D9000D1D6B /* PostHogAutocaptureIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC699D52CC790D9000D1D6B /* PostHogAutocaptureIntegration.swift */; };
 		DAC699EC2CCA73E5000D1D6B /* ForwardingPickerViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC699EB2CCA73E5000D1D6B /* ForwardingPickerViewDelegate.swift */; };
@@ -1366,6 +1367,7 @@
 		DAB9F6C32D6C49B300A988A1 /* ApplicationEventPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationEventPublisher.swift; sourceTree = "<group>"; };
 		DABDF9C22E02994000C7E498 /* PostHogDisplaySurvey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogDisplaySurvey.swift; sourceTree = "<group>"; };
 		DABF95042E8FEB6F0029CBBB /* PostHogSurveyEventsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSurveyEventsTest.swift; sourceTree = "<group>"; };
+		DAD15E012F1AB2AA00A1B2C3 /* PostHogSurveyDisplaySurveyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSurveyDisplaySurveyTest.swift; sourceTree = "<group>"; };
 		DAC699D52CC790D9000D1D6B /* PostHogAutocaptureIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogAutocaptureIntegration.swift; sourceTree = "<group>"; };
 		DAC699EB2CCA73E5000D1D6B /* ForwardingPickerViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForwardingPickerViewDelegate.swift; sourceTree = "<group>"; };
 		DACB3ED12E0193B20061FC7D /* PostHogSurvey+Display.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostHogSurvey+Display.swift"; sourceTree = "<group>"; };
@@ -1674,6 +1676,7 @@
 				DA703C1D2D66346E0069097B /* PostHogAppLifeCycleIntegrationTest.swift */,
 				DAA5ED962D4043A500D437E0 /* PostHogSurveysTest.swift */,
 				DABF95042E8FEB6F0029CBBB /* PostHogSurveyEventsTest.swift */,
+				DAD15E012F1AB2AA00A1B2C3 /* PostHogSurveyDisplaySurveyTest.swift */,
 				DA5E52EA2E0996C400159D20 /* PostHogSurveyEnumsTest.swift */,
 				DA979D7A2CD370B700F56BAE /* PostHogAutocaptureEventTrackerSpec.swift */,
 				699C5FEE2C20242A007DB818 /* UUIDTest.swift */,
@@ -3387,6 +3390,7 @@
 				DA578E9C2D68578500B3A56C /* MockApplicationLifecyclePublisher.swift in Sources */,
 				DA4FFBB52DAD5B01006BAEEA /* PostHogIdentityTests.swift in Sources */,
 				DABF95052E8FEB6F0029CBBB /* PostHogSurveyEventsTest.swift in Sources */,
+				DAD15E022F1AB2AA00A1B2C3 /* PostHogSurveyDisplaySurveyTest.swift in Sources */,
 				DACF6D5D2CD2F5BC00F14133 /* PostHogAutocaptureIntegrationSpec.swift in Sources */,
 				3A62647529CB0168007E8C07 /* TestPostHog.swift in Sources */,
 				DA27AEC12F56B3E3002A59CE /* PostHogSessionReplayEventTriggersTest.swift in Sources */,

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -2467,6 +2467,30 @@ let maxRetryDelay = 30.0
 
             return replayIntegration?.captureBridgeSnapshot(episodeFirstFrame: episodeFirstFrame) ?? false
         }
+
+        /**
+         Displays the survey with the given ID on demand, regardless of its display conditions.
+
+         The survey must be running and present in the project's surveys. Display conditions
+         (targeting flags, event triggers, and the seen/wait-period checks) are bypassed, so this
+         also works for API-type surveys, which are never displayed automatically. If another
+         survey is already being displayed, the call is ignored.
+
+         This method will have no effect if PostHog is not enabled, or if surveys are disabled in the SDK configuration.
+
+         - Parameter surveyId: The ID of the survey to display
+         */
+        @objc public func displaySurvey(_ surveyId: String) {
+            if !isEnabled() {
+                return
+            }
+
+            guard let surveysIntegration else {
+                return hedgeLog("Cannot display survey \(surveyId) - surveys integration is not installed.")
+            }
+
+            surveysIntegration.displaySurvey(surveyId: surveyId)
+        }
     #endif
 
     /// Creates and sets up an additional SDK instance.

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -295,24 +295,61 @@
                 // Check if there is a new popover surveys to be displayed
                 getActiveMatchingSurveys { activeSurveys in
                     if let survey = activeSurveys.first(where: self.canRenderSurvey) {
-                        let language = self.resolveDisplayLanguage()
-                        let translations = resolveSurveyTranslations(survey: survey, targetLanguage: language)
-                        self.setActiveSurvey(survey: survey, language: translations.matchedKey, questionTranslations: translations.questions)
+                        self.presentSurvey(survey)
+                    }
+                }
+            #endif
+        }
 
-                        DispatchQueue.main.async { [weak self] in
-                            if let self {
-                                // render the survey
-                                self.postHog?.config.surveysConfig.surveysDelegate.renderSurvey(
-                                    survey.toDisplaySurvey(
-                                        surveyTranslation: translations.survey,
-                                        questionTranslations: translations.questions
-                                    ),
-                                    onSurveyShown: self.handleSurveyShown,
-                                    onSurveyResponse: self.handleSurveyResponse,
-                                    onSurveyClosed: self.handleSurveyClosed
-                                )
-                            }
-                        }
+        /// Displays the survey with the given ID on demand.
+        ///
+        /// Unlike automatic display, this bypasses display conditions (targeting flags, event
+        /// triggers, and the seen/wait-period checks), so it also works for API-type surveys,
+        /// which are never auto-displayed. If another survey is already being displayed, the
+        /// call is ignored.
+        func displaySurvey(surveyId: String) {
+            #if os(iOS)
+                guard #available(iOS 15.0, *) else {
+                    hedgeLog("[Surveys] Surveys can be rendered only on iOS 15+")
+                    return
+                }
+            #endif
+
+            guard canShowNextSurvey() else {
+                hedgeLog("[Surveys] Cannot display survey \(surveyId) - another survey is already being displayed")
+                return
+            }
+
+            getSurveys { [weak self] surveys in
+                guard let self else { return }
+                guard let survey = surveys.first(where: { $0.id == surveyId }) else {
+                    hedgeLog("[Surveys] Cannot display survey \(surveyId) - survey not found")
+                    return
+                }
+                self.presentSurvey(survey)
+            }
+        }
+
+        /// Resolves translations, marks the survey as active, and renders it with the configured delegate
+        private func presentSurvey(_ survey: PostHogSurvey) {
+            let language = resolveDisplayLanguage()
+            let translations = resolveSurveyTranslations(survey: survey, targetLanguage: language)
+            setActiveSurvey(survey: survey, language: translations.matchedKey, questionTranslations: translations.questions)
+
+            #if os(iOS)
+                guard #available(iOS 15.0, *) else { return }
+                DispatchQueue.main.async { [weak self] in
+                    if let self {
+                        // render the survey
+                        self.postHog?.config.surveysConfig.surveysDelegate.renderSurvey(
+                            survey.toDisplaySurvey(
+                                surveyTranslation: translations.survey,
+                                questionTranslations: translations.questions
+                            ),
+                            onSurveyShown: self.handleSurveyShown,
+                            onSurveyResponse: self.handleSurveyResponse,
+                            onSurveyClosed: self.handleSurveyClosed
+                        )
                     }
                 }
             #endif
@@ -1064,6 +1101,10 @@
         extension PostHogSurveyIntegration {
             func setSurveys(_ surveys: [PostHogSurvey]) {
                 allSurveys = surveys
+            }
+
+            func getActiveSurvey() -> PostHogSurvey? {
+                activeSurveyLock.withLock { activeSurvey }
             }
 
             func setShownSurvey(_ survey: PostHogSurvey) {

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -326,6 +326,13 @@
                     hedgeLog("[Surveys] Cannot display survey \(surveyId) - survey not found")
                     return
                 }
+                // Honor the documented "must be running" precondition. We deliberately bypass
+                // targeting flags, event triggers, and seen/wait-period checks, but a survey
+                // that has been stopped on the dashboard (endDate set) must not be shown.
+                guard survey.isActive else {
+                    hedgeLog("[Surveys] Cannot display survey \(surveyId) - survey is not running")
+                    return
+                }
                 self.presentSurvey(survey)
             }
         }
@@ -334,7 +341,14 @@
         private func presentSurvey(_ survey: PostHogSurvey) {
             let language = resolveDisplayLanguage()
             let translations = resolveSurveyTranslations(survey: survey, targetLanguage: language)
-            setActiveSurvey(survey: survey, language: translations.matchedKey, questionTranslations: translations.questions)
+
+            // Atomically claim the active-survey slot. If another survey won it (e.g. a
+            // concurrent automatic trigger races a manual `displaySurvey` call), bail out
+            // without rendering so the on-screen survey never diverges from `activeSurvey`.
+            guard setActiveSurvey(survey: survey, language: translations.matchedKey, questionTranslations: translations.questions) else {
+                hedgeLog("[Surveys] Cannot display survey \(survey.id) - another survey is already being displayed")
+                return
+            }
 
             #if os(iOS)
                 guard #available(iOS 15.0, *) else { return }
@@ -748,16 +762,23 @@
             return surveyProperty
         }
 
-        private func setActiveSurvey(survey: PostHogSurvey, language: String? = nil, questionTranslations: [PostHogSurveyQuestionTranslation?]? = nil) {
+        /// Atomically claims the active-survey slot for the given survey.
+        ///
+        /// Returns `true` if this call won the slot (it was previously empty), or `false` if
+        /// another survey already holds it. Callers must only render when this returns `true`,
+        /// otherwise two concurrent flows could render a survey that diverges from the tracked
+        /// `activeSurvey`, which would permanently block all future surveys.
+        @discardableResult
+        private func setActiveSurvey(survey: PostHogSurvey, language: String? = nil, questionTranslations: [PostHogSurveyQuestionTranslation?]? = nil) -> Bool {
             activeSurveyLock.withLock {
-                if activeSurvey == nil {
-                    activeSurvey = survey
-                    activeSurveyLanguage = language
-                    activeSurveyQuestionTranslations = questionTranslations
-                    activeSurveyCompleted = false
-                    activeSurveyResponses = [:]
-                    activeSurveyQuestionIndex = 0
-                }
+                guard activeSurvey == nil else { return false }
+                activeSurvey = survey
+                activeSurveyLanguage = language
+                activeSurveyQuestionTranslations = questionTranslations
+                activeSurveyCompleted = false
+                activeSurveyResponses = [:]
+                activeSurveyQuestionIndex = 0
+                return true
             }
         }
 

--- a/PostHogTests/PostHogSurveyDisplaySurveyTest.swift
+++ b/PostHogTests/PostHogSurveyDisplaySurveyTest.swift
@@ -1,0 +1,194 @@
+//
+//  PostHogSurveyDisplaySurveyTest.swift
+//  PostHogTests
+//
+
+import Foundation
+@testable import PostHog
+import Testing
+
+@Suite("Test manual displaySurvey API", .serialized)
+class PostHogSurveyDisplaySurveyTest {
+    let server: MockPostHogServer
+
+    init() {
+        server = MockPostHogServer()
+        server.start()
+    }
+
+    deinit {
+        server.stop()
+    }
+
+    /// A delegate that records rendered survey IDs, so unit tests don't spin up real survey UI
+    private final class RecordingSurveysDelegate: PostHogSurveysDelegate {
+        var renderedSurveyIds: [String] = []
+
+        func renderSurvey(
+            _ survey: PostHogDisplaySurvey,
+            onSurveyShown _: @escaping OnPostHogSurveyShown,
+            onSurveyResponse _: @escaping OnPostHogSurveyResponse,
+            onSurveyClosed _: @escaping OnPostHogSurveyClosed
+        ) {
+            renderedSurveyIds.append(survey.id)
+        }
+
+        func cleanupSurveys() {}
+    }
+
+    private let recordingDelegate = RecordingSurveysDelegate()
+
+    func getTestSurvey(
+        id: String = "test-survey-id",
+        name: String = "Test Survey",
+        type: PostHogSurveyType = .popover,
+        conditions: PostHogSurveyConditions? = nil
+    ) -> PostHogSurvey {
+        PostHogSurvey(
+            id: id,
+            name: name,
+            type: type,
+            questions: [
+                .open(PostHogOpenSurveyQuestion(
+                    id: "qID1",
+                    question: "What do you think about our product?",
+                    description: "Please share your thoughts",
+                    descriptionContentType: .text,
+                    optional: false,
+                    buttonText: nil,
+                    originalQuestionIndex: 0,
+                    branching: nil,
+                    translations: nil
+                )),
+            ],
+            featureFlagKeys: nil,
+            linkedFlagKey: nil,
+            targetingFlagKey: nil,
+            internalTargetingFlagKey: nil,
+            conditions: conditions,
+            appearance: nil,
+            currentIteration: nil,
+            currentIterationStartDate: nil,
+            startDate: Date(),
+            endDate: nil,
+            schedule: nil,
+            translations: nil
+        )
+    }
+
+    func eventConditions(_ eventName: String) -> PostHogSurveyConditions {
+        PostHogSurveyConditions(
+            url: nil,
+            urlMatchType: nil,
+            selector: nil,
+            deviceTypes: nil,
+            deviceTypesMatchType: nil,
+            seenSurveyWaitPeriodInDays: nil,
+            events: PostHogSurveyEventConditions(
+                repeatedActivation: nil,
+                values: [PostHogEventCondition(name: eventName, propertyFilters: nil)]
+            ),
+            actions: nil
+        )
+    }
+
+    func getSut() -> PostHogSDK {
+        let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9090")
+        config._surveys = true
+        config._surveysConfig.surveysDelegate = recordingDelegate
+        config.flushAt = 1
+        config.disableReachabilityForTesting = true
+        config.disableQueueTimerForTesting = true
+        config.disableFlushOnBackgroundForTesting = true
+        config.captureApplicationLifecycleEvents = false
+
+        let storage = PostHogStorage(config)
+        storage.reset()
+
+        return PostHogSDK.with(config)
+    }
+
+    func getSurveyIntegration(_ postHog: PostHogSDK) throws -> PostHogSurveyIntegration {
+        PostHogSurveyIntegration.clearInstalls()
+        let integration = PostHogSurveyIntegration()
+        let installResult = integration.install(postHog)
+        try #require(installResult == .installed)
+        return integration
+    }
+
+    @Test("displaySurvey marks an API-type survey as active")
+    func displaySurveyActivatesApiSurvey() throws {
+        let postHog = getSut()
+        let integration = try getSurveyIntegration(postHog)
+        defer {
+            integration.uninstall(postHog)
+            postHog.close()
+            postHog.reset()
+        }
+
+        let survey = getTestSurvey(id: "api-survey-id", type: .api)
+        integration.setSurveys([survey])
+
+        integration.displaySurvey(surveyId: "api-survey-id")
+
+        #expect(integration.getActiveSurvey()?.id == "api-survey-id")
+        #expect(integration.canShowNextSurvey() == false)
+    }
+
+    @Test("displaySurvey bypasses event trigger conditions")
+    func displaySurveyBypassesEventTriggers() throws {
+        let postHog = getSut()
+        let integration = try getSurveyIntegration(postHog)
+        defer {
+            integration.uninstall(postHog)
+            postHog.close()
+            postHog.reset()
+        }
+
+        // survey with an event trigger that never fired
+        let survey = getTestSurvey(id: "event-survey-id", conditions: eventConditions("some_event"))
+        integration.setSurveys([survey])
+
+        integration.displaySurvey(surveyId: "event-survey-id")
+
+        #expect(integration.getActiveSurvey()?.id == "event-survey-id")
+    }
+
+    @Test("displaySurvey with an unknown ID does nothing")
+    func displaySurveyUnknownIdDoesNothing() throws {
+        let postHog = getSut()
+        let integration = try getSurveyIntegration(postHog)
+        defer {
+            integration.uninstall(postHog)
+            postHog.close()
+            postHog.reset()
+        }
+
+        integration.setSurveys([getTestSurvey(id: "api-survey-id", type: .api)])
+
+        integration.displaySurvey(surveyId: "unknown-id")
+
+        #expect(integration.getActiveSurvey() == nil)
+        #expect(integration.canShowNextSurvey() == true)
+    }
+
+    @Test("displaySurvey is ignored while another survey is active")
+    func displaySurveyIgnoredWhileAnotherSurveyActive() throws {
+        let postHog = getSut()
+        let integration = try getSurveyIntegration(postHog)
+        defer {
+            integration.uninstall(postHog)
+            postHog.close()
+            postHog.reset()
+        }
+
+        let first = getTestSurvey(id: "first-survey-id")
+        let second = getTestSurvey(id: "second-survey-id", type: .api)
+        integration.setSurveys([first, second])
+        integration.setShownSurvey(first)
+
+        integration.displaySurvey(surveyId: "second-survey-id")
+
+        #expect(integration.getActiveSurvey()?.id == "first-survey-id")
+    }
+}

--- a/PostHogTests/PostHogSurveyDisplaySurveyTest.swift
+++ b/PostHogTests/PostHogSurveyDisplaySurveyTest.swift
@@ -42,7 +42,9 @@ class PostHogSurveyDisplaySurveyTest {
         id: String = "test-survey-id",
         name: String = "Test Survey",
         type: PostHogSurveyType = .popover,
-        conditions: PostHogSurveyConditions? = nil
+        conditions: PostHogSurveyConditions? = nil,
+        startDate: Date? = Date(),
+        endDate: Date? = nil
     ) -> PostHogSurvey {
         PostHogSurvey(
             id: id,
@@ -69,8 +71,8 @@ class PostHogSurveyDisplaySurveyTest {
             appearance: nil,
             currentIteration: nil,
             currentIterationStartDate: nil,
-            startDate: Date(),
-            endDate: nil,
+            startDate: startDate,
+            endDate: endDate,
             schedule: nil,
             translations: nil
         )
@@ -167,6 +169,26 @@ class PostHogSurveyDisplaySurveyTest {
         integration.setSurveys([getTestSurvey(id: "api-survey-id", type: .api)])
 
         integration.displaySurvey(surveyId: "unknown-id")
+
+        #expect(integration.getActiveSurvey() == nil)
+        #expect(integration.canShowNextSurvey() == true)
+    }
+
+    @Test("displaySurvey does not show a stopped survey")
+    func displaySurveyIgnoresStoppedSurvey() throws {
+        let postHog = getSut()
+        let integration = try getSurveyIntegration(postHog)
+        defer {
+            integration.uninstall(postHog)
+            postHog.close()
+            postHog.reset()
+        }
+
+        // survey that has been stopped on the dashboard (endDate set)
+        let survey = getTestSurvey(id: "stopped-survey-id", type: .api, endDate: Date())
+        integration.setSurveys([survey])
+
+        integration.displaySurvey(surveyId: "stopped-survey-id")
 
         #expect(integration.getActiveSurvey() == nil)
         #expect(integration.canShowNextSurvey() == true)


### PR DESCRIPTION
## :bulb: Motivation and Context

Closes #648

The web SDK exposes `posthog.displaySurvey()` to display a survey on demand (see [implementing custom surveys](https://posthog.com/docs/surveys/implementing-custom-surveys)), but there is no mobile equivalent, so surveys can only be shown when the automatic display conditions are met, and API-type surveys can't be shown at all. This adds the iOS counterpart:

```swift
PostHogSDK.shared.displaySurvey("survey-id")
```

- Looks the survey up in the loaded surveys and routes it through the existing display path (translations, active-survey tracking, `survey shown`/`sent`/`dismissed` events), so all downstream behavior is unchanged.
- Bypasses display conditions (targeting flags, event triggers, seen/wait-period checks), matching the web SDK's default behavior.
- Also enables API-type surveys, which `showNextSurvey()` intentionally never auto-displays.
- No-op (with a log) when the survey isn't found or another survey is already being displayed.

`showNextSurvey()` was refactored to share the new `presentSurvey(_:)` helper; its behavior is unchanged.

Sibling PRs: posthog-android and posthog-flutter (Flutter delegates survey logic to the native SDKs, so it needs this API first). RN is tracked in PostHog/posthog-js#3817.

## :green_heart: How did you test it?

Added `PostHogSurveyDisplaySurveyTest` covering: displaying an API-type survey by ID, bypassing an unfired event trigger, unknown ID as a no-op, and ignoring the call while another survey is active. Written to match the existing survey test harness, but not executed locally (authored in a Linux environment without an Apple toolchain) — relying on CI here.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Code) from a request to bring the JS SDK's `displaySurvey` to the Flutter SDK; since Flutter's survey pipeline lives in the native SDKs, this iOS API is the prerequisite. Design choice: reuse the internal display path via a shared `presentSurvey(_:)` helper rather than a parallel code path, and keep v1 to a single `surveyId` parameter (no `ignoreConditions`/prefill options yet) to match the tracking issue's scope. Tests assert on integration state via the existing TESTING extension instead of rendering UI.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
