### PR TITLE
chore: expand Dependabot ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,35 @@
 version: 2
 updates:
+  - package-ecosystem: "swift"
+    directories:
+      - "/"
+      - "/sdk_compliance_adapter"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      swift-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      release-tooling:
+        patterns:
+          - "*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: weekly
     cooldown:
       default-days: 7
-    reviewers:
-      - "PostHog/team-client-libraries"
     groups:
       codeql-action:
         patterns:


### PR DESCRIPTION
## :bulb: Motivation and Context

Dependabot only monitors GitHub Actions today. The Swift packages and npm release tooling also need automated dependency updates.

This adds weekly Swift updates for the root package and `sdk_compliance_adapter`, grouped as `swift-dependencies`. It adds weekly npm updates for the root release tooling, grouped as `release-tooling`. Both use a seven-day cooldown. The existing GitHub Actions schedule, cooldown, and `codeql-action` group remain unchanged. The explicit reviewer assignment is removed.

CocoaPods is not included because Dependabot does not support it. Docker is outside this change.

## :green_heart: How did you test it?

- Parsed the YAML and asserted the exact ecosystem order, directories, weekly schedules, cooldowns, groups, and absence of reviewers.
- Verified each configured directory and manifest exists.
- Verified `.github/CODEOWNERS` covers the configuration.
- Ran `make lint` and `git diff --check`.
- Ran autoreview against `origin/main` with no actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A Pi coding agent used the PR, autoreview, and check-pr workflows. The human specified the ecosystem order, directories, schedules, cooldowns, groups, exclusions, and required PR workflow. The agent kept the change to `.github/dependabot.yml` and validated the exact configuration before pushing.
