### PR TITLE
fix(error-tracking): install autocapture before remote config on first launch

### DIFF
--- a/.changeset/calm-chairs-knock.md
+++ b/.changeset/calm-chairs-knock.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Fix error tracking autocapture never installing on a first launch that has no cached remote config. The crash reporter now installs by default before the first `/config` response arrives, so crashes on the very first launch are captured. If the response then reports `autocaptureExceptions: false`, the integration is uninstalled and removed.

--- a/.changeset/fix-error-tracking-remote-config-uninstall.md
+++ b/.changeset/fix-error-tracking-remote-config-uninstall.md
@@ -1,0 +1,9 @@
+---
+"posthog-ios": patch
+---
+
+Fix error tracking integration not uninstalling when remote config disables autocapture
+
+`stop()` is a no-op for crash reporters (by design — once registered, a crash handler cannot be deregistered). When remote config arrived with `autocaptureExceptions: false` after the integration was already installed, calling `stop()` left the integration in `installedIntegrations`, so `getErrorTrackingIntegration()` continued returning it.
+
+Added `removeIntegration(_:)` to `PostHogSDK` which calls `uninstall()` and removes the integration from `installedIntegrations`. The `onRemoteConfigLoaded` callback now calls `postHog.removeIntegration(self)` instead of `self.stop()`.

--- a/.changeset/fix-error-tracking-remote-config-uninstall.md
+++ b/.changeset/fix-error-tracking-remote-config-uninstall.md
@@ -1,9 +1,0 @@
----
-"posthog-ios": patch
----
-
-Fix error tracking integration not uninstalling when remote config disables autocapture
-
-`stop()` is a no-op for crash reporters (by design — once registered, a crash handler cannot be deregistered). When remote config arrived with `autocaptureExceptions: false` after the integration was already installed, calling `stop()` left the integration in `installedIntegrations`, so `getErrorTrackingIntegration()` continued returning it.
-
-Added `removeIntegration(_:)` to `PostHogSDK` which calls `uninstall()` and removes the integration from `installedIntegrations`. The `onRemoteConfigLoaded` callback now calls `postHog.removeIntegration(self)` instead of `self.stop()`.

--- a/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
+++ b/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
@@ -26,9 +26,15 @@ import Foundation
         private var crashCustomData: PostHogCrashCustomDataWriter?
         private var contextChangedToken: RegistrationToken?
         private var exceptionStepsChangedToken: RegistrationToken?
+        private var remoteConfigLoadedToken: RegistrationToken?
 
         func install(_ postHog: PostHogSDK) -> PostHogIntegrationInstallResult {
-            if postHog.remoteConfig?.isAutocaptureExceptionsEnabled() == false {
+            // Only block on remote config once it has actually loaded. Before the first
+            // fetch completes (e.g. first launch with no disk cache) we default to installing
+            // so that a crash on that very first launch is not silently missed.
+            if postHog.remoteConfig?.hasFetchedRemoteConfig == true,
+               postHog.remoteConfig?.isAutocaptureExceptionsEnabled() == false
+            {
                 return .skipped(.disabledByRemoteConfig)
             }
 
@@ -50,6 +56,18 @@ import Foundation
                     exceptionStepsChangedToken = postHog.onExceptionStepsChanged.subscribe { [weak crashCustomData] steps in
                         crashCustomData?.setSteps(steps)
                     }
+
+                    // If remote config was not yet loaded at install time, subscribe so we can
+                    // uninstall if the freshly-loaded config disables autocapture.
+                    if postHog.remoteConfig?.hasFetchedRemoteConfig == false {
+                        remoteConfigLoadedToken = postHog.remoteConfig?.onRemoteConfigLoaded.subscribe { [weak self, weak postHog] _ in
+                            guard let self, let postHog else { return }
+                            self.remoteConfigLoadedToken = nil
+                            if postHog.remoteConfig?.isAutocaptureExceptionsEnabled() == false {
+                                self.uninstall(postHog)
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -57,6 +75,7 @@ import Foundation
         func uninstall(_ postHog: PostHogSDK) {
             uninstallIfNeeded(from: postHog, installedPostHog: self.postHog, state: Self.integrationInstallState) {
                 stop()
+                remoteConfigLoadedToken = nil
                 contextChangedToken = nil
                 exceptionStepsChangedToken = nil
                 crashCustomData = nil

--- a/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
+++ b/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
@@ -64,7 +64,7 @@ import Foundation
                             guard let self, let postHog else { return }
                             self.remoteConfigLoadedToken = nil
                             if postHog.remoteConfig?.isAutocaptureExceptionsEnabled() == false {
-                                self.uninstall(postHog)
+                                self.stop()
                             }
                         }
                     }

--- a/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
+++ b/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
@@ -14,6 +14,10 @@ import Foundation
     class PostHogErrorTrackingAutoCaptureIntegration: PostHogIntegration {
         private static let integrationInstallState = PostHogIntegrationInstallState()
 
+        static func clearInstalls() {
+            integrationInstallState.clear()
+        }
+
         var requiresSwizzling: Bool { false }
 
         private weak var postHog: PostHogSDK?

--- a/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
+++ b/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
@@ -29,10 +29,12 @@ import Foundation
         private var remoteConfigLoadedToken: RegistrationToken?
 
         func install(_ postHog: PostHogSDK) -> PostHogIntegrationInstallResult {
-            // Only block on remote config once it has actually loaded. Before the first
-            // fetch completes (e.g. first launch with no disk cache) we default to installing
-            // so that a crash on that very first launch is not silently missed.
-            if postHog.remoteConfig?.hasFetchedRemoteConfig == true,
+            // Block installation when remote config (live or disk-cached) explicitly disables
+            // autocapture. When there is no remote config at all (first launch, no disk cache)
+            // we default to installing so a crash on that very first launch is not missed.
+            let hasRemoteConfig = postHog.remoteConfig?.hasFetchedRemoteConfig == true
+                || postHog.remoteConfig?.hasCachedRemoteConfig == true
+            if hasRemoteConfig,
                postHog.remoteConfig?.isAutocaptureExceptionsEnabled() == false
             {
                 return .skipped(.disabledByRemoteConfig)
@@ -58,13 +60,13 @@ import Foundation
                     }
 
                     // If remote config was not yet loaded at install time, subscribe so we can
-                    // uninstall if the freshly-loaded config disables autocapture.
+                    // remove the integration if the freshly-loaded config disables autocapture.
                     if postHog.remoteConfig?.hasFetchedRemoteConfig == false {
                         remoteConfigLoadedToken = postHog.remoteConfig?.onRemoteConfigLoaded.subscribe { [weak self, weak postHog] _ in
                             guard let self, let postHog else { return }
                             self.remoteConfigLoadedToken = nil
                             if postHog.remoteConfig?.isAutocaptureExceptionsEnabled() == false {
-                                self.stop()
+                                postHog.removeIntegration(self)
                             }
                         }
                     }

--- a/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
+++ b/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
@@ -34,11 +34,15 @@ import Foundation
         private static var pendingEnableToken: RegistrationToken?
 
         func install(_ postHog: PostHogSDK) -> PostHogIntegrationInstallResult {
-            // Block installation when remote config (live or disk-cached) explicitly disables
-            // autocapture. When there is no remote config at all (first launch, no disk cache)
-            // we default to installing so a crash on that very first launch is not missed.
-            let hasRemoteConfig = postHog.remoteConfig?.hasFetchedRemoteConfig == true
-                || postHog.remoteConfig?.hasCachedRemoteConfig == true
+            // Only block install when real config data (a successful live fetch or disk cache)
+            // disables autocapture. With no data — first launch, no cache, or a *failed* /config —
+            // default to installing so a first-launch crash isn't missed. A failed fetch sets
+            // `hasFetchedRemoteConfig` but stores none, so pair it with a data-present check;
+            // `hasFetchedRemoteConfig` also flips last (after the config is stored and applied), so
+            // the pairing never reads a half-applied live config.
+            let hasRemoteConfig = postHog.remoteConfig?.hasCachedRemoteConfig == true
+                || (postHog.remoteConfig?.hasFetchedRemoteConfig == true
+                    && postHog.remoteConfig?.getRemoteConfig() != nil)
             if hasRemoteConfig,
                postHog.remoteConfig?.isAutocaptureExceptionsEnabled() == false
             {

--- a/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
+++ b/PostHog/ErrorTracking/PostHogErrorTrackingAutoCaptureIntegration.swift
@@ -16,6 +16,7 @@ import Foundation
 
         static func clearInstalls() {
             integrationInstallState.clear()
+            pendingEnableToken = nil
         }
 
         var requiresSwizzling: Bool { false }
@@ -27,6 +28,10 @@ import Foundation
         private var contextChangedToken: RegistrationToken?
         private var exceptionStepsChangedToken: RegistrationToken?
         private var remoteConfigLoadedToken: RegistrationToken?
+        /// Held while a cached-disabled start waits for a live `/config` that may re-enable autocapture.
+        /// Static (like `integrationInstallState`) and retains `self` so the skipped instance survives
+        /// until the live config lands; cleared once it does.
+        private static var pendingEnableToken: RegistrationToken?
 
         func install(_ postHog: PostHogSDK) -> PostHogIntegrationInstallResult {
             // Block installation when remote config (live or disk-cached) explicitly disables
@@ -37,8 +42,23 @@ import Foundation
             if hasRemoteConfig,
                postHog.remoteConfig?.isAutocaptureExceptionsEnabled() == false
             {
+                // The native handler can't be torn down once enabled, so a crash during a prior
+                // default-on first-launch window may have left a report on disk. Config now says
+                // autocapture is disabled, so purge it rather than let a later re-enable transmit
+                // a crash that happened while the project was opted out.
+                purgePendingCrashReportIfNeeded()
+
+                // The disable verdict may have come purely from a disk-cached config. If the live
+                // /config has not landed yet, watch for it: a fresh response that re-enables
+                // autocapture should install now rather than wait for the next launch.
+                if postHog.remoteConfig?.hasFetchedRemoteConfig == false {
+                    watchForRemoteEnable(postHog)
+                }
                 return .skipped(.disabledByRemoteConfig)
             }
+
+            // Live config enabled autocapture: cancel any pending cached-disabled watch.
+            Self.pendingEnableToken = nil
 
             return installIfNeeded(using: Self.integrationInstallState) {
                 if let crashReporter = setupCrashReporter() {
@@ -124,6 +144,28 @@ import Foundation
             if reporter.hasPendingCrashReport() {
                 hedgeLog("Found pending crash report, processing...")
                 processPendingCrashReport()
+            }
+        }
+
+        /// Discards any on-disk crash report without processing it. Creating the reporter here
+        /// only reads/purges the report file; it does not enable the native handler.
+        private func purgePendingCrashReportIfNeeded() {
+            guard let reporter = setupCrashReporter(), reporter.hasPendingCrashReport() else {
+                return
+            }
+            hedgeLog("Autocapture disabled by remote config, purging pending crash report")
+            reporter.purgePendingCrashReport()
+        }
+
+        /// Subscribes to the live `/config` for the case where a disk-cached config disabled
+        /// autocapture. If the fresh response re-enables it, install the integration. The closure
+        /// retains `self` (via the static token) so the skipped instance stays alive until then.
+        private func watchForRemoteEnable(_ postHog: PostHogSDK) {
+            Self.pendingEnableToken = postHog.remoteConfig?.onRemoteConfigLoaded.subscribe { [self] _ in
+                Self.pendingEnableToken = nil
+                if postHog.remoteConfig?.isAutocaptureExceptionsEnabled() == true {
+                    postHog.addIntegration(self)
+                }
             }
         }
 

--- a/PostHog/PostHogIntegration.swift
+++ b/PostHog/PostHogIntegration.swift
@@ -40,7 +40,7 @@ final class PostHogIntegrationInstallState {
     }
 }
 
-protocol PostHogIntegration {
+protocol PostHogIntegration: AnyObject {
     /**
      * Indicates whether this integration requires method swizzling to function.
      *

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -36,6 +36,7 @@ class PostHogRemoteConfig {
     private var loadingRemoteConfig = false
     private var remoteConfig: [String: Any]?
     private var remoteConfigDidFetch: Bool = false
+    private var remoteConfigWasCached: Bool = false
     private var featureFlagPayloads: [String: Any]?
     private var requestId: String?
     private var evaluatedAt: Int?
@@ -124,7 +125,9 @@ class PostHogRemoteConfig {
     private func preloadRemoteConfig() {
         remoteConfigLock.withLock {
             // load disk cached config to memory
-            _ = getCachedRemoteConfig()
+            if getCachedRemoteConfig() != nil {
+                remoteConfigWasCached = true
+            }
         }
 
         guard !config.disableRemoteConfigForTesting else {
@@ -1028,6 +1031,11 @@ class PostHogRemoteConfig {
     /// Whether a `/config` request has completed at least once (set on both success and failure).
     var hasFetchedRemoteConfig: Bool {
         remoteConfigLock.withLock { remoteConfigDidFetch }
+    }
+
+    /// Whether a disk-cached remote config was present at SDK startup (before any live fetch).
+    var hasCachedRemoteConfig: Bool {
+        remoteConfigLock.withLock { remoteConfigWasCached }
     }
 
     #if os(iOS)

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -1025,14 +1025,14 @@ class PostHogRemoteConfig {
         // drop) the opening window of post-reset sessions that never re-fetch /config.
     }
 
+    /// Whether a `/config` request has completed at least once (set on both success and failure).
+    var hasFetchedRemoteConfig: Bool {
+        remoteConfigLock.withLock { remoteConfigDidFetch }
+    }
+
     #if os(iOS)
         func isSessionReplayFlagActive() -> Bool {
             sessionReplayLock.withLock { sessionReplayFlagActive }
-        }
-
-        /// Whether a `/config` request has completed at least once (set on both success and failure).
-        var hasFetchedRemoteConfig: Bool {
-            remoteConfigLock.withLock { remoteConfigDidFetch }
         }
 
         /// Whether recording is gated on a linked feature flag (vs a plain boolean). The flag's value

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -1090,5 +1090,13 @@ private struct PendingFeatureFlagsRequest {
                 sessionReplayFlagActive = active
             }
         }
+
+        /// Force the "a /config request completed" flag without storing any config data, so tests can
+        /// simulate a failed fetch (fetched == true, no cached/live config) without a live request.
+        func setRemoteConfigDidFetchForTesting(_ didFetch: Bool) {
+            remoteConfigLock.withLock {
+                remoteConfigDidFetch = didFetch
+            }
+        }
     }
 #endif

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -241,7 +241,7 @@ let maxRetryDelay = 30.0
                         errorTrackingRemoteConfigToken = remoteConfig?.onRemoteConfigLoaded.subscribe { [weak self] _ in
                             guard let self else { return }
                             setupLock.withLock {
-                                installErrorTrackingIntegration()
+                                self.installErrorTrackingIntegration()
                             }
                             errorTrackingRemoteConfigToken = nil
                         }

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -78,7 +78,6 @@ let maxRetryDelay = 30.0
     let onEventContextChanged = PostHogMulticastCallback<[String: Any]>()
     private var sessionIdChangedToken: RegistrationToken?
     private var didEnterBackgroundToken: RegistrationToken?
-    private var errorTrackingRemoteConfigToken: RegistrationToken?
 
     /// Logger facade exposing `trace/debug/info/warn/error/fatal(_:attributes:)`.
     /// `nil` before `setup(_:)` is called.
@@ -232,21 +231,6 @@ let maxRetryDelay = 30.0
             if !config.optOut {
                 // don't install integrations if in opt-out state
                 installIntegrations()
-
-                // Error tracking may have been skipped because remote config was not yet loaded
-                // (first launch, no disk cache). Subscribe to re-attempt installation once the
-                // live remote config arrives — mirroring the late-install path session replay uses.
-                #if os(iOS) || os(macOS) || os(tvOS)
-                    if !isErrorTrackingInstalled() {
-                        errorTrackingRemoteConfigToken = remoteConfig?.onRemoteConfigLoaded.subscribe { [weak self] _ in
-                            guard let self else { return }
-                            setupLock.withLock {
-                                self.installErrorTrackingIntegration()
-                            }
-                            errorTrackingRemoteConfigToken = nil
-                        }
-                    }
-                #endif
 
                 createExceptionStepsBufferIfNeeded()
 
@@ -2785,28 +2769,7 @@ let maxRetryDelay = 30.0
         }
     #endif
 
-    #if os(iOS) || os(macOS) || os(tvOS)
-        private func isErrorTrackingInstalled() -> Bool {
-            installedIntegrations.contains { $0 is PostHogErrorTrackingAutoCaptureIntegration }
-        }
-
-        private func installErrorTrackingIntegration() {
-            guard !isErrorTrackingInstalled() else { return }
-
-            let integration = PostHogErrorTrackingAutoCaptureIntegration()
-            let installOutcome = integration.install(self)
-            if case let .skipped(reason) = installOutcome {
-                hedgeLog("Integration \(type(of: integration)) skipped: \(reason)")
-                return
-            }
-
-            installedIntegrations.append(integration)
-            hedgeLog("Integration \(type(of: integration)) installed")
-        }
-    #endif
-
     private func uninstallIntegrations() {
-        errorTrackingRemoteConfigToken = nil
         for integration in installedIntegrations {
             integration.uninstall(self)
             hedgeLog("Integration \(type(of: integration)) uninstalled")

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -78,6 +78,7 @@ let maxRetryDelay = 30.0
     let onEventContextChanged = PostHogMulticastCallback<[String: Any]>()
     private var sessionIdChangedToken: RegistrationToken?
     private var didEnterBackgroundToken: RegistrationToken?
+    private var errorTrackingRemoteConfigToken: RegistrationToken?
 
     /// Logger facade exposing `trace/debug/info/warn/error/fatal(_:attributes:)`.
     /// `nil` before `setup(_:)` is called.
@@ -231,6 +232,21 @@ let maxRetryDelay = 30.0
             if !config.optOut {
                 // don't install integrations if in opt-out state
                 installIntegrations()
+
+                // Error tracking may have been skipped because remote config was not yet loaded
+                // (first launch, no disk cache). Subscribe to re-attempt installation once the
+                // live remote config arrives — mirroring the late-install path session replay uses.
+                #if os(iOS) || os(macOS) || os(tvOS)
+                    if !isErrorTrackingInstalled() {
+                        errorTrackingRemoteConfigToken = remoteConfig?.onRemoteConfigLoaded.subscribe { [weak self] _ in
+                            guard let self else { return }
+                            setupLock.withLock {
+                                installErrorTrackingIntegration()
+                            }
+                            errorTrackingRemoteConfigToken = nil
+                        }
+                    }
+                #endif
 
                 createExceptionStepsBufferIfNeeded()
 
@@ -2769,7 +2785,28 @@ let maxRetryDelay = 30.0
         }
     #endif
 
+    #if os(iOS) || os(macOS) || os(tvOS)
+        private func isErrorTrackingInstalled() -> Bool {
+            installedIntegrations.contains { $0 is PostHogErrorTrackingAutoCaptureIntegration }
+        }
+
+        private func installErrorTrackingIntegration() {
+            guard !isErrorTrackingInstalled() else { return }
+
+            let integration = PostHogErrorTrackingAutoCaptureIntegration()
+            let installOutcome = integration.install(self)
+            if case let .skipped(reason) = installOutcome {
+                hedgeLog("Integration \(type(of: integration)) skipped: \(reason)")
+                return
+            }
+
+            installedIntegrations.append(integration)
+            hedgeLog("Integration \(type(of: integration)) installed")
+        }
+    #endif
+
     private func uninstallIntegrations() {
+        errorTrackingRemoteConfigToken = nil
         for integration in installedIntegrations {
             integration.uninstall(self)
             hedgeLog("Integration \(type(of: integration)) uninstalled")
@@ -2840,6 +2877,12 @@ let maxRetryDelay = 30.0
 
         #if os(iOS)
             func getReplayIntegration() -> PostHogReplayIntegration? {
+                getIntegration()
+            }
+        #endif
+
+        #if os(iOS) || os(macOS) || os(tvOS)
+            func getErrorTrackingIntegration() -> PostHogErrorTrackingAutoCaptureIntegration? {
                 getIntegration()
             }
         #endif

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -2769,6 +2769,13 @@ let maxRetryDelay = 30.0
         }
     #endif
 
+    func removeIntegration(_ integration: PostHogIntegration) {
+        let id = ObjectIdentifier(integration)
+        integration.uninstall(self)
+        installedIntegrations.removeAll { ObjectIdentifier($0) == id }
+        hedgeLog("Integration \(type(of: integration)) removed")
+    }
+
     private func uninstallIntegrations() {
         for integration in installedIntegrations {
             integration.uninstall(self)

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -2769,10 +2769,14 @@ let maxRetryDelay = 30.0
         }
     #endif
 
+    /// Callable from any thread (e.g. the main-queue `onRemoteConfigLoaded` callback), so the
+    /// mutation runs under `setupLock` like every other `installedIntegrations` access.
     func removeIntegration(_ integration: PostHogIntegration) {
         let id = ObjectIdentifier(integration)
-        integration.uninstall(self)
-        installedIntegrations.removeAll { ObjectIdentifier($0) == id }
+        setupLock.withLock {
+            integration.uninstall(self)
+            installedIntegrations.removeAll { ObjectIdentifier($0) == id }
+        }
         hedgeLog("Integration \(type(of: integration)) removed")
     }
 
@@ -2870,7 +2874,9 @@ let maxRetryDelay = 30.0
         }
 
         private func getIntegration<T: PostHogIntegration>() -> T? {
-            installedIntegrations.compactMap { $0 as? T }.first
+            setupLock.withLock {
+                installedIntegrations.compactMap { $0 as? T }.first
+            }
         }
     }
 #endif

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -2780,6 +2780,20 @@ let maxRetryDelay = 30.0
         hedgeLog("Integration \(type(of: integration)) removed")
     }
 
+    /// Installs a single integration after initial setup, tracking it for teardown. Twin of
+    /// `removeIntegration`, for integrations that install lazily once remote config lands (e.g.
+    /// error-tracking autocapture re-enabled by a live `/config` after a cached-disabled start).
+    /// Callable from any thread; runs under `setupLock` like every other `installedIntegrations` access.
+    func addIntegration(_ integration: PostHogIntegration) {
+        setupLock.withLock {
+            let id = ObjectIdentifier(integration)
+            guard !installedIntegrations.contains(where: { ObjectIdentifier($0) == id }) else { return }
+            guard case .installed = integration.install(self) else { return }
+            installedIntegrations.append(integration)
+            hedgeLog("Integration \(type(of: integration)) added")
+        }
+    }
+
     private func uninstallIntegrations() {
         for integration in installedIntegrations {
             integration.uninstall(self)

--- a/PostHogTests/PostHogIntegrationInstallationTest.swift
+++ b/PostHogTests/PostHogIntegrationInstallationTest.swift
@@ -136,10 +136,11 @@ class PostHogIntegrationInstallationTest {
             #expect(sut.getErrorTrackingIntegration() != nil)
         }
 
-        @Test("error tracking integration not installed when remote config already loaded and disabled")
+        @Test("error tracking integration not installed when disk-cached remote config disables it")
         func errorTrackingNotInstalledWhenRemoteConfigDisables() async {
-            // Seed the cached remote config with autocaptureExceptions=false so hasFetchedRemoteConfig
-            // is true and the gate blocks installation.
+            // Remote fetch is disabled, so hasFetchedRemoteConfig stays false. The disk-cached config
+            // (seeded below) is what flips hasCachedRemoteConfig → true, and with autocaptureExceptions=false
+            // that makes the gate skip installation.
             let token = "test_error_tracking_\(UUID().uuidString)"
             let config = PostHogConfig(projectToken: token, host: "http://localhost:9001")
             config.disableRemoteConfigForTesting = true
@@ -149,7 +150,7 @@ class PostHogIntegrationInstallationTest {
 
             let storage = PostHogStorage(config)
             defer { storage.reset() }
-            // Seed cached config with autocapture disabled so hasFetchedRemoteConfig → true
+            // Seed disk-cached config with autocapture disabled so hasCachedRemoteConfig → true
             storage.setDictionary(forKey: .remoteConfig, contents: ["errorTracking": ["autocaptureExceptions": false]])
 
             let sut = PostHogSDK.with(config)

--- a/PostHogTests/PostHogIntegrationInstallationTest.swift
+++ b/PostHogTests/PostHogIntegrationInstallationTest.swift
@@ -163,6 +163,8 @@ class PostHogIntegrationInstallationTest {
             // Start with no cached config (hasFetchedRemoteConfig=false) → integration installs.
             // Then simulate remote config arriving with autocaptureExceptions=false → integration uninstalls.
             server.remoteConfigErrorTracking = ["autocaptureExceptions": false]
+            // Hold the /config response so the installed-by-default state is observable before it lands.
+            server.configResponseDelay = 0.5
 
             let token = "test_error_tracking_\(UUID().uuidString)"
             let config = PostHogConfig(projectToken: token, host: "http://localhost:9001")
@@ -183,11 +185,10 @@ class PostHogIntegrationInstallationTest {
             // Before /config arrives the integration must be installed (default-on)
             #expect(sut.getErrorTrackingIntegration() != nil)
 
-            // Wait for /config to arrive
-            let remoteConfigLoaded = AsyncLatch()
-            let token2 = sut.remoteConfig?.onRemoteConfigLoaded.subscribe { _ in remoteConfigLoaded.signal() }
-            await remoteConfigLoaded.wait()
-            _ = token2
+            // Poll for the end state rather than awaiting onRemoteConfigLoaded: multicast callbacks
+            // are unordered, so a subscriber can be notified before the integration's own removal
+            // callback has run.
+            await waitUntil(timeout: 10) { sut.getErrorTrackingIntegration() == nil }
 
             // After /config with autocaptureExceptions=false the integration must be removed
             #expect(sut.getErrorTrackingIntegration() == nil)
@@ -212,10 +213,12 @@ class PostHogIntegrationInstallationTest {
             let sut = PostHogSDK.with(config)
             defer { sut.close() }
 
-            let remoteConfigLoaded = AsyncLatch()
-            let token2 = sut.remoteConfig?.onRemoteConfigLoaded.subscribe { _ in remoteConfigLoaded.signal() }
-            await remoteConfigLoaded.wait()
-            _ = token2
+            #expect(sut.getErrorTrackingIntegration() != nil)
+
+            // onRemoteConfigLoaded is enqueued on main before hasFetchedRemoteConfig flips, so a
+            // main-queue hop after the flag flips guarantees any removal callback has already run.
+            await waitUntil(timeout: 10) { sut.remoteConfig?.hasFetchedRemoteConfig == true }
+            await MainActor.run {}
 
             #expect(sut.getErrorTrackingIntegration() != nil)
         }

--- a/PostHogTests/PostHogIntegrationInstallationTest.swift
+++ b/PostHogTests/PostHogIntegrationInstallationTest.swift
@@ -7,10 +7,15 @@
 
 @testable import PostHog
 import Testing
+import XCTest
 
 @Suite("Test integration installation", .serialized)
 class PostHogIntegrationInstallationTest {
+    var server: MockPostHogServer!
+
     init() {
+        server = MockPostHogServer()
+        server.start()
         #if os(iOS)
             PostHogReplayIntegration.clearInstalls()
         #endif
@@ -19,6 +24,14 @@ class PostHogIntegrationInstallationTest {
         #endif
         PostHogAppLifeCycleIntegration.clearInstalls()
         PostHogScreenViewIntegration.clearInstalls()
+        #if os(iOS) || os(macOS) || os(tvOS)
+            PostHogErrorTrackingAutoCaptureIntegration.clearInstalls()
+        #endif
+    }
+
+    deinit {
+        server.stop()
+        server = nil
     }
 
     private func getSut(
@@ -26,10 +39,15 @@ class PostHogIntegrationInstallationTest {
         sessionReplay: Bool = false,
         captureApplicationLifecycleEvents: Bool = false,
         captureScreenViews: Bool = false,
-        captureElementInteractions: Bool = false
+        captureElementInteractions: Bool = false,
+        disableRemoteConfig: Bool = true,
+        errorTrackingAutoCapture: Bool = false
     ) -> PostHogSDK {
-        let config = PostHogConfig(projectToken: projectToken)
+        let config = PostHogConfig(projectToken: projectToken, host: "http://localhost:9001")
         config.captureApplicationLifecycleEvents = captureApplicationLifecycleEvents
+        config.disableRemoteConfigForTesting = disableRemoteConfig
+        config.disableFlushOnBackgroundForTesting = true
+        config.disableReachabilityForTesting = true
 
         #if os(iOS)
             config.sessionReplay = sessionReplay
@@ -40,8 +58,7 @@ class PostHogIntegrationInstallationTest {
         #endif
 
         config.captureScreenViews = captureScreenViews
-        config.disableFlushOnBackgroundForTesting = true
-        config.disableReachabilityForTesting = true
+        config.errorTrackingConfig.autoCapture = errorTrackingAutoCapture
 
         let storage = PostHogStorage(config)
         storage.reset()
@@ -100,4 +117,107 @@ class PostHogIntegrationInstallationTest {
         first.close()
         second.close()
     }
+
+    // MARK: - Error tracking integration
+
+    #if os(iOS) || os(macOS) || os(tvOS)
+        @Test("error tracking integration installed on first launch before remote config arrives")
+        func errorTrackingInstalledBeforeRemoteConfig() {
+            // disableRemoteConfig=true means hasFetchedRemoteConfig stays false.
+            // The integration must install by default so a crash on the very first launch
+            // (before /config responds) is not silently missed.
+            let sut = getSut(
+                projectToken: "test_error_tracking_\(UUID().uuidString)",
+                disableRemoteConfig: true,
+                errorTrackingAutoCapture: true
+            )
+            defer { sut.close() }
+
+            #expect(sut.getErrorTrackingIntegration() != nil)
+        }
+
+        @Test("error tracking integration not installed when remote config already loaded and disabled")
+        func errorTrackingNotInstalledWhenRemoteConfigDisables() async {
+            // Seed the cached remote config with autocaptureExceptions=false so hasFetchedRemoteConfig
+            // is true and the gate blocks installation.
+            let token = "test_error_tracking_\(UUID().uuidString)"
+            let config = PostHogConfig(projectToken: token, host: "http://localhost:9001")
+            config.disableRemoteConfigForTesting = true
+            config.disableFlushOnBackgroundForTesting = true
+            config.disableReachabilityForTesting = true
+            config.errorTrackingConfig.autoCapture = true
+
+            let storage = PostHogStorage(config)
+            defer { storage.reset() }
+            // Seed cached config with autocapture disabled so hasFetchedRemoteConfig → true
+            storage.setDictionary(forKey: .remoteConfig, contents: ["errorTracking": ["autocaptureExceptions": false]])
+
+            let sut = PostHogSDK.with(config)
+            defer { sut.close() }
+
+            #expect(sut.getErrorTrackingIntegration() == nil)
+        }
+
+        @Test("error tracking integration uninstalls when remote config loads with autocapture disabled")
+        func errorTrackingUninstallsWhenRemoteConfigDisables() async {
+            // Start with no cached config (hasFetchedRemoteConfig=false) → integration installs.
+            // Then simulate remote config arriving with autocaptureExceptions=false → integration uninstalls.
+            server.remoteConfigErrorTracking = ["autocaptureExceptions": false]
+
+            let token = "test_error_tracking_\(UUID().uuidString)"
+            let config = PostHogConfig(projectToken: token, host: "http://localhost:9001")
+            config.disableRemoteConfigForTesting = false
+            config.preloadFeatureFlags = false
+            config.disableFlushOnBackgroundForTesting = true
+            config.disableReachabilityForTesting = true
+            config.errorTrackingConfig.autoCapture = true
+
+            let storage = PostHogStorage(config)
+            defer { storage.reset() }
+            // Ensure no cached remote config so hasFetchedRemoteConfig starts false
+            storage.remove(key: .remoteConfig)
+
+            let sut = PostHogSDK.with(config)
+            defer { sut.close() }
+
+            // Before /config arrives the integration must be installed (default-on)
+            #expect(sut.getErrorTrackingIntegration() != nil)
+
+            // Wait for /config to arrive
+            let remoteConfigLoaded = AsyncLatch()
+            let token2 = sut.remoteConfig?.onRemoteConfigLoaded.subscribe { _ in remoteConfigLoaded.signal() }
+            await remoteConfigLoaded.wait()
+            _ = token2
+
+            // After /config with autocaptureExceptions=false the integration must be removed
+            #expect(sut.getErrorTrackingIntegration() == nil)
+        }
+
+        @Test("error tracking integration stays installed when remote config loads with autocapture enabled")
+        func errorTrackingStaysInstalledWhenRemoteConfigEnables() async {
+            server.remoteConfigErrorTracking = ["autocaptureExceptions": true]
+
+            let token = "test_error_tracking_\(UUID().uuidString)"
+            let config = PostHogConfig(projectToken: token, host: "http://localhost:9001")
+            config.disableRemoteConfigForTesting = false
+            config.preloadFeatureFlags = false
+            config.disableFlushOnBackgroundForTesting = true
+            config.disableReachabilityForTesting = true
+            config.errorTrackingConfig.autoCapture = true
+
+            let storage = PostHogStorage(config)
+            defer { storage.reset() }
+            storage.remove(key: .remoteConfig)
+
+            let sut = PostHogSDK.with(config)
+            defer { sut.close() }
+
+            let remoteConfigLoaded = AsyncLatch()
+            let token2 = sut.remoteConfig?.onRemoteConfigLoaded.subscribe { _ in remoteConfigLoaded.signal() }
+            await remoteConfigLoaded.wait()
+            _ = token2
+
+            #expect(sut.getErrorTrackingIntegration() != nil)
+        }
+    #endif
 }

--- a/PostHogTests/PostHogIntegrationInstallationTest.swift
+++ b/PostHogTests/PostHogIntegrationInstallationTest.swift
@@ -223,5 +223,36 @@ class PostHogIntegrationInstallationTest {
 
             #expect(sut.getErrorTrackingIntegration() != nil)
         }
+
+        @Test("error tracking integration installs when live remote config enables after a cached-disabled start")
+        func errorTrackingInstallsWhenRemoteConfigEnablesAfterCachedDisable() async {
+            // Disk cache disables autocapture → integration is skipped at startup. The live /config
+            // then enables it → the integration must install rather than wait for the next launch.
+            server.remoteConfigErrorTracking = ["autocaptureExceptions": true]
+            server.configResponseDelay = 0.5
+
+            let token = "test_error_tracking_\(UUID().uuidString)"
+            let config = PostHogConfig(projectToken: token, host: "http://localhost:9001")
+            config.disableRemoteConfigForTesting = false
+            config.preloadFeatureFlags = false
+            config.disableFlushOnBackgroundForTesting = true
+            config.disableReachabilityForTesting = true
+            config.errorTrackingConfig.autoCapture = true
+
+            let storage = PostHogStorage(config)
+            defer { storage.reset() }
+            // Seed cached config with autocapture disabled so the startup gate skips installation.
+            storage.setDictionary(forKey: .remoteConfig, contents: ["errorTracking": ["autocaptureExceptions": false]])
+
+            let sut = PostHogSDK.with(config)
+            defer { sut.close() }
+
+            // Cached-disabled: not installed before the live /config lands.
+            #expect(sut.getErrorTrackingIntegration() == nil)
+
+            // Live /config enables autocapture → integration installs.
+            await waitUntil(timeout: 10) { sut.getErrorTrackingIntegration() != nil }
+            #expect(sut.getErrorTrackingIntegration() != nil)
+        }
     #endif
 }

--- a/PostHogTests/PostHogIntegrationInstallationTest.swift
+++ b/PostHogTests/PostHogIntegrationInstallationTest.swift
@@ -254,5 +254,34 @@ class PostHogIntegrationInstallationTest {
             await waitUntil(timeout: 10) { sut.getErrorTrackingIntegration() != nil }
             #expect(sut.getErrorTrackingIntegration() != nil)
         }
+
+        @Test("error tracking integration installs on re-install after a failed /config fetch")
+        func errorTrackingInstallsAfterFailedRemoteConfigFetch() async {
+            // A failed /config sets hasFetchedRemoteConfig=true but leaves no config data. A later
+            // re-install (here via optIn) must not read that failure as a remote disable — it should
+            // install by default, just as a first launch would.
+            let token = "test_error_tracking_\(UUID().uuidString)"
+            let config = PostHogConfig(projectToken: token, host: "http://localhost:9001")
+            config.disableRemoteConfigForTesting = true
+            config.disableFlushOnBackgroundForTesting = true
+            config.disableReachabilityForTesting = true
+            config.errorTrackingConfig.autoCapture = true
+            config.optOut = true // integrations are not installed while opted out
+
+            let storage = PostHogStorage(config)
+            storage.reset() // no cached config → the only remote state is the simulated failed fetch
+            defer { storage.reset() }
+
+            let sut = PostHogSDK.with(config)
+            defer { sut.close() }
+
+            #expect(sut.getErrorTrackingIntegration() == nil) // opted out, not installed yet
+
+            // Simulate a completed-but-failed /config: fetched flag set, no config data stored.
+            sut.remoteConfig?.setRemoteConfigDidFetchForTesting(true)
+
+            sut.optIn() // triggers re-install with a fetched-but-failed remote config
+            #expect(sut.getErrorTrackingIntegration() != nil)
+        }
     #endif
 }

--- a/PostHogTests/TestUtils/MockPostHogServer.swift
+++ b/PostHogTests/TestUtils/MockPostHogServer.swift
@@ -26,6 +26,7 @@ class MockPostHogServer {
     var flagsRequests = [URLRequest]()
     private var stubDescriptors = [HTTPStubsDescriptor]()
     var flagsResponseDelay: TimeInterval = 0
+    var configResponseDelay: TimeInterval = 0
     var flagsResponseHandler: ((URLRequest) -> HTTPStubsResponse)?
     /// If set, the closure is invoked for each `/i/v1/logs` request (with the
     /// 1-based request number) and returns the stub response. If `nil`, the
@@ -439,7 +440,11 @@ class MockPostHogServer {
                 }
                 """.data(using: .utf8)!
 
-            return HTTPStubsResponse(data: configData, statusCode: 200, headers: nil)
+            let response = HTTPStubsResponse(data: configData, statusCode: 200, headers: nil)
+            if self.configResponseDelay > 0 {
+                response.responseTime = self.configResponseDelay
+            }
+            return response
         })
 
         HTTPStubs.onStubActivation { request, _, _ in


### PR DESCRIPTION
## :bulb: Motivation and Context

Supersedes #689. I've carried the original approach forward and added the remaining fixes. Credit to @tsushanth for the initial implementation.

Fixes #551. Error-tracking autocapture never installed on a first app launch when there was no cached remote config, because installation raced the `/config` response. If the crash reporter wasn't installed before the app crashed on that first launch, the crash was missed entirely.

This installs the crash reporter by default at setup, before the first `/config` response arrives, so first-launch crashes are captured. Local config still wins: the integration is only added when `errorTrackingConfig.autoCapture` is on. If remote config (live or disk-cached) explicitly reports `autocaptureExceptions: false`, installation is skipped. And if a freshly-loaded config disables it after a default install, the integration is uninstalled and dropped from `installedIntegrations`, instead of being left installed with a released crash reporter.

## :green_heart: How did you test it?

Added tests in `PostHogIntegrationInstallationTest.swift`:

- installs before remote config arrives (first-launch default-on)
- does not install when remote config explicitly disables autocapture
- removes the integration when a freshly-loaded config disables it after a default install

All `installedIntegrations` mutations are guarded by `setupLock`. The timing-sensitive test polls for integration state instead of racing `onRemoteConfigLoaded`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**DRI:** @ioannisj
**Autonomy:** Human-driven (agent-assisted)
