### PR TITLE
fix: support CocoaPods static libraries on Xcode 16.2

### DIFF
--- a/.changeset/fix-cocoapods-module-verification-xcode-16.md
+++ b/.changeset/fix-cocoapods-module-verification-xcode-16.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Fix CocoaPods static-library builds on older Xcode versions by disabling emitted module interface verification with the Swift compiler flag.

--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -56,22 +56,32 @@ jobs:
         run: make buildExampleXCFramework
 
   build-pods:
-    runs-on: macos-15
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: Static Lib
             target: buildExamplePodsStaticLib
+            runner: macos-15
+            xcode-version: latest-stable
+          - name: Static Lib (Xcode 16.2)
+            target: buildExamplePodsStaticLib
+            runner: macos-14-xlarge
+            xcode-version: '16.2'
           - name: Static Framework
             target: buildExamplePodsStaticFramework
+            runner: macos-15
+            xcode-version: latest-stable
           - name: Dynamic Framework
             target: buildExamplePodsDynamicFramework
+            runner: macos-15
+            xcode-version: latest-stable
     name: Example Pods (${{ matrix.name }})
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
-          xcode-version: latest-stable
+          xcode-version: ${{ matrix.xcode-version }}
       - name: Build Pods Example (${{ matrix.name }})
         run: make ${{ matrix.target }}

--- a/PostHog.podspec
+++ b/PostHog.podspec
@@ -31,8 +31,10 @@ Pod::Spec.new do |s|
     'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES',
     'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) PLCR_PRIVATE PLCF_RELEASE_BUILD PLCRASHREPORTER_PREFIX=PH SWIFT_PACKAGE',
     # Static-library source pods cannot resolve the underlying Objective-C module
-    # while verifying the emitted Swift interface.
+    # while verifying the emitted Swift interface. Xcode 16.2 still schedules
+    # verification when the build setting is NO, so pass the compiler flag as well.
     'SWIFT_VERIFY_EMITTED_MODULE_INTERFACE' => 'NO',
+    'OTHER_SWIFT_FLAGS' => '$(inherited) -no-verify-emitted-module-interface',
     'HEADER_SEARCH_PATHS' => '$(inherited) "${PODS_TARGET_SRCROOT}/vendor/PHPLCrashReporter/Source"',
     'SWIFT_INCLUDE_PATHS' => '$(inherited) "${PODS_TARGET_SRCROOT}/PostHog/PrivateModules/phlibwebp" "${PODS_TARGET_SRCROOT}/PostHog/PrivateModules/PHPLCrashReporter" "${PODS_TARGET_SRCROOT}/PostHog/PrivateModules/PostHogObjCExceptionSupport"'
   }


### PR DESCRIPTION
## :bulb: Motivation and Context

PostHog 3.69.1 attempted to fix CocoaPods static-library archives by setting `SWIFT_VERIFY_EMITTED_MODULE_INTERFACE = NO`, but the React Native plugin CI still reproduces the same `SwiftVerifyEmittedModuleInterface` failure on Xcode 16.2. Xcode 16.2 continues scheduling verification despite that build setting.

This follows up on #744 and unblocks [PostHog/posthog-js#4415](https://github.com/PostHog/posthog-js/pull/4415).

The podspec now also passes Swift's `-no-verify-emitted-module-interface` compiler flag. The existing build setting remains for Xcode versions that honor it. Static-library CI now covers both latest Xcode and the failing Xcode 16.2 environment.

## :green_heart: How did you test it?

- `pod spec lint PostHog.podspec --quick --allow-warnings`
- Installed the local podspec as a CocoaPods static library and verified the generated PostHog xcconfig includes the compiler flag.
- Built the static-library example in Release configuration with XcodeBuildMCP.
- Forced `SWIFT_VERIFY_EMITTED_MODULE_INTERFACE = YES` in the generated xcconfig and verified the compiler flag still lets the Release build succeed.
- Ran autoreview against `origin/main` with no actionable findings.

The added CI matrix entry performs the exact Xcode 16.2 static-library archive regression check.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated with the Pi coding agent, reviewer/advisor subagents, XcodeBuildMCP CLI, and the autoreview skill. The first fix was confirmed to work on newer Xcode but not Xcode 16.2, so this keeps the existing build setting and adds the compiler-level fallback. Latest-Xcode static-library coverage is retained alongside the targeted Xcode 16.2 regression job.
