### PR TITLE
fix: forward push notification opens to Objective-C delegates

### DIFF
--- a/.changeset/calm-pushes-forward.md
+++ b/.changeset/calm-pushes-forward.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': patch
+---
+
+Fix push notification open forwarding for Objective-C delegates.

--- a/Package.swift
+++ b/Package.swift
@@ -44,6 +44,11 @@ let package = Package(
             publicHeadersPath: "."
         ),
         .target(
+            name: "PostHogTestsObjC",
+            path: "PostHogTestsObjC",
+            publicHeadersPath: "."
+        ),
+        .target(
             name: "phlibwebp",
             path: "vendor/libwebp",
             publicHeadersPath: ".",
@@ -89,6 +94,7 @@ let package = Package(
             name: "PostHogTests",
             dependencies: [
                 "PostHog",
+                "PostHogTestsObjC",
                 "Quick",
                 "Nimble",
                 "OHHTTPStubs",

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -43,6 +43,11 @@ let package = Package(
             publicHeadersPath: "."
         ),
         .target(
+            name: "PostHogTestsObjC",
+            path: "PostHogTestsObjC",
+            publicHeadersPath: "."
+        ),
+        .target(
             name: "phlibwebp",
             path: "vendor/libwebp",
             publicHeadersPath: ".",
@@ -88,6 +93,7 @@ let package = Package(
             name: "PostHogTests",
             dependencies: [
                 "PostHog",
+                "PostHogTestsObjC",
                 "Quick",
                 "Nimble",
                 "OHHTTPStubs",

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B74800000000000000000001 /* PostHogPushNotificationSwizzlingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B74800000000000000000003 /* PostHogPushNotificationSwizzlingTest.swift */; };
+		B74800000000000000000002 /* PHNotificationDelegateTestFixture.m in Sources */ = {isa = PBXBuildFile; fileRef = B74800000000000000000006 /* PHNotificationDelegateTestFixture.m */; };
 		0799FC592DA8A0837BC771E3 /* PLCrashAsyncDwarfEncoding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8E1E01C22EB902B360AE5A3 /* PLCrashAsyncDwarfEncoding.cpp */; };
 		081C4D5910919F0E5872CAC2 /* PostHogBootstrapConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CBE5E053785289B0CCA4ED /* PostHogBootstrapConfig.swift */; };
 		08CF51A212DF4E6ABF3DDA77 /* PLCrashMachExceptionPort.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D784BEF45D7E472FBE56B84 /* PLCrashMachExceptionPort.m */; };
@@ -764,6 +766,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		B74800000000000000000003 /* PostHogPushNotificationSwizzlingTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogPushNotificationSwizzlingTest.swift; sourceTree = "<group>"; };
+		B74800000000000000000004 /* PostHogTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PostHogTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		B74800000000000000000005 /* PHNotificationDelegateTestFixture.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PHNotificationDelegateTestFixture.h; sourceTree = "<group>"; };
+		B74800000000000000000006 /* PHNotificationDelegateTestFixture.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PHNotificationDelegateTestFixture.m; sourceTree = "<group>"; };
 		001A4831298758176E2711B8 /* PLCrashLogWriter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PLCrashLogWriter.m; path = vendor/PHPLCrashReporter/Source/PLCrashLogWriter.m; sourceTree = "<group>"; };
 		00F98E7D98CC906E4BA3D582 /* PostHogReachabilityTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostHogReachabilityTest.swift; sourceTree = "<group>"; };
 		045078ECC7B3488DA27D06E9 /* PostHogLogger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostHogLogger.swift; sourceTree = "<group>"; };
@@ -1564,6 +1570,15 @@
 			path = Utils;
 			sourceTree = "<group>";
 		};
+		B74800000000000000000007 /* PostHogTestsObjC */ = {
+			isa = PBXGroup;
+			children = (
+				B74800000000000000000005 /* PHNotificationDelegateTestFixture.h */,
+				B74800000000000000000006 /* PHNotificationDelegateTestFixture.m */,
+			);
+			path = PostHogTestsObjC;
+			sourceTree = "<group>";
+		};
 		3AC745AB296D6FE60025C109 = {
 			isa = PBXGroup;
 			children = (
@@ -1575,6 +1590,7 @@
 				3AAFB13129C0C699004F485B /* Package.swift */,
 				3AC745B7296D6FE60025C109 /* PostHog */,
 				3AC745C3296D6FE60025C109 /* PostHogTests */,
+				B74800000000000000000007 /* PostHogTestsObjC */,
 				3AA34CF8296D951A003398F4 /* PostHogExample */,
 				69278D332AE6BC7100BB541A /* PostHogObjCExample */,
 				699991862AFE1B37000DCB78 /* PostHogExampleMacOS */,
@@ -1661,6 +1677,8 @@
 		3AC745C3296D6FE60025C109 /* PostHogTests */ = {
 			isa = PBXGroup;
 			children = (
+				B74800000000000000000004 /* PostHogTests-Bridging-Header.h */,
+				B74800000000000000000003 /* PostHogPushNotificationSwizzlingTest.swift */,
 				DA27AEC82F56B3F3002A59CE /* PostHogSamplingTest.swift */,
 				DB7100052F80000100000001 /* PostHogTracingHeadersTest.swift */,
 				DA27AEC02F56B3E3002A59CE /* PostHogSessionReplayEventTriggersTest.swift */,
@@ -3422,6 +3440,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B74800000000000000000001 /* PostHogPushNotificationSwizzlingTest.swift in Sources */,
+				B74800000000000000000002 /* PHNotificationDelegateTestFixture.m in Sources */,
 				DA979D7B2CD370B700F56BAE /* PostHogAutocaptureEventTrackerSpec.swift in Sources */,
 				DA0C944B2D54CDD000BFD9FB /* PostHogStorageMigrationTest.swift in Sources */,
 				690FF0F52AF0F06100A0B06B /* PostHogSDKTest.swift in Sources */,
@@ -4002,7 +4022,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/PostHog/PrivateModules/phlibwebp $(SRCROOT)/PostHog/PrivateModules/PHPLCrashReporter $(SRCROOT)/PostHog/PrivateModules/PostHogObjCExceptionSupport";
-				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_OBJC_BRIDGING_HEADER = "PostHogTests/PostHogTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,7";
@@ -4036,7 +4056,7 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/PostHog/PrivateModules/phlibwebp $(SRCROOT)/PostHog/PrivateModules/PHPLCrashReporter $(SRCROOT)/PostHog/PrivateModules/PostHogObjCExceptionSupport";
-				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_OBJC_BRIDGING_HEADER = "PostHogTests/PostHogTests-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,7";
 				TVOS_DEPLOYMENT_TARGET = 13.0;
@@ -4493,7 +4513,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "TESTING DEBUG";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/PostHog/PrivateModules/phlibwebp $(SRCROOT)/PostHog/PrivateModules/PHPLCrashReporter $(SRCROOT)/PostHog/PrivateModules/PostHogObjCExceptionSupport";
-				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_OBJC_BRIDGING_HEADER = "PostHogTests/PostHogTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,7";

--- a/PostHog/PushNotifications/PushNotificationPublisher.swift
+++ b/PostHog/PushNotifications/PushNotificationPublisher.swift
@@ -19,6 +19,15 @@
 
     // MARK: - Publisher
 
+    private final class OriginalDelegateIMP {
+        let lock = NSLock()
+        var value: IMP?
+
+        init(_ value: IMP?) {
+            self.value = value
+        }
+    }
+
     /// Owns all push-notification swizzling and publishes events to subscribers.
     ///
     /// Swizzles are installed when the first subscriber attaches and removed when the last one detaches,
@@ -64,33 +73,98 @@
 
         private static let delegateSetterOriginal = #selector(setter: UNUserNotificationCenter.delegate)
         private static let delegateSetterSwizzled = #selector(UNUserNotificationCenter.ph_swizzled_setDelegate(_:))
+        private static let didReceiveResponseSelector = #selector(
+            UNUserNotificationCenterDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:)
+        )
 
         private func swizzleNotificationCenterDelegateSetter() {
             swizzle(forClass: UNUserNotificationCenter.self, original: Self.delegateSetterOriginal, new: Self.delegateSetterSwizzled)
         }
 
         private func unswizzleNotificationCenterDelegateSetter() {
-            // Calling swizzle() again reverses the exchange. `swizzledDelegateClasses` is deliberately
-            // NOT cleared: the per-class `didReceive` swaps stay in place for the process lifetime
-            // (invoking an empty multicast is a no-op), and clearing the set would make a re-install
-            // exchange the implementations a second time — swapping our handler back OUT.
+            // Calling swizzle() again reverses the setter exchange. `swizzledDelegateClasses` is
+            // deliberately NOT cleared: the per-class `didReceive` replacements stay in place for the
+            // process lifetime (invoking an empty multicast is a no-op), and clearing the set would wrap
+            // an already-replaced method on re-install.
             swizzle(forClass: UNUserNotificationCenter.self, original: Self.delegateSetterOriginal, new: Self.delegateSetterSwizzled)
         }
 
         func swizzleNotificationDelegateMethods(on delegateClass: AnyClass) {
-            let classId = ObjectIdentifier(delegateClass)
-            let alreadySwizzled = delegateClassesLock.withLock {
-                !swizzledDelegateClasses.insert(classId).inserted
+            delegateClassesLock.withLock {
+                let classId = ObjectIdentifier(delegateClass)
+                guard !swizzledDelegateClasses.contains(classId) else { return }
+
+                let selector = Self.didReceiveResponseSelector
+                let originalMethod = class_getInstanceMethod(delegateClass, selector)
+                let originalImplementation = originalMethod.map(method_getImplementation)
+                let ownsMethod = originalMethod != class_getSuperclass(delegateClass).flatMap {
+                    class_getInstanceMethod($0, selector)
+                }
+                if !ownsMethod {
+                    var superclass: AnyClass? = class_getSuperclass(delegateClass)
+                    while let current = superclass {
+                        if swizzledDelegateClasses.contains(ObjectIdentifier(current)) {
+                            swizzledDelegateClasses.insert(classId)
+                            return
+                        }
+                        superclass = class_getSuperclass(current)
+                    }
+                }
+
+                let typeEncoding: UnsafePointer<CChar>?
+                if let originalMethod {
+                    typeEncoding = method_getTypeEncoding(originalMethod)
+                } else {
+                    guard let delegateProtocol = objc_getProtocol("UNUserNotificationCenterDelegate") else {
+                        hedgeLog("Push notification publisher: UNUserNotificationCenterDelegate protocol not found")
+                        return
+                    }
+                    typeEncoding = protocol_getMethodDescription(delegateProtocol, selector, false, true).types.map {
+                        UnsafePointer<CChar>($0)
+                    }
+                }
+                guard let typeEncoding else {
+                    hedgeLog("Push notification publisher: type encoding not found for \(selector)")
+                    return
+                }
+
+                typealias CompletionHandler = @convention(block) () -> Void
+                typealias OriginalImplementation = @convention(c) (
+                    AnyObject,
+                    Selector,
+                    UNUserNotificationCenter,
+                    UNNotificationResponse,
+                    CompletionHandler
+                ) -> Void
+                typealias ReplacementBlock = @convention(block) (
+                    AnyObject,
+                    UNUserNotificationCenter,
+                    UNNotificationResponse,
+                    CompletionHandler
+                ) -> Void
+
+                let implementationHolder = OriginalDelegateIMP(originalImplementation)
+                let replacement: ReplacementBlock = { delegate, center, response, completionHandler in
+                    DI.main.pushNotificationPublisher.onNotificationResponse.invoke(response)
+                    guard let originalImplementation = implementationHolder.lock.withLock({ implementationHolder.value }) else {
+                        completionHandler()
+                        return
+                    }
+                    // Call the captured IMP with its original selector. Aliasing it under a synthetic
+                    // selector breaks call-through for some Objective-C delegates (see #748).
+                    let callOriginal = unsafeBitCast(originalImplementation, to: OriginalImplementation.self)
+                    callOriginal(delegate, selector, center, response, completionHandler)
+                }
+                let replacementImplementation = imp_implementationWithBlock(replacement)
+
+                // Keep replacement invocations from observing the pre-replacement fallback while the
+                // runtime atomically returns a newer direct implementation installed by another swizzler.
+                implementationHolder.lock.lock()
+                let replacedImplementation = class_replaceMethod(delegateClass, selector, replacementImplementation, typeEncoding)
+                implementationHolder.value = replacedImplementation ?? originalImplementation
+                implementationHolder.lock.unlock()
+                swizzledDelegateClasses.insert(classId)
             }
-            if alreadySwizzled {
-                return
-            }
-            swizzleAddingIfNeeded(
-                on: delegateClass,
-                original: #selector(UNUserNotificationCenterDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:)),
-                swizzled: #selector(NSObject.ph_swizzled_userNotificationCenter(_:didReceive:withCompletionHandler:)),
-                noop: #selector(NSObject.ph_noop_userNotificationCenter(_:didReceive:withCompletionHandler:))
-            )
         }
 
         // MARK: - App Delegate Swizzling
@@ -186,25 +260,6 @@
     // MARK: - NSObject Swizzled Methods
 
     extension NSObject {
-        @objc func ph_swizzled_userNotificationCenter(
-            _ center: UNUserNotificationCenter,
-            didReceive response: UNNotificationResponse,
-            withCompletionHandler completionHandler: @escaping () -> Void
-        ) {
-            DI.main.pushNotificationPublisher.onNotificationResponse.invoke(response)
-            ph_swizzled_userNotificationCenter(center, didReceive: response, withCompletionHandler: completionHandler)
-        }
-
-        /// Call-through target when the host delegate never implemented `didReceive`: the system still
-        /// expects its completion handler to be invoked.
-        @objc func ph_noop_userNotificationCenter(
-            _: UNUserNotificationCenter,
-            didReceive _: UNNotificationResponse,
-            withCompletionHandler completionHandler: @escaping () -> Void
-        ) {
-            completionHandler()
-        }
-
         #if os(iOS)
             @objc func ph_swizzled_application(
                 _ application: UIApplication,
@@ -249,8 +304,8 @@
 
     #if TESTING
         extension PushNotificationPublisher {
-            /// Test isolation only — safe because the bundle guard in the integrations means no
-            /// swizzle is ever actually installed under a test runner.
+            /// Test isolation only. Production delegate swizzles are skipped by the integrations'
+            /// bundle guard; swizzling tests use process-unique Objective-C fixture classes.
             static func reset() {
                 shared.swizzledAppDelegateClass = nil
                 shared.delegateClassesLock.withLock {

--- a/PostHogTests/PostHogPushNotificationSwizzlingTest.swift
+++ b/PostHogTests/PostHogPushNotificationSwizzlingTest.swift
@@ -1,0 +1,128 @@
+#if os(iOS) || os(macOS)
+    import Foundation
+    @testable import PostHog
+    #if SWIFT_PACKAGE
+        import PostHogTestsObjC
+    #endif
+    import Testing
+    import UserNotifications
+
+    private final class TestPushNotificationPublisher: PushNotificationPublishing {
+        let onNotificationResponse = PostHogMulticastCallback<UNNotificationResponse>()
+        let onDeviceToken = PostHogMulticastCallback<String>()
+    }
+
+    @Suite("Push Notification Swizzling Tests", .serialized)
+    final class PostHogPushNotificationSwizzlingTest {
+        private let publisher = TestPushNotificationPublisher()
+        private let previousContainer: DI.Container
+
+        init() {
+            previousContainer = DI.main
+            let container = DI.Container()
+            container.pushNotificationPublisher = publisher
+            DI.main = container
+        }
+
+        deinit {
+            DI.main = previousContainer
+        }
+
+        private var selector: Selector {
+            #selector(UNUserNotificationCenterDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:))
+        }
+
+        @Test("captures and calls an Objective-C delegate with the original selector")
+        func callsObjectiveCDelegate() {
+            let delegate = PHDirectNotificationDelegateTestFixture()
+            PushNotificationPublisher.shared.swizzleNotificationDelegateMethods(on: type(of: delegate))
+
+            var captureCount = 0
+            let token = publisher.onNotificationResponse.subscribe { _ in captureCount += 1 }
+            var completionCount = 0
+            delegate.invoke { completionCount += 1 }
+            withExtendedLifetime(token) {}
+
+            #expect(captureCount == 1)
+            #expect(delegate.invocationCount == 1)
+            #expect(delegate.receivedSelector == selector)
+            #expect(completionCount == 1)
+        }
+
+        @Test("installing twice does not wrap the delegate twice")
+        func duplicateInstallationIsHarmless() {
+            let delegate = PHDuplicateNotificationDelegateTestFixture()
+            PushNotificationPublisher.shared.swizzleNotificationDelegateMethods(on: type(of: delegate))
+            PushNotificationPublisher.shared.swizzleNotificationDelegateMethods(on: type(of: delegate))
+
+            var captureCount = 0
+            let token = publisher.onNotificationResponse.subscribe { _ in captureCount += 1 }
+            var completionCount = 0
+            delegate.invoke { completionCount += 1 }
+            withExtendedLifetime(token) {}
+
+            #expect(captureCount == 1)
+            #expect(delegate.invocationCount == 1)
+            #expect(completionCount == 1)
+        }
+
+        @Test("completes when the Objective-C delegate omits the optional method")
+        func missingImplementationCompletes() {
+            let delegate = PHMissingNotificationDelegateTestFixture()
+            PushNotificationPublisher.shared.swizzleNotificationDelegateMethods(on: type(of: delegate))
+
+            var captureCount = 0
+            let token = publisher.onNotificationResponse.subscribe { _ in captureCount += 1 }
+            var completionCount = 0
+            delegate.invoke { completionCount += 1 }
+            withExtendedLifetime(token) {}
+
+            #expect(captureCount == 1)
+            #expect(delegate.invocationCount == 0)
+            #expect(completionCount == 1)
+        }
+
+        @Test("swizzling a subclass after its superclass does not wrap the inherited method twice")
+        func superclassFirstDoesNotWrapInheritedMethodTwice() {
+            let delegate = PHSuperclassFirstNotificationDelegateTestFixture()
+            PushNotificationPublisher.shared.swizzleNotificationDelegateMethods(
+                on: PHSuperclassFirstNotificationDelegateBaseTestFixture.self
+            )
+            PushNotificationPublisher.shared.swizzleNotificationDelegateMethods(on: type(of: delegate))
+
+            var captureCount = 0
+            let token = publisher.onNotificationResponse.subscribe { _ in captureCount += 1 }
+            var completionCount = 0
+            delegate.invoke { completionCount += 1 }
+            withExtendedLifetime(token) {}
+
+            #expect(captureCount == 1)
+            #expect(delegate.invocationCount == 1)
+            #expect(delegate.receivedSelector == selector)
+            #expect(completionCount == 1)
+        }
+
+        @Test("swizzling an inherited implementation does not mutate its base class")
+        func inheritedImplementationDoesNotMutateBaseClass() {
+            let delegate = PHInheritedNotificationDelegateTestFixture()
+            let baseDelegate = PHInheritedNotificationDelegateBaseTestFixture()
+            PushNotificationPublisher.shared.swizzleNotificationDelegateMethods(on: type(of: delegate))
+
+            var captureCount = 0
+            let token = publisher.onNotificationResponse.subscribe { _ in captureCount += 1 }
+            var delegateCompletionCount = 0
+            delegate.invoke { delegateCompletionCount += 1 }
+            var baseCompletionCount = 0
+            baseDelegate.invoke { baseCompletionCount += 1 }
+            withExtendedLifetime(token) {}
+
+            #expect(captureCount == 1)
+            #expect(delegate.invocationCount == 1)
+            #expect(delegate.receivedSelector == selector)
+            #expect(delegateCompletionCount == 1)
+            #expect(baseDelegate.invocationCount == 1)
+            #expect(baseDelegate.receivedSelector == selector)
+            #expect(baseCompletionCount == 1)
+        }
+    }
+#endif

--- a/PostHogTests/PostHogTests-Bridging-Header.h
+++ b/PostHogTests/PostHogTests-Bridging-Header.h
@@ -1,0 +1,1 @@
+#import "../PostHogTestsObjC/PHNotificationDelegateTestFixture.h"

--- a/PostHogTestsObjC/PHNotificationDelegateTestFixture.h
+++ b/PostHogTestsObjC/PHNotificationDelegateTestFixture.h
@@ -1,0 +1,37 @@
+#import <Foundation/Foundation.h>
+#import <UserNotifications/UserNotifications.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PHNotificationDelegateTestFixture : NSObject <UNUserNotificationCenterDelegate>
+
+@property(nonatomic, assign) NSUInteger invocationCount;
+@property(nonatomic, assign, nullable) SEL receivedSelector;
+
+- (void)invokeWithCompletionHandler:(void (^)(void))completionHandler
+    NS_SWIFT_NAME(invoke(completionHandler:));
+
+@end
+
+@interface PHDirectNotificationDelegateTestFixture : PHNotificationDelegateTestFixture
+@end
+
+@interface PHDuplicateNotificationDelegateTestFixture : PHNotificationDelegateTestFixture
+@end
+
+@interface PHInheritedNotificationDelegateBaseTestFixture : PHNotificationDelegateTestFixture
+@end
+
+@interface PHInheritedNotificationDelegateTestFixture : PHInheritedNotificationDelegateBaseTestFixture
+@end
+
+@interface PHSuperclassFirstNotificationDelegateBaseTestFixture : PHNotificationDelegateTestFixture
+@end
+
+@interface PHSuperclassFirstNotificationDelegateTestFixture : PHSuperclassFirstNotificationDelegateBaseTestFixture
+@end
+
+@interface PHMissingNotificationDelegateTestFixture : PHNotificationDelegateTestFixture
+@end
+
+NS_ASSUME_NONNULL_END

--- a/PostHogTestsObjC/PHNotificationDelegateTestFixture.m
+++ b/PostHogTestsObjC/PHNotificationDelegateTestFixture.m
@@ -1,0 +1,49 @@
+#import "PHNotificationDelegateTestFixture.h"
+
+#import <objc/message.h>
+
+@implementation PHNotificationDelegateTestFixture
+
+- (void)invokeWithCompletionHandler:(void (^)(void))completionHandler {
+    SEL selector = @selector(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:);
+    UNUserNotificationCenter *center = (id)[NSObject new];
+    UNNotificationResponse *response = (id)[NSObject new];
+    ((void (*)(id, SEL, UNUserNotificationCenter *, UNNotificationResponse *, void (^)(void)))objc_msgSend)(
+        self, selector, center, response, completionHandler);
+}
+
+@end
+
+#define PH_IMPLEMENT_NOTIFICATION_RESPONSE()                                                                    \
+    - (void)userNotificationCenter:(UNUserNotificationCenter *)center                                            \
+        didReceiveNotificationResponse:(UNNotificationResponse *)response                                       \
+                 withCompletionHandler:(void (^)(void))completionHandler {                                      \
+        self.invocationCount += 1;                                                                               \
+        self.receivedSelector = _cmd;                                                                            \
+        completionHandler();                                                                                     \
+    }
+
+@implementation PHDirectNotificationDelegateTestFixture
+PH_IMPLEMENT_NOTIFICATION_RESPONSE()
+@end
+
+@implementation PHDuplicateNotificationDelegateTestFixture
+PH_IMPLEMENT_NOTIFICATION_RESPONSE()
+@end
+
+@implementation PHInheritedNotificationDelegateBaseTestFixture
+PH_IMPLEMENT_NOTIFICATION_RESPONSE()
+@end
+
+@implementation PHInheritedNotificationDelegateTestFixture
+@end
+
+@implementation PHSuperclassFirstNotificationDelegateBaseTestFixture
+PH_IMPLEMENT_NOTIFICATION_RESPONSE()
+@end
+
+@implementation PHSuperclassFirstNotificationDelegateTestFixture
+@end
+
+@implementation PHMissingNotificationDelegateTestFixture
+@end


### PR DESCRIPTION
## :bulb: Motivation and Context

When PostHog swizzles `UNUserNotificationCenterDelegate`, its wrapper calls the original implementation through a synthetic selector. That call does not reach Objective-C delegates such as FlutterFire's `FLTFirebaseMessagingPlugin`. PostHog captures `$push_notification_opened`, but `FirebaseMessaging.onMessageOpenedApp` never fires.

This fixes #748.

The notification delegate wrapper now retains the original Objective-C implementation and calls it with the original selector. It also handles delegates that omit the optional method, avoids changing inherited superclass implementations, and prevents duplicate wrapping across superclass and subclass delegate assignments.

## :green_heart: How did you test it?

- `make test filter=PostHogPushNotificationSwizzlingTest` - 5 tests passed
- Focused iOS simulator test with XcodeBuildMCP using the `Testing` configuration - 5 tests passed
- `make buildSdk`
- `make format`
- `make lint`
- Autoreview against `origin/main` with no actionable findings

The regression tests use Objective-C delegates and cover direct implementations, missing optional methods, repeated installation, inherited implementations, the selector passed to the original method, and superclass-first installation.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated and implemented with the Pi coding agent, oracle, worker, and reviewer subagents, XcodeBuildMCP CLI, and the autoreview skill. The fix keeps the generic swizzler unchanged and replaces only the push notification delegate call-through. A retained Objective-C implementation was chosen so the original delegate receives the selector it implemented.
