### PR TITLE
feat: support release-independent dsym upload via POSTHOG_NO_RELEASE_BIND

### DIFF
--- a/PostHog/PostHogContext.swift
+++ b/PostHog/PostHogContext.swift
@@ -45,13 +45,6 @@ class PostHogContext {
 
         properties["$app_namespace"] = getBundleIdentifier()
 
-        // Release id baked into the build by posthog-cli (Info.plist key `PostHogReleaseId`).
-        // Emitted on every event so the server resolves the release with a plain foreign-key
-        // lookup instead of matching on app version, which the upload can rename.
-        if let releaseId = infoDictionary?["PostHogReleaseId"] as? String, !releaseId.isEmpty {
-            properties["$release_id"] = releaseId
-        }
-
         properties["$device_manufacturer"] = "Apple"
         let deviceModel = platform()
         properties["$device_model"] = deviceModel

--- a/PostHog/PostHogContext.swift
+++ b/PostHog/PostHogContext.swift
@@ -45,6 +45,13 @@ class PostHogContext {
 
         properties["$app_namespace"] = getBundleIdentifier()
 
+        // Release id baked into the build by posthog-cli (Info.plist key `PostHogReleaseId`).
+        // Emitted on every event so the server resolves the release with a plain foreign-key
+        // lookup instead of matching on app version, which the upload can rename.
+        if let releaseId = infoDictionary?["PostHogReleaseId"] as? String, !releaseId.isEmpty {
+            properties["$release_id"] = releaseId
+        }
+
         properties["$device_manufacturer"] = "Apple"
         let deviceModel = platform()
         properties["$device_model"] = deviceModel

--- a/build-tools/upload-symbols.sh
+++ b/build-tools/upload-symbols.sh
@@ -22,13 +22,12 @@
 #   POSTHOG_INCLUDE_SOURCE - Set to "1" to include source files in dSYM upload
 #   POSTHOG_SKIP_ON_CONFLICT - Set to "1" to skip symbol sets that already exist
 #                              with different content instead of failing the build
-#   POSTHOG_NO_RELEASE_ASSOCIATION - Set to "1" to upload symbol sets without binding them to the
-#                              created release (via `dsym upload --no-release-association`). The
-#                              release is still created; the server resolves it from the
-#                              `$app_version` / `$app_namespace` / `$app_build` the SDK sends on
-#                              every event, so the uploaded chunks stay content-addressed and
-#                              release-independent. Requires a posthog-cli that supports
-#                              `dsym upload --no-release-association`.
+#   POSTHOG_NO_RELEASE_BIND - Set to "1" to upload symbol sets without binding them to the created
+#                              release (via `dsym upload --no-release-bind`). The release is still
+#                              created; the server resolves it from the `$app_version` /
+#                              `$app_namespace` / `$app_build` the SDK sends on every event, so the
+#                              uploaded chunks stay content-addressed and release-independent.
+#                              Requires a posthog-cli that supports `dsym upload --no-release-bind`.
 #
 
 # Skip non-Release builds.
@@ -136,8 +135,8 @@ fi
 # Optionally upload the symbol sets without binding them to the release. The release is still
 # created, and the server resolves it from the $app_version / $app_namespace / $app_build the SDK
 # sends on every event, so nothing is written into the built bundle.
-if [ "${POSTHOG_NO_RELEASE_ASSOCIATION}" = "1" ]; then
-    CLI_ARGS+=(--no-release-association)
+if [ "${POSTHOG_NO_RELEASE_BIND}" = "1" ]; then
+    CLI_ARGS+=(--no-release-bind)
 fi
 
 "${PH_CLI_PATH}" dsym upload "${CLI_ARGS[@]}" || exit 1

--- a/build-tools/upload-symbols.sh
+++ b/build-tools/upload-symbols.sh
@@ -28,7 +28,7 @@
 #                              created; the server resolves it from the `$app_version` /
 #                              `$app_namespace` / `$app_build` the SDK sends on every event, so the
 #                              uploaded chunks stay content-addressed and release-independent.
-#                              Requires a posthog-cli that supports `dsym upload --no-release-bind`.
+#                              Requires posthog-cli >= 0.10.0.
 #
 
 # Skip non-Release builds.
@@ -92,6 +92,9 @@ fi
 MIN_POSTHOG_CLI_VERSION="0.7.7"
 if [ "${POSTHOG_SKIP_ON_CONFLICT}" = "1" ]; then
     MIN_POSTHOG_CLI_VERSION="0.7.12"
+fi
+if [ "${POSTHOG_NO_RELEASE_BIND}" = "1" ]; then
+    MIN_POSTHOG_CLI_VERSION="0.10.0"
 fi
 PH_CLI_VERSION=$("$PH_CLI_PATH" --version 2>/dev/null | grep -oE '[0-9]+(\.[0-9]+)+' | head -n1)
 

--- a/build-tools/upload-symbols.sh
+++ b/build-tools/upload-symbols.sh
@@ -12,6 +12,7 @@
 #   Basic:          "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
 #   With source:    POSTHOG_INCLUDE_SOURCE=1 "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
 #   Skip conflicts: POSTHOG_SKIP_ON_CONFLICT=1 "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
+#   No release bind: POSTHOG_NO_RELEASE_BIND=1 "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
 #
 # Build Settings (required):
 #   DEBUG_INFORMATION_FORMAT = DWARF with dSYM File

--- a/build-tools/upload-symbols.sh
+++ b/build-tools/upload-symbols.sh
@@ -22,6 +22,13 @@
 #   POSTHOG_INCLUDE_SOURCE - Set to "1" to include source files in dSYM upload
 #   POSTHOG_SKIP_ON_CONFLICT - Set to "1" to skip symbol sets that already exist
 #                              with different content instead of failing the build
+#   POSTHOG_NO_RELEASE_ASSOCIATION - Set to "1" to upload symbol sets without binding them to the
+#                              created release (via `dsym upload --no-release-association`). The
+#                              release is still created; the server resolves it from the
+#                              `$app_version` / `$app_namespace` / `$app_build` the SDK sends on
+#                              every event, so the uploaded chunks stay content-addressed and
+#                              release-independent. Requires a posthog-cli that supports
+#                              `dsym upload --no-release-association`.
 #
 
 # Skip non-Release builds.
@@ -124,6 +131,13 @@ if [ "${POSTHOG_INCLUDE_SOURCE}" = "1" ]; then
 fi
 if [ "${POSTHOG_SKIP_ON_CONFLICT}" = "1" ]; then
     CLI_ARGS+=(--skip-on-conflict)
+fi
+
+# Optionally upload the symbol sets without binding them to the release. The release is still
+# created, and the server resolves it from the $app_version / $app_namespace / $app_build the SDK
+# sends on every event, so nothing is written into the built bundle.
+if [ "${POSTHOG_NO_RELEASE_ASSOCIATION}" = "1" ]; then
+    CLI_ARGS+=(--no-release-association)
 fi
 
 "${PH_CLI_PATH}" dsym upload "${CLI_ARGS[@]}" || exit 1


### PR DESCRIPTION
## :bulb: Motivation and Context

iOS resolves the release from the app metadata every event already carries (`$app_namespace`, `$app_version`, `$app_build`), so nothing is injected into the bundle and the SDK needs no change.

This PR is just the build-tools side: `upload-symbols.sh` gains `POSTHOG_NO_RELEASE_BIND`, which runs `dsym upload --no-release-bind` (release still created, symbol sets left release-independent).

**Related:** CLI flag in PostHog/posthog#75248 · cymbal resolver in PostHog/posthog#75254 · companion to PostHog/posthog-js#4308.

> ⚠️ **Do not merge** until the cymbal resolver (**PostHog/posthog#75254**) lands.

## :green_heart: How did you test it?

End-to-end against a local stack: built the example app, uploaded the dSYM with `POSTHOG_NO_RELEASE_BIND`, confirmed the server resolved the release from app metadata (no `$release_id` on the event) and frames resolved with source.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Only `upload-symbols.sh` changes; an earlier iteration also read a `PostHogReleaseId` plist key in the SDK, dropped since the app-metadata path makes it unnecessary.
