### PR TITLE
test: snapshot event and request shapes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build buildSdk buildExamples format swiftLint swiftFormat swiftLintCheck swiftFormatCheck installSwiftLint installSwiftFormat test testDowngradeCompatibility testOniOSSimulator testOnMacSimulator maskSnapshots recordMaskSnapshots checkMaskSnapshotRuntime lint bootstrap releaseCocoaPods api apiCheck apiUpdate buildIOS
+.PHONY: build buildSdk buildExamples format swiftLint swiftFormat swiftLintCheck swiftFormatCheck installSwiftLint installSwiftFormat test recordEventShapeSnapshots testDowngradeCompatibility testOniOSSimulator testOnMacSimulator maskSnapshots recordMaskSnapshots checkMaskSnapshotRuntime lint bootstrap releaseCocoaPods api apiCheck apiUpdate buildIOS
 
 build: buildSdk buildExamples
 
@@ -156,6 +156,9 @@ recordMaskSnapshots: checkMaskSnapshotRuntime
 #   make test filter=PostHogPropertiesSerializationTests        # Run specific test suite, class or method
 test:
 	set -o pipefail && swift test --no-parallel -Xswiftc -DTESTING $(if $(filter),--filter $(filter))
+
+recordEventShapeSnapshots:
+	UPDATE_EVENT_SHAPE_SNAPSHOTS=1 $(MAKE) test filter=PostHogEventSnapshotTests
 
 testDowngradeCompatibility:
 	DOWNGRADE_REF="$${DOWNGRADE_REF:-3.48.0}" ./scripts/test-downgrade-compatibility.sh

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -9,6 +9,10 @@
 /* Begin PBXBuildFile section */
 		B74800000000000000000001 /* PostHogPushNotificationSwizzlingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B74800000000000000000003 /* PostHogPushNotificationSwizzlingTest.swift */; };
 		B74800000000000000000002 /* PHNotificationDelegateTestFixture.m in Sources */ = {isa = PBXBuildFile; fileRef = B74800000000000000000006 /* PHNotificationDelegateTestFixture.m */; };
+		D0E500012FA0000100000002 /* PostHogEventSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E500012FA0000100000001 /* PostHogEventSnapshotTests.swift */; };
+		D0E500012FA0000100000021 /* event-shapes-batch.json in Resources */ = {isa = PBXBuildFile; fileRef = D0E500012FA0000100000011 /* event-shapes-batch.json */; };
+		D0E500012FA0000100000022 /* feature-flags-request.json in Resources */ = {isa = PBXBuildFile; fileRef = D0E500012FA0000100000012 /* feature-flags-request.json */; };
+		D0E500012FA0000100000023 /* session-replay-request.json in Resources */ = {isa = PBXBuildFile; fileRef = D0E500012FA0000100000013 /* session-replay-request.json */; };
 		0799FC592DA8A0837BC771E3 /* PLCrashAsyncDwarfEncoding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8E1E01C22EB902B360AE5A3 /* PLCrashAsyncDwarfEncoding.cpp */; };
 		081C4D5910919F0E5872CAC2 /* PostHogBootstrapConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CBE5E053785289B0CCA4ED /* PostHogBootstrapConfig.swift */; };
 		08CF51A212DF4E6ABF3DDA77 /* PLCrashMachExceptionPort.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D784BEF45D7E472FBE56B84 /* PLCrashMachExceptionPort.m */; };
@@ -770,6 +774,10 @@
 		B74800000000000000000004 /* PostHogTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PostHogTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		B74800000000000000000005 /* PHNotificationDelegateTestFixture.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PHNotificationDelegateTestFixture.h; sourceTree = "<group>"; };
 		B74800000000000000000006 /* PHNotificationDelegateTestFixture.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PHNotificationDelegateTestFixture.m; sourceTree = "<group>"; };
+		D0E500012FA0000100000001 /* PostHogEventSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogEventSnapshotTests.swift; sourceTree = "<group>"; };
+		D0E500012FA0000100000011 /* event-shapes-batch.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = "event-shapes-batch.json"; sourceTree = "<group>"; };
+		D0E500012FA0000100000012 /* feature-flags-request.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = "feature-flags-request.json"; sourceTree = "<group>"; };
+		D0E500012FA0000100000013 /* session-replay-request.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = "session-replay-request.json"; sourceTree = "<group>"; };
 		001A4831298758176E2711B8 /* PLCrashLogWriter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PLCrashLogWriter.m; path = vendor/PHPLCrashReporter/Source/PLCrashLogWriter.m; sourceTree = "<group>"; };
 		00F98E7D98CC906E4BA3D582 /* PostHogReachabilityTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostHogReachabilityTest.swift; sourceTree = "<group>"; };
 		045078ECC7B3488DA27D06E9 /* PostHogLogger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostHogLogger.swift; sourceTree = "<group>"; };
@@ -1679,6 +1687,7 @@
 			children = (
 				B74800000000000000000004 /* PostHogTests-Bridging-Header.h */,
 				B74800000000000000000003 /* PostHogPushNotificationSwizzlingTest.swift */,
+				D0E500012FA0000100000001 /* PostHogEventSnapshotTests.swift */,
 				DA27AEC82F56B3F3002A59CE /* PostHogSamplingTest.swift */,
 				DB7100052F80000100000001 /* PostHogTracingHeadersTest.swift */,
 				DA27AEC02F56B3E3002A59CE /* PostHogSessionReplayEventTriggersTest.swift */,
@@ -2538,6 +2547,9 @@
 		DAF95F5B2D077BCC001E82BB /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				D0E500012FA0000100000011 /* event-shapes-batch.json */,
+				D0E500012FA0000100000012 /* feature-flags-request.json */,
+				D0E500012FA0000100000013 /* session-replay-request.json */,
 				DA53DE702D3E299F00C38DCA /* fixture_remote_config.json */,
 				DAA5EE132D43605000D437E0 /* fixture_survey_basic.json */,
 				DAA5EE162D43605000D437E0 /* fixture_survey_branching_end.json */,
@@ -3030,6 +3042,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D0E500012FA0000100000021 /* event-shapes-batch.json in Resources */,
+				D0E500012FA0000100000022 /* feature-flags-request.json in Resources */,
+				D0E500012FA0000100000023 /* session-replay-request.json in Resources */,
 				DA53DE762D3E29A900C38DCA /* fixture_remote_config.json in Resources */,
 				DA7185482D07E11200396388 /* input_3.png in Resources */,
 				DAA022472D78203D00197660 /* fixture_survey_url_match_type_not_regex.json in Resources */,
@@ -3442,6 +3457,7 @@
 			files = (
 				B74800000000000000000001 /* PostHogPushNotificationSwizzlingTest.swift in Sources */,
 				B74800000000000000000002 /* PHNotificationDelegateTestFixture.m in Sources */,
+				D0E500012FA0000100000002 /* PostHogEventSnapshotTests.swift in Sources */,
 				DA979D7B2CD370B700F56BAE /* PostHogAutocaptureEventTrackerSpec.swift in Sources */,
 				DA0C944B2D54CDD000BFD9FB /* PostHogStorageMigrationTest.swift in Sources */,
 				690FF0F52AF0F06100A0B06B /* PostHogSDKTest.swift in Sources */,

--- a/PostHogTests/PostHogEventSnapshotTests.swift
+++ b/PostHogTests/PostHogEventSnapshotTests.swift
@@ -264,10 +264,18 @@ final class PostHogEventSnapshotTests {
 
         // These keys are optional in SwiftPM's command-line test bundle but are populated by
         // the Xcode test host. Validate them when available, then omit them from the shared golden.
-        for key in ["$app_name", "$app_version", "$app_build"] where properties[key] != nil {
+        for key in ["$app_name", "$app_version"] where properties[key] != nil {
             let value = try #require(properties[key] as? String)
             #expect(!value.isEmpty)
             properties.removeValue(forKey: key)
+        }
+        if let appBuild = properties["$app_build"] {
+            if let appBuild = appBuild as? String {
+                #expect(!appBuild.isEmpty)
+            } else {
+                _ = try #require(appBuild as? NSNumber)
+            }
+            properties.removeValue(forKey: "$app_build")
         }
 
         let stringKeys = [

--- a/PostHogTests/PostHogEventSnapshotTests.swift
+++ b/PostHogTests/PostHogEventSnapshotTests.swift
@@ -1,0 +1,357 @@
+import Foundation
+@testable import PostHog
+import Testing
+import XCTest
+
+@Suite("Event and request golden snapshots", .serialized, .resetsGlobalState)
+final class PostHogEventSnapshotTests {
+    private let server: MockPostHogServer
+
+    init() {
+        deleteSafely(applicationSupportDirectoryURL())
+        server = MockPostHogServer(version: 4)
+        server.start(batchCount: 0)
+    }
+
+    deinit {
+        server.stop()
+        deleteSafely(applicationSupportDirectoryURL())
+    }
+
+    @Test("final enriched event shapes and batch request match the golden")
+    func enrichedEventBatchGolden() async throws {
+        server.reset(batchCount: 1)
+        server.flagsResponseDelay = 1
+        let sut = makeSDK(flushAt: 5, identified: false)
+        defer { sut.close() }
+        sut.sessionManager.setSessionId("00000000-0000-7000-8000-000000000001")
+
+        await withMockedNow({ Self.fixedDate }) {
+            sut.register(["registered_property": "registered-value"])
+            sut.capture(
+                "order completed",
+                properties: [
+                    "amount": 42.5,
+                    "items": ["coffee", "cake"],
+                    "nested": ["coupon": "WELCOME"] as [String: Any],
+                ],
+                userProperties: ["plan": "pro"],
+                userPropertiesSetOnce: ["first_order": true],
+                groups: ["workspace": "workspace-1"]
+            )
+            sut.identify(
+                "user-123",
+                userProperties: ["email": "person@example.com"],
+                userPropertiesSetOnce: ["created_at": "2024-01-01"]
+            )
+            sut.group(
+                type: "company",
+                key: "posthog",
+                groupProperties: ["industry": "analytics", "employees": 120]
+            )
+            sut.captureFeatureInteraction(flag: "checkout-redesign", flagVariant: "test")
+            sut.captureException(
+                NSError(
+                    domain: "SnapshotError",
+                    code: 7,
+                    userInfo: [NSLocalizedDescriptionKey: "Golden failure"]
+                ),
+                properties: ["handled_by": "snapshot-test"]
+            )
+        }
+
+        _ = try await getServerEvents(server)
+        let request = try #require(server.batchRequests.first)
+        var snapshot = try requestSnapshot(request, gzip: true)
+        try normalizeBatchSnapshot(&snapshot)
+        try assertGolden(snapshot, named: "event-shapes-batch")
+    }
+
+    @Test("session replay request matches the golden")
+    func sessionReplayRequestGolden() async throws {
+        server.reset(batchCount: 0, snapshotCount: 1)
+        let sut = makeSDK(flushAt: 20, identified: true)
+        defer { sut.close() }
+        sut.sessionManager.setSessionId("00000000-0000-7000-8000-000000000002")
+
+        await withMockedNow({ Self.fixedDate }) {
+            sut.capture(
+                "$snapshot",
+                properties: [
+                    "$session_id": "00000000-0000-7000-8000-000000000002",
+                    "$snapshot_source": "mobile",
+                    "$snapshot_data": [
+                        "type": 3,
+                        "data": ["source": 0, "href": "https://example.com/checkout"] as [String: Any],
+                        "timestamp": 1_704_164_645_000 as Int64,
+                    ] as [String: Any],
+                ]
+            )
+            sut.flush()
+        }
+
+        try await waitForSnapshotRequest(server)
+        let request = try #require(server.snapshotRequests.first)
+        var snapshot = try requestSnapshot(request, gzip: true)
+        try normalizeReplaySnapshot(&snapshot)
+        try assertGolden(snapshot, named: "session-replay-request")
+    }
+
+    @Test("SDK-driven feature flag request matches the golden")
+    func featureFlagRequestGolden() async throws {
+        let sut = makeSDK(flushAt: 20, identified: true)
+        defer { sut.close() }
+
+        sut.remoteConfig?.canReloadFlagsForTesting = false
+        sut.group(type: "company", key: "posthog")
+        sut.remoteConfig?.canReloadFlagsForTesting = true
+
+        server.reset(batchCount: 0, flagsCount: 1)
+        sut.setPersonPropertiesForFlags(
+            ["email": "person@example.com", "plan": "enterprise"],
+            reloadFeatureFlags: false
+        )
+        sut.setGroupPropertiesForFlags(
+            "company",
+            properties: ["industry": "analytics", "employees": 120],
+            reloadFeatureFlags: false
+        )
+
+        let loaded = AsyncLatch()
+        sut.reloadFeatureFlags { loaded.signal() }
+        await loaded.wait()
+
+        let request = try #require(server.flagsRequests.first)
+        var snapshot = try requestSnapshot(request, gzip: false)
+        try normalizeFlagsSnapshot(&snapshot)
+        try assertGolden(snapshot, named: "feature-flags-request")
+    }
+
+    private func makeSDK(flushAt: Int, identified: Bool) -> PostHogSDK {
+        deleteSafely(applicationSupportDirectoryURL())
+        let config = PostHogConfig(projectToken: "snapshot-project-token", host: "http://localhost:9001")
+        config.flushAt = flushAt
+        config.maxBatchSize = flushAt
+        config.captureApplicationLifecycleEvents = false
+        config.captureScreenViews = false
+        config.enableSwizzling = false
+        config.preloadFeatureFlags = false
+        config.disableReachabilityForTesting = true
+        config.disableQueueTimerForTesting = true
+        config.disableFlushOnBackgroundForTesting = true
+        config.personProfiles = .always
+        config.bootstrap = PostHogBootstrapConfig(
+            distinctId: identified ? "user-123" : "anonymous-123",
+            isIdentifiedId: identified,
+            featureFlags: ["checkout-redesign": "test", "beta": true],
+            featureFlagPayloads: ["checkout-redesign": ["color": "blue"]]
+        )
+        return PostHogSDK.with(config)
+    }
+
+    private func requestSnapshot(_ request: URLRequest, gzip: Bool) throws -> [String: Any] {
+        let url = try #require(request.url)
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let bodyData = try #require(request.body())
+        let decodedBody = gzip ? try bodyData.gunzipped() : bodyData
+        let body = try JSONSerialization.jsonObject(with: decodedBody)
+
+        var headers: [String: String] = [:]
+        for (name, value) in request.allHTTPHeaderFields ?? [:] {
+            headers[name.lowercased()] = value
+        }
+        if let contentLength = headers["content-length"] {
+            try #require(Int(contentLength) != nil)
+            headers["content-length"] = "<content-length>"
+        }
+        if let userAgent = headers["user-agent"] {
+            let prefix = "posthog-ios/"
+            #expect(userAgent.hasPrefix(prefix))
+            #expect(userAgent.count > prefix.count)
+            headers["user-agent"] = "posthog-ios/<sdk-version>"
+        }
+
+        return [
+            "method": try #require(request.httpMethod),
+            "url": [
+                "scheme": try #require(components.scheme),
+                "host": try #require(components.host),
+                "port": try #require(components.port),
+                "path": components.path,
+                "query": (components.queryItems ?? []).map {
+                    ["name": $0.name, "value": $0.value as Any? ?? NSNull()] as [String: Any]
+                },
+            ] as [String: Any],
+            "headers": headers,
+            "body": body,
+        ]
+    }
+
+    private func normalizeBatchSnapshot(_ snapshot: inout [String: Any]) throws {
+        var body = try #require(snapshot["body"] as? [String: Any])
+        let sentAt = try #require(body["sent_at"] as? String)
+        try #require(toISO8601Date(sentAt) != nil)
+        body["sent_at"] = "<iso8601-timestamp>"
+
+        var events = try #require(body["batch"] as? [[String: Any]])
+        for index in events.indices {
+            try normalizeEvent(&events[index])
+        }
+        body["batch"] = events
+        snapshot["body"] = body
+    }
+
+    private func normalizeReplaySnapshot(_ snapshot: inout [String: Any]) throws {
+        var events = try #require(snapshot["body"] as? [[String: Any]])
+        #expect(events.count == 1)
+        for index in events.indices {
+            try normalizeEvent(&events[index])
+        }
+        snapshot["body"] = events
+    }
+
+    private func normalizeFlagsSnapshot(_ snapshot: inout [String: Any]) throws {
+        var body = try #require(snapshot["body"] as? [String: Any])
+        let timezone = try #require(body["timezone"] as? String)
+        #expect(!timezone.isEmpty)
+        body["timezone"] = "<timezone>"
+
+        let deviceId = try #require(body["$device_id"] as? String)
+        try #require(UUID(uuidString: deviceId) != nil)
+        body["$device_id"] = "<uuid>"
+
+        if let anonymousId = body["$anon_distinct_id"] {
+            let anonymousUUID = try #require(anonymousId as? String)
+            try #require(UUID(uuidString: anonymousUUID) != nil)
+            body["$anon_distinct_id"] = "<uuid>"
+        }
+
+        if var personProperties = body["person_properties"] as? [String: Any] {
+            try normalizeEnvironmentProperties(&personProperties)
+            body["person_properties"] = personProperties
+        }
+        snapshot["body"] = body
+    }
+
+    private func normalizeEvent(_ event: inout [String: Any]) throws {
+        let timestamp = try #require(event["timestamp"] as? String)
+        try #require(toISO8601Date(timestamp) != nil)
+        event["timestamp"] = "<iso8601-timestamp>"
+
+        let uuid = try #require(event["uuid"] as? String)
+        try #require(UUID(uuidString: uuid) != nil)
+        let uuidParts = uuid.split(separator: "-")
+        #expect(uuidParts.count == 5)
+        #expect(uuidParts[2].first == "7")
+        let variantCharacter = try #require(uuidParts[3].first)
+        let variantNibble = try #require(Int(String(variantCharacter), radix: 16))
+        #expect(variantNibble & 0xC == 0x8)
+        event["uuid"] = "<uuid-v7>"
+
+        var properties = try #require(event["properties"] as? [String: Any])
+        try normalizeEnvironmentProperties(&properties)
+        try normalizeFeatureFlagProperties(&properties)
+        try normalizeExceptionProperties(&properties)
+        event["properties"] = properties
+    }
+
+    private func normalizeEnvironmentProperties(_ properties: inout [String: Any]) throws {
+        if let rawVersion = properties["$lib_version"] {
+            let version = try #require(rawVersion as? String)
+            #expect(!version.isEmpty)
+            properties["$lib_version"] = "<sdk-version>"
+        }
+
+        // These keys are optional in SwiftPM's command-line test bundle but are populated by
+        // the Xcode test host. Validate them when available, then omit them from the shared golden.
+        for key in ["$app_name", "$app_version", "$app_build"] where properties[key] != nil {
+            let value = try #require(properties[key] as? String)
+            #expect(!value.isEmpty)
+            properties.removeValue(forKey: key)
+        }
+
+        let stringKeys = [
+            "$app_namespace", "$device_model", "$device_type", "$device_name", "$os_name",
+            "$os_version", "$locale", "$timezone",
+        ]
+        for key in stringKeys where properties[key] != nil {
+            _ = try #require(properties[key] as? String)
+            properties[key] = "<environment-string>"
+        }
+
+        let boolKeys = [
+            "$is_testflight", "$is_sideloaded", "$is_emulator", "$is_ios_running_on_mac",
+            "$is_mac_catalyst_app", "$network_wifi", "$network_cellular",
+        ]
+        for key in boolKeys where properties[key] != nil {
+            _ = try #require(properties[key] as? Bool)
+            properties[key] = "<environment-bool>"
+        }
+
+        for key in ["$screen_width", "$screen_height"] where properties[key] != nil {
+            _ = try #require(properties[key] as? NSNumber)
+            properties[key] = "<environment-number>"
+        }
+    }
+
+    private func normalizeFeatureFlagProperties(_ properties: inout [String: Any]) throws {
+        guard let flags = properties["$active_feature_flags"] as? [String] else { return }
+        properties["$active_feature_flags"] = flags.sorted()
+    }
+
+    private func normalizeExceptionProperties(_ properties: inout [String: Any]) throws {
+        if let rawDebugImages = properties["$debug_images"] {
+            let debugImages = try #require(rawDebugImages as? [[String: Any]])
+            #expect(!debugImages.isEmpty)
+            for image in debugImages {
+                _ = try #require(image["code_file"] as? String)
+                let debugId = try #require(image["debug_id"] as? String)
+                try #require(UUID(uuidString: debugId) != nil)
+                _ = try #require(image["image_addr"] as? String)
+                _ = try #require(image["image_size"] as? NSNumber)
+                #expect(image["type"] as? String == "macho")
+            }
+            properties["$debug_images"] = ["<debug-image>"]
+        }
+
+        guard var exceptions = properties["$exception_list"] as? [[String: Any]] else { return }
+        for index in exceptions.indices {
+            if exceptions[index]["thread_id"] != nil {
+                _ = try #require(exceptions[index]["thread_id"] as? NSNumber)
+                exceptions[index]["thread_id"] = "<thread-id>"
+            }
+            if var stacktrace = exceptions[index]["stacktrace"] as? [String: Any] {
+                let frames = try #require(stacktrace["frames"] as? [[String: Any]])
+                #expect(!frames.isEmpty)
+                stacktrace["frames"] = ["<stack-frame>"]
+                exceptions[index]["stacktrace"] = stacktrace
+            }
+        }
+        properties["$exception_list"] = exceptions
+    }
+
+    private func assertGolden(_ actual: Any, named name: String) throws {
+        let actualJSON = try canonicalJSON(actual)
+        if ProcessInfo.processInfo.environment["UPDATE_EVENT_SHAPE_SNAPSHOTS"] == "1" {
+            let sourceURL = URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()
+                .appendingPathComponent("Resources")
+                .appendingPathComponent("\(name).json")
+            try "\(actualJSON)\n".write(to: sourceURL, atomically: true, encoding: .utf8)
+            return
+        }
+
+        let url = try #require(Bundle.test.url(forResource: name, withExtension: "json"))
+        let expectedData = try Data(contentsOf: url)
+        let expected = try JSONSerialization.jsonObject(with: expectedData)
+        let expectedJSON = try canonicalJSON(expected)
+        #expect(actualJSON == expectedJSON)
+    }
+
+    private func canonicalJSON(_ object: Any) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys])
+        return try #require(String(data: data, encoding: .utf8))
+    }
+
+    private static let fixedDate = Date(timeIntervalSince1970: 1_704_164_645)
+}

--- a/PostHogTests/PostHogExceptionStepsTest.swift
+++ b/PostHogTests/PostHogExceptionStepsTest.swift
@@ -94,15 +94,15 @@ class PostHogExceptionStepsTest {
 
     @Test("preserves buffered steps when the caller supplies their own $exception_steps")
     func preservesBufferOnManualOverride() {
-        let sut = getSut()
-        server.reset(batchCount: 2)
+        let sut = getSut(flushAt: 2)
+        server.reset(batchCount: 1)
 
         sut.addExceptionStep("buffered")
 
         // Caller supplies their own steps: the SDK must neither attach nor discard its buffer.
         let manual: [[String: Any]] = [["$message": "manual", "$timestamp": "2026-06-09T10:00:00.000Z"]]
-        sut.captureException(TestError.boom, properties: ["$exception_steps": manual]) // batch 1
-        sut.captureException(TestError.boom) // batch 2 — the preserved buffered step attaches here
+        sut.captureException(TestError.boom, properties: ["$exception_steps": manual])
+        sut.captureException(TestError.boom) // both exceptions flush in one deterministic batch
 
         let events = getBatchedEvents(server).filter { $0.event == "$exception" }
         #expect(events.count == 2)

--- a/PostHogTests/Resources/event-shapes-batch.json
+++ b/PostHogTests/Resources/event-shapes-batch.json
@@ -1,0 +1,273 @@
+{
+  "body" : {
+    "api_key" : "snapshot-project-token",
+    "batch" : [
+      {
+        "distinct_id" : "anonymous-123",
+        "event" : "order completed",
+        "properties" : {
+          "$active_feature_flags" : [
+            "beta",
+            "checkout-redesign"
+          ],
+          "$app_namespace" : "<environment-string>",
+          "$device_manufacturer" : "Apple",
+          "$device_model" : "<environment-string>",
+          "$device_name" : "<environment-string>",
+          "$device_type" : "<environment-string>",
+          "$feature\/beta" : true,
+          "$feature\/checkout-redesign" : "test",
+          "$groups" : {
+            "workspace" : "workspace-1"
+          },
+          "$is_emulator" : "<environment-bool>",
+          "$is_identified" : false,
+          "$is_ios_running_on_mac" : "<environment-bool>",
+          "$is_mac_catalyst_app" : "<environment-bool>",
+          "$is_sideloaded" : "<environment-bool>",
+          "$is_testflight" : "<environment-bool>",
+          "$lib" : "posthog-ios",
+          "$lib_version" : "<sdk-version>",
+          "$locale" : "<environment-string>",
+          "$network_cellular" : "<environment-bool>",
+          "$network_wifi" : "<environment-bool>",
+          "$os_name" : "<environment-string>",
+          "$os_version" : "<environment-string>",
+          "$process_person_profile" : true,
+          "$session_id" : "00000000-0000-7000-8000-000000000001",
+          "$set" : {
+            "plan" : "pro"
+          },
+          "$set_once" : {
+            "first_order" : true
+          },
+          "$timezone" : "<environment-string>",
+          "amount" : 42.5,
+          "items" : [
+            "coffee",
+            "cake"
+          ],
+          "nested" : {
+            "coupon" : "WELCOME"
+          },
+          "registered_property" : "registered-value"
+        },
+        "timestamp" : "<iso8601-timestamp>",
+        "uuid" : "<uuid-v7>"
+      },
+      {
+        "distinct_id" : "user-123",
+        "event" : "$identify",
+        "properties" : {
+          "$active_feature_flags" : [
+            "beta",
+            "checkout-redesign"
+          ],
+          "$anon_distinct_id" : "anonymous-123",
+          "$app_namespace" : "<environment-string>",
+          "$device_manufacturer" : "Apple",
+          "$device_model" : "<environment-string>",
+          "$device_name" : "<environment-string>",
+          "$device_type" : "<environment-string>",
+          "$feature\/beta" : true,
+          "$feature\/checkout-redesign" : "test",
+          "$is_emulator" : "<environment-bool>",
+          "$is_identified" : true,
+          "$is_ios_running_on_mac" : "<environment-bool>",
+          "$is_mac_catalyst_app" : "<environment-bool>",
+          "$is_sideloaded" : "<environment-bool>",
+          "$is_testflight" : "<environment-bool>",
+          "$lib" : "posthog-ios",
+          "$lib_version" : "<sdk-version>",
+          "$locale" : "<environment-string>",
+          "$network_cellular" : "<environment-bool>",
+          "$network_wifi" : "<environment-bool>",
+          "$os_name" : "<environment-string>",
+          "$os_version" : "<environment-string>",
+          "$process_person_profile" : true,
+          "$session_id" : "00000000-0000-7000-8000-000000000001",
+          "$set" : {
+            "email" : "person@example.com"
+          },
+          "$set_once" : {
+            "created_at" : "2024-01-01"
+          },
+          "$timezone" : "<environment-string>",
+          "distinct_id" : "user-123",
+          "registered_property" : "registered-value"
+        },
+        "timestamp" : "<iso8601-timestamp>",
+        "uuid" : "<uuid-v7>"
+      },
+      {
+        "distinct_id" : "user-123",
+        "event" : "$groupidentify",
+        "properties" : {
+          "$active_feature_flags" : [
+            "beta",
+            "checkout-redesign"
+          ],
+          "$app_namespace" : "<environment-string>",
+          "$device_manufacturer" : "Apple",
+          "$device_model" : "<environment-string>",
+          "$device_name" : "<environment-string>",
+          "$device_type" : "<environment-string>",
+          "$feature\/beta" : true,
+          "$feature\/checkout-redesign" : "test",
+          "$group_key" : "posthog",
+          "$group_set" : {
+            "employees" : 120,
+            "industry" : "analytics"
+          },
+          "$group_type" : "company",
+          "$groups" : {
+            "company" : "posthog"
+          },
+          "$is_emulator" : "<environment-bool>",
+          "$is_identified" : true,
+          "$is_ios_running_on_mac" : "<environment-bool>",
+          "$is_mac_catalyst_app" : "<environment-bool>",
+          "$is_sideloaded" : "<environment-bool>",
+          "$is_testflight" : "<environment-bool>",
+          "$lib" : "posthog-ios",
+          "$lib_version" : "<sdk-version>",
+          "$locale" : "<environment-string>",
+          "$network_cellular" : "<environment-bool>",
+          "$network_wifi" : "<environment-bool>",
+          "$os_name" : "<environment-string>",
+          "$os_version" : "<environment-string>",
+          "$process_person_profile" : true,
+          "$session_id" : "00000000-0000-7000-8000-000000000001",
+          "$timezone" : "<environment-string>",
+          "registered_property" : "registered-value"
+        },
+        "timestamp" : "<iso8601-timestamp>",
+        "uuid" : "<uuid-v7>"
+      },
+      {
+        "distinct_id" : "user-123",
+        "event" : "$feature_interaction",
+        "properties" : {
+          "$active_feature_flags" : [
+            "beta",
+            "checkout-redesign"
+          ],
+          "$app_namespace" : "<environment-string>",
+          "$device_manufacturer" : "Apple",
+          "$device_model" : "<environment-string>",
+          "$device_name" : "<environment-string>",
+          "$device_type" : "<environment-string>",
+          "$feature\/beta" : true,
+          "$feature\/checkout-redesign" : "test",
+          "$groups" : {
+            "company" : "posthog"
+          },
+          "$is_emulator" : "<environment-bool>",
+          "$is_identified" : true,
+          "$is_ios_running_on_mac" : "<environment-bool>",
+          "$is_mac_catalyst_app" : "<environment-bool>",
+          "$is_sideloaded" : "<environment-bool>",
+          "$is_testflight" : "<environment-bool>",
+          "$lib" : "posthog-ios",
+          "$lib_version" : "<sdk-version>",
+          "$locale" : "<environment-string>",
+          "$network_cellular" : "<environment-bool>",
+          "$network_wifi" : "<environment-bool>",
+          "$os_name" : "<environment-string>",
+          "$os_version" : "<environment-string>",
+          "$process_person_profile" : true,
+          "$session_id" : "00000000-0000-7000-8000-000000000001",
+          "$set" : {
+            "$feature_interaction\/checkout-redesign" : "test"
+          },
+          "$timezone" : "<environment-string>",
+          "feature_flag" : "checkout-redesign",
+          "feature_flag_variant" : "test",
+          "registered_property" : "registered-value"
+        },
+        "timestamp" : "<iso8601-timestamp>",
+        "uuid" : "<uuid-v7>"
+      },
+      {
+        "distinct_id" : "user-123",
+        "event" : "$exception",
+        "properties" : {
+          "$active_feature_flags" : [
+            "beta",
+            "checkout-redesign"
+          ],
+          "$app_namespace" : "<environment-string>",
+          "$debug_images" : [
+            "<debug-image>"
+          ],
+          "$device_manufacturer" : "Apple",
+          "$device_model" : "<environment-string>",
+          "$device_name" : "<environment-string>",
+          "$device_type" : "<environment-string>",
+          "$exception_level" : "error",
+          "$exception_list" : [
+            {
+              "mechanism" : {
+                "handled" : true,
+                "synthetic" : true,
+                "type" : "generic"
+              },
+              "stacktrace" : {
+                "frames" : [
+                  "<stack-frame>"
+                ],
+                "type" : "raw"
+              },
+              "thread_id" : "<thread-id>",
+              "type" : "SnapshotError",
+              "value" : "Golden failure (Code: 7)"
+            }
+          ],
+          "$feature\/beta" : true,
+          "$feature\/checkout-redesign" : "test",
+          "$groups" : {
+            "company" : "posthog"
+          },
+          "$is_emulator" : "<environment-bool>",
+          "$is_identified" : true,
+          "$is_ios_running_on_mac" : "<environment-bool>",
+          "$is_mac_catalyst_app" : "<environment-bool>",
+          "$is_sideloaded" : "<environment-bool>",
+          "$is_testflight" : "<environment-bool>",
+          "$lib" : "posthog-ios",
+          "$lib_version" : "<sdk-version>",
+          "$locale" : "<environment-string>",
+          "$network_cellular" : "<environment-bool>",
+          "$network_wifi" : "<environment-bool>",
+          "$os_name" : "<environment-string>",
+          "$os_version" : "<environment-string>",
+          "$process_person_profile" : true,
+          "$session_id" : "00000000-0000-7000-8000-000000000001",
+          "$timezone" : "<environment-string>",
+          "handled_by" : "snapshot-test",
+          "registered_property" : "registered-value"
+        },
+        "timestamp" : "<iso8601-timestamp>",
+        "uuid" : "<uuid-v7>"
+      }
+    ],
+    "sent_at" : "<iso8601-timestamp>"
+  },
+  "headers" : {
+    "accept-encoding" : "gzip",
+    "content-encoding" : "gzip",
+    "content-length" : "<content-length>",
+    "content-type" : "application\/json; charset=utf-8",
+    "user-agent" : "posthog-ios\/<sdk-version>"
+  },
+  "method" : "POST",
+  "url" : {
+    "host" : "localhost",
+    "path" : "\/batch",
+    "port" : 9001,
+    "query" : [
+
+    ],
+    "scheme" : "http"
+  }
+}

--- a/PostHogTests/Resources/feature-flags-request.json
+++ b/PostHogTests/Resources/feature-flags-request.json
@@ -1,0 +1,47 @@
+{
+  "body" : {
+    "$anon_distinct_id" : "<uuid>",
+    "$device_id" : "<uuid>",
+    "api_key" : "snapshot-project-token",
+    "distinct_id" : "user-123",
+    "group_properties" : {
+      "company" : {
+        "employees" : 120,
+        "industry" : "analytics"
+      }
+    },
+    "groups" : {
+      "company" : "posthog"
+    },
+    "person_properties" : {
+      "$app_namespace" : "<environment-string>",
+      "$device_type" : "<environment-string>",
+      "$lib" : "posthog-ios",
+      "$lib_version" : "<sdk-version>",
+      "$os_name" : "<environment-string>",
+      "$os_version" : "<environment-string>",
+      "email" : "person@example.com",
+      "plan" : "enterprise"
+    },
+    "timezone" : "<timezone>"
+  },
+  "headers" : {
+    "accept-encoding" : "gzip",
+    "content-length" : "<content-length>",
+    "content-type" : "application\/json; charset=utf-8",
+    "user-agent" : "posthog-ios\/<sdk-version>"
+  },
+  "method" : "POST",
+  "url" : {
+    "host" : "localhost",
+    "path" : "\/flags",
+    "port" : 9001,
+    "query" : [
+      {
+        "name" : "v",
+        "value" : "2"
+      }
+    ],
+    "scheme" : "http"
+  }
+}

--- a/PostHogTests/Resources/session-replay-request.json
+++ b/PostHogTests/Resources/session-replay-request.json
@@ -1,0 +1,43 @@
+{
+  "body" : [
+    {
+      "api_key" : "snapshot-project-token",
+      "distinct_id" : "user-123",
+      "event" : "$snapshot",
+      "properties" : {
+        "$lib" : "posthog-ios",
+        "$lib_version" : "<sdk-version>",
+        "$session_id" : "00000000-0000-7000-8000-000000000002",
+        "$snapshot_data" : {
+          "data" : {
+            "href" : "https:\/\/example.com\/checkout",
+            "source" : 0
+          },
+          "timestamp" : 1704164645000,
+          "type" : 3
+        },
+        "$snapshot_source" : "mobile",
+        "distinct_id" : "user-123"
+      },
+      "timestamp" : "<iso8601-timestamp>",
+      "uuid" : "<uuid-v7>"
+    }
+  ],
+  "headers" : {
+    "accept-encoding" : "gzip",
+    "content-encoding" : "gzip",
+    "content-length" : "<content-length>",
+    "content-type" : "application\/json; charset=utf-8",
+    "user-agent" : "posthog-ios\/<sdk-version>"
+  },
+  "method" : "POST",
+  "url" : {
+    "host" : "localhost",
+    "path" : "\/s\/",
+    "port" : 9001,
+    "query" : [
+
+    ],
+    "scheme" : "http"
+  }
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

Material changes to final enriched events or wire request parameters should require an explicit golden update. This brings the deterministic coverage introduced for the browser in [d0933e1](https://github.com/PostHog/posthog-js/commit/d0933e1bcb600957b82e37d72dab895ceed16e27) to the iOS SDK.

The new suite captures batch events, SDK-driven feature-flag requests, and session replay requests. Environment-dependent and volatile values are validated before normalization, and fixtures are packaged for both SwiftPM and the Xcode test target. `make recordEventShapeSnapshots` is the explicit update path.

## :green_heart: How did you test it?

- `make recordEventShapeSnapshots`
- `make test filter=PostHogEventSnapshotTests`
- `swiftlint lint --quiet` (existing repository warnings only)
- Validated the Xcode project and all JSON fixtures parse successfully

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent and built-in reviewer subagents in a local session. Production sources remain unchanged; the design exercises the SDK's real enrichment and request serialization paths and keeps snapshot recording explicitly opt-in.
