### PR TITLE
fix(push): re-register the device token on opt-in (#746)

### DIFF
--- a/.changeset/push-optin-reregister.md
+++ b/.changeset/push-optin-reregister.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Fix: opting back in now re-arms push notifications without an app restart. After a logout unregister clears the device token, `optIn()` re-requests the APNs token and re-registers the device (when `capturePushNotificationSubscriptions` is enabled) instead of only restoring consent (#746).

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -2427,6 +2427,15 @@ let maxRetryDelay = 30.0
             notifyContextDidChange()
             notifyExceptionStepsDidChange()
         }
+
+        #if os(iOS)
+            // A prior logout unregister cleared the push token; opt-in re-installs the subscription
+            // integration above but that alone doesn't refetch the token. Re-request it so the
+            // redelivered token re-registers this device, re-arming push without an app restart (#746).
+            if #available(iOS 14.0, *), config.capturePushNotificationSubscriptions {
+                PostHogPushNotificationSubscriptionIntegration.requestTokenRefresh()
+            }
+        #endif
     }
 
     /// Opts the current user out of data capture.

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -2432,7 +2432,10 @@ let maxRetryDelay = 30.0
             // A prior logout unregister cleared the push token; opt-in re-installs the subscription
             // integration above but that alone doesn't refetch the token. Re-request it so the
             // redelivered token re-registers this device, re-arming push without an app restart (#746).
-            if #available(iOS 14.0, *), config.capturePushNotificationSubscriptions {
+            // Gate on the same conditions that install the subscription integration: auto-capture and
+            // swizzling. Without swizzling the integration is skipped, so refetching would fire the host's
+            // APNs lifecycle with no observer to forward the token.
+            if #available(iOS 14.0, *), config.capturePushNotificationSubscriptions, config.enableSwizzling {
                 PostHogPushNotificationSubscriptionIntegration.requestTokenRefresh()
             }
         #endif

--- a/PostHog/PushNotifications/PostHogPushNotificationSubscriptionIntegration.swift
+++ b/PostHog/PushNotifications/PostHogPushNotificationSubscriptionIntegration.swift
@@ -2,6 +2,7 @@
 // still supports macOS). See the push-notifications shared plan, decision 3.
 #if os(iOS)
     import Foundation
+    import UIKit
     import UserNotifications
 
     /// Subscribes to `PushNotificationPublisher.onDeviceToken` to automatically forward APNs tokens
@@ -47,6 +48,19 @@
 
         func stop() {
             token = nil
+        }
+
+        /// Re-requests the APNs device token so opting back in re-arms push without an app restart.
+        /// A prior logout unregister clears the stored token, and opt-in only restores consent and the
+        /// observer; asking the OS to register again redelivers the token to the swizzled callback, which
+        /// re-registers it. Overridable in tests (posthog-ios#746).
+        static var requestTokenRefresh: () -> Void = {
+            // App-only: `UIApplication.shared` is unavailable in app extensions, which can't register for
+            // remote notifications anyway.
+            guard Bundle.main.bundleURL.pathExtension == "app" else { return }
+            DispatchQueue.main.async {
+                UIApplication.shared.registerForRemoteNotifications()
+            }
         }
     }
 

--- a/PostHogTests/PostHogPushNotificationTest.swift
+++ b/PostHogTests/PostHogPushNotificationTest.swift
@@ -143,6 +143,7 @@
             optOut: Bool = false,
             enableSwizzling: Bool = true,
             capturePushNotificationOpened: Bool = false,
+            capturePushNotificationSubscriptions: Bool = false,
             reuseAnonymousId: Bool = false,
             pushIdentityProvider: ((String, String, @escaping (String?) -> Void) -> Void)? = nil
         ) -> PostHogSDK {
@@ -154,7 +155,7 @@
             config.pushIdentityProvider = pushIdentityProvider
             config.captureApplicationLifecycleEvents = false
             config.captureScreenViews = false
-            config.capturePushNotificationSubscriptions = false
+            config.capturePushNotificationSubscriptions = capturePushNotificationSubscriptions
             config.capturePushNotificationOpened = capturePushNotificationOpened
             config.disableReachabilityForTesting = true
             config.disableQueueTimerForTesting = true
@@ -1675,6 +1676,43 @@
             #expect(event.event == "$push_notification_opened")
             #expect(event.properties["$notification_title"] as? String == "Hello")
         }
+
+        // MARK: - Opt-in re-registration (posthog-ios#746)
+
+        #if os(iOS)
+            @Test("opting back in re-requests the push token so push re-arms without an app restart")
+            func optInReRequestsPushToken() {
+                if #available(iOS 14.0, *) {
+                    let original = PostHogPushNotificationSubscriptionIntegration.requestTokenRefresh
+                    defer { PostHogPushNotificationSubscriptionIntegration.requestTokenRefresh = original }
+                    var refetchCount = 0
+                    PostHogPushNotificationSubscriptionIntegration.requestTokenRefresh = { refetchCount += 1 }
+
+                    let sut = getSDK(optOut: true, capturePushNotificationSubscriptions: true)
+                    defer { sut.close() }
+
+                    #expect(sut.isOptOut())
+                    sut.optIn()
+                    #expect(refetchCount == 1, "opt-in should re-request the APNs token, not just restore consent")
+                }
+            }
+
+            @Test("opt-in does not re-request the token when auto-capture is disabled")
+            func optInSkipsReRequestWhenAutoCaptureDisabled() {
+                if #available(iOS 14.0, *) {
+                    let original = PostHogPushNotificationSubscriptionIntegration.requestTokenRefresh
+                    defer { PostHogPushNotificationSubscriptionIntegration.requestTokenRefresh = original }
+                    var refetchCount = 0
+                    PostHogPushNotificationSubscriptionIntegration.requestTokenRefresh = { refetchCount += 1 }
+
+                    let sut = getSDK(optOut: true, capturePushNotificationSubscriptions: false)
+                    defer { sut.close() }
+
+                    sut.optIn()
+                    #expect(refetchCount == 0, "manual push mode leaves the token lifecycle to the host")
+                }
+            }
+        #endif
     }
 
 #endif

--- a/PostHogTests/PostHogPushNotificationTest.swift
+++ b/PostHogTests/PostHogPushNotificationTest.swift
@@ -1712,6 +1712,24 @@
                     #expect(refetchCount == 0, "manual push mode leaves the token lifecycle to the host")
                 }
             }
+
+            @Test("opt-in does not re-request the token when swizzling is disabled")
+            func optInSkipsReRequestWhenSwizzlingDisabled() {
+                if #available(iOS 14.0, *) {
+                    let original = PostHogPushNotificationSubscriptionIntegration.requestTokenRefresh
+                    defer { PostHogPushNotificationSubscriptionIntegration.requestTokenRefresh = original }
+                    var refetchCount = 0
+                    PostHogPushNotificationSubscriptionIntegration.requestTokenRefresh = { refetchCount += 1 }
+
+                    // Auto-capture on, but swizzling off: the subscription integration is not installed,
+                    // so refetching would fire the host's APNs lifecycle with no observer to catch it.
+                    let sut = getSDK(optOut: true, enableSwizzling: false, capturePushNotificationSubscriptions: true)
+                    defer { sut.close() }
+
+                    sut.optIn()
+                    #expect(refetchCount == 0, "no observer is installed without swizzling, so opt-in must not refetch")
+                }
+            }
         #endif
     }
 


### PR DESCRIPTION
## Problem

The opt-in half of #746. After a logout `unregister` clears the stored push token, `optIn()` only restores consent and the notification observer. It never refetches the APNs token or re-registers the device, so a user who opts out and back in stays unsubscribed and Workflows can't deliver to them until the next app restart re-runs registration.

## Change

On `optIn()`, when `capturePushNotificationSubscriptions` is enabled, the SDK now re-requests the APNs device token. The OS redelivers it to the (re-installed) subscription integration, which re-registers the device. A new `PostHogPushNotificationSubscriptionIntegration.requestTokenRefresh` hook encapsulates the `registerForRemoteNotifications()` call (with the same app-context guard `start()` uses) and is overridable in tests.

Manual push mode (`capturePushNotificationSubscriptions = false`) is unchanged: the host owns the token lifecycle, so opt-in does not auto-refetch.

## How tested

- Unit tests in `PostHogPushNotificationTest`: opt-in re-requests the token when auto-capture is on, and does not when it's off.
- Real-device E2E (iPhone, real backend): register, opt out (which clears the token), then opt in, and observed a re-register `POST /api/push_subscriptions`. With the refetch disabled, the same taps produced no re-register, confirming the fix is what re-arms push.

## Not in this PR

The unregister-DELETE-during-opt-out half of #746 is fixed separately in #759. This PR is independent and targets `main`.

🤖 Draft — opening for review; will un-draft after self-review.
