### PR TITLE
fix: identify anonymous user when id already matches persisted distinct id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: `identify()` no longer leaves a user anonymous when the supplied ID already matches the persisted distinct ID (for example after a non-identified bootstrap seeded the same ID); the SDK now marks the user identified and captures a person-processed `$set` event
+
 ## 3.68.4
 
 ### Patch Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- fix: `identify()` no longer leaves a user anonymous when the supplied ID already matches the persisted distinct ID (for example after a non-identified bootstrap seeded the same ID); the SDK now marks the user identified and captures a person-processed `$set` event
+- fix: `identify()` no longer leaves a user anonymous when the supplied ID already matches the persisted distinct ID (for example after a non-identified bootstrap seeded the same ID); the SDK now marks the user identified and captures a person-processed `$set` event. The identity transition is now atomic, so concurrent `identify()` calls can no longer emit duplicate person events for the same transition
 
 ## 3.68.4
 

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -763,6 +763,7 @@ let maxRetryDelay = 30.0
         let isIdentified = storageManager.isIdentified()
 
         let hasDifferentDistinctId = distinctId != oldDistinctId
+        let shouldTransitionToIdentified = !hasDifferentDistinctId && !isIdentified
 
         if hasDifferentDistinctId, !isIdentified {
             var props: [String: Any] = ["distinct_id": distinctId]
@@ -799,6 +800,37 @@ let maxRetryDelay = 30.0
 
             // we need to make sure the user props update is for the same user
             // otherwise they have to reset and identify again
+        } else if shouldTransitionToIdentified {
+            // Matching id while still anonymous (e.g. a non-identified bootstrap seeded the same
+            // id): upgrade to identified and emit one person-processed $set — there is no
+            // anonymous id to merge, so no $identify (matches posthog-js).
+            storageManager.setIdentified(true)
+
+            setPersonPropertiesForFlagsIfNeeded(userProperties, userPropertiesSetOnce: userPropertiesSetOnce)
+
+            capture("$set",
+                    distinctId: distinctId,
+                    userProperties: userProperties,
+                    userPropertiesSetOnce: userPropertiesSetOnce)
+
+            // The transition event must fire even when an identical property call was cached
+            // earlier; cache only after capture so deduplication cannot suppress it.
+            let hash = getPersonPropertiesHash(
+                distinctId: distinctId,
+                userPropertiesToSet: userProperties,
+                userPropertiesToSetOnce: userPropertiesSetOnce
+            )
+            cachedPersonPropertiesLock.withLock {
+                cachedPersonPropertiesHash = hash
+            }
+
+            // The identified state itself is not part of the flags request; reload only when the
+            // caller supplied properties that can affect flag evaluation.
+            if !(userProperties?.isEmpty ?? true) || !(userPropertiesSetOnce?.isEmpty ?? true) {
+                remoteConfig?.reloadFeatureFlags()
+            }
+
+            notifyContextDidChange()
         } else if !hasDifferentDistinctId, !(userProperties?.isEmpty ?? true) || !(userPropertiesSetOnce?.isEmpty ?? true) {
             if !shouldCapturePersonPropertiesEvent(
                 distinctId: distinctId,

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -40,6 +40,7 @@ let maxRetryDelay = 30.0
     private let flagCallReportedLock = NSLock()
     private let personPropsLock = NSLock()
     private let cachedPersonPropertiesLock = NSLock()
+    private let identifyLock = NSLock()
     private var cachedPersonPropertiesHash: String?
 
     private let lastScreenLock = NSLock()
@@ -760,22 +761,36 @@ let maxRetryDelay = 30.0
         }
         let oldDistinctId = getDistinctId()
 
-        let isIdentified = storageManager.isIdentified()
+        var isIdentified = false
+        var hasDifferentDistinctId = false
+        var shouldTransitionToIdentified = false
 
-        let hasDifferentDistinctId = distinctId != oldDistinctId
-        let shouldTransitionToIdentified = !hasDifferentDistinctId && !isIdentified
+        // Read isIdentified, decide the transition, and persist it atomically so two
+        // concurrent identify() calls on an anonymous user can't both see isIdentified
+        // == false and each emit a person-processed event for the same transition.
+        identifyLock.withLock {
+            isIdentified = storageManager.isIdentified()
+            hasDifferentDistinctId = distinctId != oldDistinctId
+            shouldTransitionToIdentified = !hasDifferentDistinctId && !isIdentified
+
+            if hasDifferentDistinctId, !isIdentified {
+                if !config.reuseAnonymousId {
+                    // We keep the AnonymousId to be used by flags calls and identify to link the previousId
+                    storageManager.setAnonymousId(oldDistinctId)
+                }
+                storageManager.setDistinctId(distinctId)
+                storageManager.setIdentified(true)
+            } else if shouldTransitionToIdentified {
+                storageManager.setIdentified(true)
+            }
+        }
 
         if hasDifferentDistinctId, !isIdentified {
             var props: [String: Any] = ["distinct_id": distinctId]
 
             if !config.reuseAnonymousId {
-                // We keep the AnonymousId to be used by flags calls and identify to link the previousId
-                storageManager.setAnonymousId(oldDistinctId)
                 props["$anon_distinct_id"] = oldDistinctId
             }
-
-            storageManager.setDistinctId(distinctId)
-            storageManager.setIdentified(true)
 
             let properties = buildProperties(
                 distinctId: distinctId,
@@ -804,7 +819,7 @@ let maxRetryDelay = 30.0
             // Matching id while still anonymous (e.g. a non-identified bootstrap seeded the same
             // id): upgrade to identified and emit one person-processed $set — there is no
             // anonymous id to merge, so no $identify (matches posthog-js).
-            storageManager.setIdentified(true)
+            // setIdentified(true) already performed above under identifyLock.
 
             setPersonPropertiesForFlagsIfNeeded(userProperties, userPropertiesSetOnce: userPropertiesSetOnce)
 

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -318,6 +318,32 @@ class PostHogSDKTest: QuickSpec {
             expect(events[1].event) == "event"
         }
 
+        it("forwards userProperties and userPropertiesSetOnce on a matching-id identify") {
+            let config = bootstrapReconcileConfig(existing: (anon: "user-123", distinct: nil, identified: false))
+            config.captureApplicationLifecycleEvents = false
+            config.flushAt = 1
+
+            let sut = PostHogSDK.with(config)
+            self.trackedSuts.append(sut)
+
+            sut.identify("user-123", userProperties: ["foo": "bar"], userPropertiesSetOnce: ["baz": "qux"])
+
+            let events = getBatchedEvents(server)
+            expect(events.count) == 1
+
+            let event = events.first!
+            expect(event.event) == "$set"
+            expect(event.properties["$process_person_profile"] as? Bool) == true
+
+            let set = event.properties["$set"] as? [String: Any] ?? [:]
+            expect(set["foo"] as? String) == "bar"
+
+            let setOnce = event.properties["$set_once"] as? [String: Any] ?? [:]
+            expect(setOnce["baz"] as? String) == "qux"
+
+            expect(config.storageManager?.isIdentified()) == true
+        }
+
         it("captures the capture event") {
             let sut = self.getSut()
 

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -280,6 +280,44 @@ class PostHogSDKTest: QuickSpec {
             expect(config.storageManager?.isIdentified()) == false
         }
 
+        it("identifies an anonymous user via identify() when the id already matches the persisted distinct id") {
+            // Anonymous user whose persisted id already equals the id being identified with
+            // (e.g. a non-identified bootstrap seeded the same id).
+            let config = bootstrapReconcileConfig(existing: (anon: "user-123", distinct: nil, identified: false))
+            config.captureApplicationLifecycleEvents = false
+            config.flushAt = 1
+
+            let sut = PostHogSDK.with(config)
+            self.trackedSuts.append(sut)
+
+            sut.identify("user-123")
+
+            // No $identify (nothing to merge); a single person-processed $set marks the transition.
+            let events = getBatchedEvents(server)
+            expect(events.count) == 1
+            expect(events.first?.event) == "$set"
+            expect(events.first?.properties["$process_person_profile"] as? Bool) == true
+            expect(config.storageManager?.isIdentified()) == true
+        }
+
+        it("does not emit a second $set on a repeated matching-id identify") {
+            let config = bootstrapReconcileConfig(existing: (anon: "user-123", distinct: nil, identified: false))
+            config.captureApplicationLifecycleEvents = false
+            config.flushAt = 2
+
+            let sut = PostHogSDK.with(config)
+            self.trackedSuts.append(sut)
+
+            sut.identify("user-123") // transition: one $set
+            sut.identify("user-123") // already identified: no event
+            sut.capture("event") // flushes the batch (flushAt 2)
+
+            let events = getBatchedEvents(server)
+            expect(events.count) == 2
+            expect(events[0].event) == "$set"
+            expect(events[1].event) == "event"
+        }
+
         it("captures the capture event") {
             let sut = self.getSut()
 


### PR DESCRIPTION
## :bulb: Motivation & Context

Calling `identify(id)` where `id` already equals the persisted distinct ID left the user anonymous: no identity transition fired, no person-processed event was sent, and `$is_identified` stayed `false`. This is easy to hit after a non-identified bootstrap, where the bootstrap ID is seeded as the anonymous ID, so a later `identify(sameId)` matches the stored distinct ID and the transition is skipped.

The transition is also now atomic under a lock, so two concurrent `identify()` calls on an anonymous user can't both emit a person-processed event for the same transition.

Ports the browser fix from PostHog/posthog-js#4328 to iOS.

## :green_heart: How did you test it?

Added a regression test for the matching-ID-while-anonymous path: the user ends up identified, one person-processed `$set` is captured (no `$identify`, since there's no anonymous ID to merge), and flags reload only when properties that affect evaluation are supplied. Ran the unit suite, green.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change, or an entry was added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**DRI:** @ioannisj
**Autonomy:** Human-driven (agent-assisted)
