### PR TITLE
fix: rage click interrupt

### DIFF
--- a/.changeset/rage-click-interrupt.md
+++ b/.changeset/rage-click-interrupt.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Fix rage click detection dismissing presented UI (e.g. popovers and sheets) on the opening tap. The hit-test fallback used to recover a tapped view now runs as a stateless query (`hitTest` with `nil`) instead of re-entering UIKit's hit-testing/gesture machinery with the in-flight event, which corrupted internal touch/gesture state.

--- a/PostHog/Autocapture/PostHogRageClickIntegration.swift
+++ b/PostHog/Autocapture/PostHogRageClickIntegration.swift
@@ -71,7 +71,7 @@
 
             // `touch.view` is nil for taps consumed by a gesture recognizer (text fields, pickers,
             // scroll views), so fall back to a hit-test to recover the tapped view.
-            let hitView = touch.view ?? window.hitTest(touchCoordinates, with: event)
+            let hitView = tappedView(touchView: touch.view, in: window, at: touchCoordinates, for: event)
 
             // Skip taps where rapid repeats are intentional before they reach the detector.
             // The ancestor walk covers UIKit; SwiftUI hosts controls below the hit view, so we
@@ -136,6 +136,18 @@
                 elementsChain: normalizedElementsChain,
                 properties: properties
             )
+        }
+
+        /// Resolves the tapped view, falling back to a hit-test when the touch itself has no view.
+        ///
+        /// IMPORTANT: the fallback hit-tests with `nil` (a stateless query), never the live `event`.
+        /// We run inside `UIApplication.sendEvent(_:)` (via swizzle), so re-entering UIKit's
+        /// hit-testing/gesture machinery with the in-flight event corrupts its internal touch/gesture
+        /// state and causes presented UI (e.g. PaperMarkupViewController popovers/sheets) to treat
+        /// the opening tap as an outside touch and dismiss immediately. `event` is accepted only to
+        /// make this contract explicit (and testable).
+        private func tappedView(touchView: UIView?, in window: UIWindow, at point: CGPoint, for _: UIEvent?) -> UIView? {
+            touchView ?? window.hitTest(point, with: nil)
         }
 
         private func currentScreenName() -> String? {
@@ -245,6 +257,10 @@
 
             func isRageClickIneligibleForTesting(view: UIView?, isKeyboardWindow: Bool = false) -> Bool {
                 isRageClickIneligible(view: view, isKeyboardWindow: isKeyboardWindow)
+            }
+
+            func tappedViewForTesting(touchView: UIView?, in window: UIWindow, at point: CGPoint, for event: UIEvent?) -> UIView? {
+                tappedView(touchView: touchView, in: window, at: point, for: event)
             }
         }
     #endif

--- a/PostHogTests/PostHogRageClickIntegrationTest.swift
+++ b/PostHogTests/PostHogRageClickIntegrationTest.swift
@@ -274,5 +274,65 @@
             #expect(integration.isRageClickIneligibleForTesting(view: UIView()) == false)
             #expect(integration.isRageClickIneligibleForTesting(view: nil) == false)
         }
+
+        // MARK: - Regression: markup/presented UI dismissed on open
+
+        /// A window that records every `event` argument passed to `hitTest(_:with:)`.
+        final class HitTestRecordingWindow: UIWindow {
+            /// Outer optional: `nil` means `hitTest` was never called.
+            /// Inner optional: the `event` value that was passed.
+            private(set) var recordedHitTestEvent: UIEvent??
+
+            override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+                recordedHitTestEvent = event
+                return super.hitTest(point, with: event)
+            }
+        }
+
+        /// Regression test for the bug where opening a `PaperMarkupViewController` (and other
+        /// presented popovers/sheets) got dismissed immediately.
+        ///
+        /// Root cause: the fallback hit-test forwarded the in-flight `UIEvent` from
+        /// `UIApplication.sendEvent(_:)` into `window.hitTest(_:with:)`, re-entering UIKit's
+        /// hit-testing/gesture machinery mid-delivery and corrupting touch state. The fix hit-tests
+        /// with `nil`. This asserts the live event is never forwarded, even when present.
+        @MainActor
+        @Test("Fallback hit-test never forwards the in-flight event (regression: markup dismissed on open)")
+        func fallbackHitTestNeverForwardsLiveEvent() throws {
+            let integration = PostHogRageClickIntegration()
+            let window = HitTestRecordingWindow(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+
+            // A non-nil, live-ish event that must NOT be forwarded to hitTest.
+            let liveEvent = UIEvent()
+
+            // touchView == nil forces the hit-test fallback path.
+            _ = integration.tappedViewForTesting(
+                touchView: nil,
+                in: window,
+                at: CGPoint(x: 10, y: 10),
+                for: liveEvent
+            )
+
+            let recorded = try #require(window.recordedHitTestEvent, "expected the fallback to perform a hit-test")
+            #expect(recorded == nil, "fallback hit-test must be stateless (with: nil), not the in-flight event")
+        }
+
+        /// When the touch already has a view, no hit-test should happen at all.
+        @MainActor
+        @Test("Fallback hit-test is skipped when the touch already has a view")
+        func noHitTestWhenTouchHasView() {
+            let integration = PostHogRageClickIntegration()
+            let window = HitTestRecordingWindow(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+            let existingView = UIView()
+
+            _ = integration.tappedViewForTesting(
+                touchView: existingView,
+                in: window,
+                at: CGPoint(x: 10, y: 10),
+                for: UIEvent()
+            )
+
+            #expect(window.recordedHitTestEvent == nil, "hitTest should not be called when touch.view is set")
+        }
     }
 #endif


### PR DESCRIPTION
We noticed that popovers such as PencilKit’s PaperMarkupViewController’s color pickers were dismissed immediately.

<img width="300" height="137" alt="bug" src="https://github.com/user-attachments/assets/c86e97d6-56a5-4843-9e1a-62e570046fca" />

Bisected to [b9861d880](https://github.com/PostHog/posthog-ios/commit/b9861d880) feat: skip rage clicks on keyboard, text inputs, steppers

 Root cause: PostHogRageClickIntegration.handleApplicationEvent(_:) runs on every
 UIApplication.sendEvent(_:) via swizzling. That commit added a fallback hit-test:

 ```swift
   let hitView = touch.view ?? window.hitTest(touchCoordinates, with: event)
 ```

 Passing the live, in-flight UIEvent into hitTest(_:with:) while UIKit is still mid-delivery of
 that same event re-enters UIKit's hit-testing/gesture machinery and corrupts its internal touch
 state. For a presented markup dialog (PaperMarkupViewController, which is a popover/sheet),
 UIKit then treats the opening tap as an outside touch and dismisses it immediately.

 Fix: Perform a stateless hit-test by passing nil instead of the live event:

 ```swift
   let hitView = touch.view ?? window.hitTest(touchCoordinates, with: nil)
 ```

 This still recovers the tapped view for rage-click eligibility checks without perturbing
 UIKit's active event delivery. The event parameter is still used elsewhere in the method
 (event.type, event.allTouches), so nothing else changes.