### PR TITLE
fix: support CocoaPods static library archives

### DIFF
--- a/.changeset/fix-cocoapods-static-library-archives.md
+++ b/.changeset/fix-cocoapods-static-library-archives.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Fix CocoaPods static-library archives by skipping emitted module interface verification for source pod builds.

--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,10 @@ buildExamplePodsStaticFramework:
 		-scheme PostHogExampleWithPods \
 		-destination generic/platform=ios | xcpretty
 
-buildExamplePodsStaticLib: 
+buildExamplePodsStaticLib:
 	cd PostHogExampleWithPods && \
 	pod install && cd .. && \
-	set -o pipefail && xcrun xcodebuild clean build \
+	set -o pipefail && xcrun xcodebuild clean archive \
 		-workspace PostHogExampleWithPods/PostHogExampleWithPods.xcworkspace \
 		-scheme PostHogExampleWithPods \
 		-destination generic/platform=ios | xcpretty

--- a/PostHog.podspec
+++ b/PostHog.podspec
@@ -30,6 +30,9 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES',
     'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) PLCR_PRIVATE PLCF_RELEASE_BUILD PLCRASHREPORTER_PREFIX=PH SWIFT_PACKAGE',
+    # Static-library source pods cannot resolve the underlying Objective-C module
+    # while verifying the emitted Swift interface.
+    'SWIFT_VERIFY_EMITTED_MODULE_INTERFACE' => 'NO',
     'HEADER_SEARCH_PATHS' => '$(inherited) "${PODS_TARGET_SRCROOT}/vendor/PHPLCrashReporter/Source"',
     'SWIFT_INCLUDE_PATHS' => '$(inherited) "${PODS_TARGET_SRCROOT}/PostHog/PrivateModules/phlibwebp" "${PODS_TARGET_SRCROOT}/PostHog/PrivateModules/PHPLCrashReporter" "${PODS_TARGET_SRCROOT}/PostHog/PrivateModules/PostHogObjCExceptionSupport"'
   }


### PR DESCRIPTION
## :bulb: Motivation and Context

CocoaPods static-library consumers can fail to archive on Xcode 26.2 when library evolution causes Swift to verify an emitted mixed Swift/Objective-C module interface. The interface imports its own underlying Objective-C module, which is not resolvable during the static-library verification job.

Addresses #744.

## :green_heart: How did you test it?

- `make buildExamplePodsStaticLib` using the updated podspec through a clean local `:podspec` installation (Release archive)
- `make buildExamplePodsStaticFramework`
- `make buildExamplePodsDynamicFramework`
- `pod lib lint PostHog.podspec --allow-warnings --skip-tests --use-libraries --platforms=ios`
- `make test` (737 tests)
- `make format`
- `make lint`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent, a reviewer subagent, the autoreview skill, and GitHub CLI. Removing library evolution from the source pod was tested but caused consumer builds to lose the SDK's private implementation modules, so the pod retains library evolution and disables only producer-side emitted-interface verification. The CocoaPods static-library example now performs a Release archive to cover the reported build path.
