### PR TITLE
fix(surveys): refresh definitions from remote config

### DIFF
--- a/.changeset/fresh-surveys-refresh.md
+++ b/.changeset/fresh-surveys-refresh.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': patch
+---
+
+Refresh survey definitions when a new remote config loads.

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -20,7 +20,6 @@ class PostHogRemoteConfig {
     private let featureFlagsLock = NSLock()
     private var loadingFeatureFlags = false
     private var pendingFeatureFlagsRequest: PendingFeatureFlagsRequest?
-    private var pendingSurveyFeatureFlagsRequest: PendingFeatureFlagsRequest?
     private let sessionReplayLock = NSLock()
     private var sessionReplayFlagActive = false
     private var recordingSampleRate: Double?
@@ -382,13 +381,11 @@ class PostHogRemoteConfig {
                     callback: callback,
                     forSurveyRefresh: forSurveyRefresh
                 )
-                if forSurveyRefresh {
-                    let prev = self.pendingSurveyFeatureFlagsRequest?.callback
-                    self.pendingSurveyFeatureFlagsRequest = request
-                    return (true, prev)
-                }
-                let prev = self.pendingFeatureFlagsRequest?.callback
+                let previous = self.pendingFeatureFlagsRequest
                 self.pendingFeatureFlagsRequest = request
+                let prev = previous.map { pending in
+                    pending.forSurveyRefresh ? { _ in pending.callback(nil) } : pending.callback
+                }
                 return (true, prev)
             }
             self.loadingFeatureFlags = true
@@ -648,10 +645,6 @@ class PostHogRemoteConfig {
 
         let pending: PendingFeatureFlagsRequest? = loadingFeatureFlagsLock.withLock {
             self.loadingFeatureFlags = false
-            if let req = self.pendingSurveyFeatureFlagsRequest {
-                self.pendingSurveyFeatureFlagsRequest = nil
-                return req
-            }
             let req = self.pendingFeatureFlagsRequest
             self.pendingFeatureFlagsRequest = nil
             return req

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -19,6 +19,8 @@ class PostHogRemoteConfig {
     private let loadingFeatureFlagsLock = NSLock()
     private let featureFlagsLock = NSLock()
     private var loadingFeatureFlags = false
+    private var featureFlagsEvaluationContextVersion = 0
+    private var activeFeatureFlagsRequestContext: [String: Any]?
     private var pendingFeatureFlagsRequest: PendingFeatureFlagsRequest?
     private var surveyFeatureFlagsWaiters: [([String: Any]?) -> Void] = []
     private let sessionReplayLock = NSLock()
@@ -293,7 +295,8 @@ class PostHogRemoteConfig {
             deviceId: deviceId.isEmpty ? nil : deviceId,
             groups: groups,
             callback: callback ?? { _ in },
-            surveyCompletion: surveyCompletion
+            surveyCompletion: surveyCompletion,
+            coalesceWithCurrentRequest: surveyCompletion != nil && callback == nil
         )
     }
 
@@ -376,13 +379,29 @@ class PostHogRemoteConfig {
         deviceId: String? = nil,
         groups: [String: String],
         callback: @escaping ([String: Any]?) -> Void,
-        surveyCompletion: (([String: Any]?) -> Void)? = nil
+        surveyCompletion: (([String: Any]?) -> Void)? = nil,
+        coalesceWithCurrentRequest: Bool = false
     ) {
         let (alreadyLoading, previousCallback): (Bool, (([String: Any]?) -> Void)?) = loadingFeatureFlagsLock.withLock {
+            let requestContext: [String: Any] = [
+                "distinctId": distinctId,
+                "anonymousId": anonymousId ?? NSNull(),
+                "deviceId": deviceId ?? NSNull(),
+                "groups": groups,
+                "evaluationContextVersion": self.featureFlagsEvaluationContextVersion,
+            ]
             if let surveyCompletion {
                 self.surveyFeatureFlagsWaiters.append(surveyCompletion)
             }
             if self.loadingFeatureFlags {
+                if coalesceWithCurrentRequest,
+                   self.pendingFeatureFlagsRequest == nil,
+                   self.activeFeatureFlagsRequestContext.map({
+                       NSDictionary(dictionary: $0).isEqual(to: requestContext)
+                   }) == true
+                {
+                    return (true, nil)
+                }
                 let prev = self.pendingFeatureFlagsRequest?.callback
                 self.pendingFeatureFlagsRequest = PendingFeatureFlagsRequest(
                     distinctId: distinctId,
@@ -394,6 +413,7 @@ class PostHogRemoteConfig {
                 return (true, prev)
             }
             self.loadingFeatureFlags = true
+            self.activeFeatureFlagsRequestContext = requestContext
             return (false, nil)
         }
         if alreadyLoading {
@@ -648,6 +668,7 @@ class PostHogRemoteConfig {
     private func notifyFeatureFlagsAndRelease(_ featureFlags: [String: Any]?) {
         let (pending, surveyWaiters): (PendingFeatureFlagsRequest?, [([String: Any]?) -> Void]) = loadingFeatureFlagsLock.withLock {
             self.loadingFeatureFlags = false
+            self.activeFeatureFlagsRequestContext = nil
             let req = self.pendingFeatureFlagsRequest
             self.pendingFeatureFlagsRequest = nil
             guard req == nil else { return (req, []) }
@@ -810,6 +831,7 @@ class PostHogRemoteConfig {
         // value so a `capture()` carrying unchanged person properties doesn't re-run survey
         // translation resolution. Invoked outside the lock so subscribers don't run while we hold it.
         if didChange {
+            loadingFeatureFlagsLock.withLock { featureFlagsEvaluationContextVersion += 1 }
             onPersonPropertiesForFlagsChanged.invoke(())
         }
     }
@@ -823,6 +845,7 @@ class PostHogRemoteConfig {
             return hadProperties
         }
         if didChange {
+            loadingFeatureFlagsLock.withLock { featureFlagsEvaluationContextVersion += 1 }
             onPersonPropertiesForFlagsChanged.invoke(())
         }
     }
@@ -834,6 +857,7 @@ class PostHogRemoteConfig {
             // Persist to disk
             storage.setDictionary(forKey: .groupPropertiesForFlags, contents: groupPropertiesForFlags)
         }
+        loadingFeatureFlagsLock.withLock { featureFlagsEvaluationContextVersion += 1 }
     }
 
     func resetGroupPropertiesForFlags(_ groupType: String? = nil) {
@@ -846,6 +870,7 @@ class PostHogRemoteConfig {
             // Persist changes to disk
             storage.setDictionary(forKey: .groupPropertiesForFlags, contents: groupPropertiesForFlags)
         }
+        loadingFeatureFlagsLock.withLock { featureFlagsEvaluationContextVersion += 1 }
     }
 
     private func getGroupPropertiesForFlags() -> [String: [String: Any]] {

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -20,6 +20,7 @@ class PostHogRemoteConfig {
     private let featureFlagsLock = NSLock()
     private var loadingFeatureFlags = false
     private var pendingFeatureFlagsRequest: PendingFeatureFlagsRequest?
+    private var surveyFeatureFlagsWaiters: [([String: Any]?) -> Void] = []
     private let sessionReplayLock = NSLock()
     private var sessionReplayFlagActive = false
     private var recordingSampleRate: Double?
@@ -69,6 +70,10 @@ class PostHogRemoteConfig {
 
     private let dispatchQueue = DispatchQueue(label: "com.posthog.RemoteConfig",
                                               target: .global(qos: .utility))
+
+    var isLoadingFeatureFlags: Bool {
+        loadingFeatureFlagsLock.withLock { loadingFeatureFlags }
+    }
 
     var lastRequestId: String? {
         featureFlagsLock.withLock {
@@ -254,24 +259,26 @@ class PostHogRemoteConfig {
     func reloadFeatureFlags(
         callback: (([String: Any]?) -> Void)? = nil
     ) {
-        reloadFeatureFlags(callback: callback, forSurveyRefresh: false)
+        reloadFeatureFlags(callback: callback, surveyCompletion: nil)
     }
 
     func reloadFeatureFlagsForSurvey(callback: @escaping ([String: Any]?) -> Void) {
-        reloadFeatureFlags(callback: callback, forSurveyRefresh: true)
+        reloadFeatureFlags(callback: nil, surveyCompletion: callback)
     }
 
     private func reloadFeatureFlags(
         callback: (([String: Any]?) -> Void)?,
-        forSurveyRefresh: Bool
+        surveyCompletion: (([String: Any]?) -> Void)?
     ) {
         guard canReloadFlagsForTesting else {
+            surveyCompletion?(nil)
             return
         }
 
         guard let storageManager = config.storageManager else {
             hedgeLog("No PostHogStorageManager found in config, skipping loading feature flags")
             callback?(nil)
+            surveyCompletion?(nil)
             return
         }
 
@@ -286,7 +293,7 @@ class PostHogRemoteConfig {
             deviceId: deviceId.isEmpty ? nil : deviceId,
             groups: groups,
             callback: callback ?? { _ in },
-            forSurveyRefresh: forSurveyRefresh
+            surveyCompletion: surveyCompletion
         )
     }
 
@@ -369,23 +376,21 @@ class PostHogRemoteConfig {
         deviceId: String? = nil,
         groups: [String: String],
         callback: @escaping ([String: Any]?) -> Void,
-        forSurveyRefresh: Bool = false
+        surveyCompletion: (([String: Any]?) -> Void)? = nil
     ) {
         let (alreadyLoading, previousCallback): (Bool, (([String: Any]?) -> Void)?) = loadingFeatureFlagsLock.withLock {
+            if let surveyCompletion {
+                self.surveyFeatureFlagsWaiters.append(surveyCompletion)
+            }
             if self.loadingFeatureFlags {
-                let request = PendingFeatureFlagsRequest(
+                let prev = self.pendingFeatureFlagsRequest?.callback
+                self.pendingFeatureFlagsRequest = PendingFeatureFlagsRequest(
                     distinctId: distinctId,
                     anonymousId: anonymousId,
                     deviceId: deviceId,
                     groups: groups,
-                    callback: callback,
-                    forSurveyRefresh: forSurveyRefresh
+                    callback: callback
                 )
-                let previous = self.pendingFeatureFlagsRequest
-                self.pendingFeatureFlagsRequest = request
-                let prev = previous.map { pending in
-                    pending.forSurveyRefresh ? { _ in pending.callback(nil) } : pending.callback
-                }
                 return (true, prev)
             }
             self.loadingFeatureFlags = true
@@ -643,11 +648,14 @@ class PostHogRemoteConfig {
     private func notifyFeatureFlagsAndRelease(_ featureFlags: [String: Any]?) {
         notifyFeatureFlags(featureFlags)
 
-        let pending: PendingFeatureFlagsRequest? = loadingFeatureFlagsLock.withLock {
+        let (pending, surveyWaiters): (PendingFeatureFlagsRequest?, [([String: Any]?) -> Void]) = loadingFeatureFlagsLock.withLock {
             self.loadingFeatureFlags = false
             let req = self.pendingFeatureFlagsRequest
             self.pendingFeatureFlagsRequest = nil
-            return req
+            guard req == nil else { return (req, []) }
+            let waiters = self.surveyFeatureFlagsWaiters
+            self.surveyFeatureFlagsWaiters = []
+            return (nil, waiters)
         }
 
         if let pending {
@@ -656,9 +664,12 @@ class PostHogRemoteConfig {
                 anonymousId: pending.anonymousId,
                 deviceId: pending.deviceId,
                 groups: pending.groups,
-                callback: pending.callback,
-                forSurveyRefresh: pending.forSurveyRefresh
+                callback: pending.callback
             )
+        } else {
+            for waiter in surveyWaiters {
+                waiter(featureFlags)
+            }
         }
     }
 
@@ -1141,7 +1152,6 @@ private struct PendingFeatureFlagsRequest {
     let deviceId: String?
     let groups: [String: String]
     let callback: ([String: Any]?) -> Void
-    let forSurveyRefresh: Bool
 }
 
 #if TESTING

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -20,6 +20,7 @@ class PostHogRemoteConfig {
     private let featureFlagsLock = NSLock()
     private var loadingFeatureFlags = false
     private var pendingFeatureFlagsRequest: PendingFeatureFlagsRequest?
+    private var pendingSurveyFeatureFlagsRequest: PendingFeatureFlagsRequest?
     private let sessionReplayLock = NSLock()
     private var sessionReplayFlagActive = false
     private var recordingSampleRate: Double?
@@ -254,6 +255,17 @@ class PostHogRemoteConfig {
     func reloadFeatureFlags(
         callback: (([String: Any]?) -> Void)? = nil
     ) {
+        reloadFeatureFlags(callback: callback, forSurveyRefresh: false)
+    }
+
+    func reloadFeatureFlagsForSurvey(callback: @escaping ([String: Any]?) -> Void) {
+        reloadFeatureFlags(callback: callback, forSurveyRefresh: true)
+    }
+
+    private func reloadFeatureFlags(
+        callback: (([String: Any]?) -> Void)?,
+        forSurveyRefresh: Bool
+    ) {
         guard canReloadFlagsForTesting else {
             return
         }
@@ -274,7 +286,8 @@ class PostHogRemoteConfig {
             anonymousId: anonymousId,
             deviceId: deviceId.isEmpty ? nil : deviceId,
             groups: groups,
-            callback: callback ?? { _ in }
+            callback: callback ?? { _ in },
+            forSurveyRefresh: forSurveyRefresh
         )
     }
 
@@ -356,18 +369,26 @@ class PostHogRemoteConfig {
         anonymousId: String?,
         deviceId: String? = nil,
         groups: [String: String],
-        callback: @escaping ([String: Any]?) -> Void
+        callback: @escaping ([String: Any]?) -> Void,
+        forSurveyRefresh: Bool = false
     ) {
         let (alreadyLoading, previousCallback): (Bool, (([String: Any]?) -> Void)?) = loadingFeatureFlagsLock.withLock {
             if self.loadingFeatureFlags {
-                let prev = self.pendingFeatureFlagsRequest?.callback
-                self.pendingFeatureFlagsRequest = PendingFeatureFlagsRequest(
+                let request = PendingFeatureFlagsRequest(
                     distinctId: distinctId,
                     anonymousId: anonymousId,
                     deviceId: deviceId,
                     groups: groups,
-                    callback: callback
+                    callback: callback,
+                    forSurveyRefresh: forSurveyRefresh
                 )
+                if forSurveyRefresh {
+                    let prev = self.pendingSurveyFeatureFlagsRequest?.callback
+                    self.pendingSurveyFeatureFlagsRequest = request
+                    return (true, prev)
+                }
+                let prev = self.pendingFeatureFlagsRequest?.callback
+                self.pendingFeatureFlagsRequest = request
                 return (true, prev)
             }
             self.loadingFeatureFlags = true
@@ -627,6 +648,10 @@ class PostHogRemoteConfig {
 
         let pending: PendingFeatureFlagsRequest? = loadingFeatureFlagsLock.withLock {
             self.loadingFeatureFlags = false
+            if let req = self.pendingSurveyFeatureFlagsRequest {
+                self.pendingSurveyFeatureFlagsRequest = nil
+                return req
+            }
             let req = self.pendingFeatureFlagsRequest
             self.pendingFeatureFlagsRequest = nil
             return req
@@ -638,7 +663,8 @@ class PostHogRemoteConfig {
                 anonymousId: pending.anonymousId,
                 deviceId: pending.deviceId,
                 groups: pending.groups,
-                callback: pending.callback
+                callback: pending.callback,
+                forSurveyRefresh: pending.forSurveyRefresh
             )
         }
     }
@@ -1122,6 +1148,7 @@ private struct PendingFeatureFlagsRequest {
     let deviceId: String?
     let groups: [String: String]
     let callback: ([String: Any]?) -> Void
+    let forSurveyRefresh: Bool
 }
 
 #if TESTING

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -646,8 +646,6 @@ class PostHogRemoteConfig {
     }
 
     private func notifyFeatureFlagsAndRelease(_ featureFlags: [String: Any]?) {
-        notifyFeatureFlags(featureFlags)
-
         let (pending, surveyWaiters): (PendingFeatureFlagsRequest?, [([String: Any]?) -> Void]) = loadingFeatureFlagsLock.withLock {
             self.loadingFeatureFlags = false
             let req = self.pendingFeatureFlagsRequest
@@ -671,6 +669,7 @@ class PostHogRemoteConfig {
                 waiter(featureFlags)
             }
         }
+        notifyFeatureFlags(featureFlags)
     }
 
     func getFeatureFlags() -> [String: Any]? {

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -286,26 +286,31 @@
                 guard hasActiveSurveyWindow(), canShowNextSurvey(), canShowSurveyWithFreshFeatureFlags
                 else { return }
 
+                let refreshGeneration = freshFeatureFlagsLock.withLock { surveyRefreshGeneration }
                 getActiveMatchingSurveys { activeSurveys in
-                    if let survey = activeSurveys.first(where: self.canRenderSurvey) {
+                    DispatchQueue.main.async { [weak self] in
+                        guard let self,
+                              self.freshFeatureFlagsLock.withLock({ self.surveyRefreshGeneration == refreshGeneration }),
+                              self.hasActiveSurveyWindow(),
+                              self.canShowNextSurvey(),
+                              self.canShowSurveyWithFreshFeatureFlags,
+                              let survey = activeSurveys.first(where: self.canRenderSurvey)
+                        else { return }
+
                         let language = self.resolveDisplayLanguage()
                         let translations = resolveSurveyTranslations(survey: survey, targetLanguage: language)
                         self.setActiveSurvey(survey: survey, language: translations.matchedKey, questionTranslations: translations.questions)
 
-                        DispatchQueue.main.async { [weak self] in
-                            if let self {
-                                // render the survey
-                                self.postHog?.config.surveysConfig.surveysDelegate.renderSurvey(
-                                    survey.toDisplaySurvey(
-                                        surveyTranslation: translations.survey,
-                                        questionTranslations: translations.questions
-                                    ),
-                                    onSurveyShown: self.handleSurveyShown,
-                                    onSurveyResponse: self.handleSurveyResponse,
-                                    onSurveyClosed: self.handleSurveyClosed
-                                )
-                            }
-                        }
+                        // render the survey
+                        self.postHog?.config.surveysConfig.surveysDelegate.renderSurvey(
+                            survey.toDisplaySurvey(
+                                surveyTranslation: translations.survey,
+                                questionTranslations: translations.questions
+                            ),
+                            onSurveyShown: self.handleSurveyShown,
+                            onSurveyResponse: self.handleSurveyResponse,
+                            onSurveyClosed: self.handleSurveyClosed
+                        )
                     }
                 }
             #endif

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -39,6 +39,7 @@
         let eventActivatedSurveysLock = NSLock()
         var eventActivatedSurveys: [String: [PostHogEventCondition]] = [:]
         let freshFeatureFlagsLock = NSLock()
+        let surveyRefreshProcessingLock = NSLock()
         var surveyRefreshGeneration = 0
         var surveyAwaitingFeatureFlagsGeneration: Int?
         var surveyFeatureFlagsUnavailable = false

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -40,6 +40,9 @@
         var eventActivatedSurveys: [String: [PostHogEventCondition]] = [:]
         let freshFeatureFlagsLock = NSLock()
         var surveysAwaitingFreshFeatureFlags = false
+        #if os(iOS)
+            var hasActiveSurveyWindow: () -> Bool = { UIApplication.getCurrentWindow() != nil }
+        #endif
 
         private var didBecomeActiveToken: RegistrationToken?
         private var didLayoutViewToken: RegistrationToken?
@@ -51,8 +54,6 @@
         private var activeSurveyLock = NSLock()
         private var activeSurvey: PostHogSurvey?
         private var activeSurveyLanguage: String?
-        /// Language the survey was rendered with, frozen at show time and reused as `$survey_language` on
-        /// `sent`/`dismissed`. Not touched by `refreshActiveSurveyTranslations`, so a drop stays detectable.
         private var activeSurveyRenderedLanguage: String?
         private var activeSurveyQuestionTranslations: [PostHogSurveyQuestionTranslation?]?
         /// Question translations frozen at show time — the fallback text for questions never answered,
@@ -299,11 +300,6 @@
             return postHog.isFeatureEnabled(flagKey)
         }
 
-        private func canRenderSurvey(survey: PostHogSurvey) -> Bool {
-            // only render popover surveys for now
-            survey.type == .popover
-        }
-
         /// Shows next survey in queue. No-op if a survey is already being shown
         func showNextSurvey() {
             #if os(iOS)
@@ -312,7 +308,11 @@
                     return
                 }
 
-                guard canShowNextSurvey(), canShowSurveyWithFreshFeatureFlags
+                guard Thread.isMainThread else {
+                    DispatchQueue.main.async { [weak self] in self?.showNextSurvey() }
+                    return
+                }
+                guard hasActiveSurveyWindow(), canShowNextSurvey(), canShowSurveyWithFreshFeatureFlags
                 else { return }
 
                 getActiveMatchingSurveys { activeSurveys in

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -41,6 +41,7 @@
         let freshFeatureFlagsLock = NSLock()
         var surveyRefreshGeneration = 0
         var surveyAwaitingFeatureFlagsGeneration: Int?
+        var surveyFailedFeatureFlagsGeneration: Int?
         #if os(iOS)
             var hasActiveSurveyWindow: () -> Bool = { UIApplication.getCurrentWindow() != nil }
         #endif
@@ -50,6 +51,7 @@
         private var eventCapturedToken: RegistrationToken?
         private var personPropertiesChangedToken: RegistrationToken?
         var remoteConfigLoadedToken: RegistrationToken?
+        var featureFlagsLoadedToken: RegistrationToken?
 
         private var activeSurveyLock = NSLock()
         private var activeSurvey: PostHogSurvey?

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -39,7 +39,8 @@
         let eventActivatedSurveysLock = NSLock()
         var eventActivatedSurveys: [String: [PostHogEventCondition]] = [:]
         let freshFeatureFlagsLock = NSLock()
-        var surveysAwaitingFreshFeatureFlags = false
+        var surveyRefreshGeneration = 0
+        var surveyAwaitingFeatureFlagsGeneration: Int?
         #if os(iOS)
             var hasActiveSurveyWindow: () -> Bool = { UIApplication.getCurrentWindow() != nil }
         #endif
@@ -49,11 +50,12 @@
         private var eventCapturedToken: RegistrationToken?
         private var personPropertiesChangedToken: RegistrationToken?
         var remoteConfigLoadedToken: RegistrationToken?
-        var featureFlagsLoadedToken: RegistrationToken?
 
         private var activeSurveyLock = NSLock()
         private var activeSurvey: PostHogSurvey?
         private var activeSurveyLanguage: String?
+        /// Language the survey was rendered with, frozen at show time and reused as `$survey_language` on
+        /// `sent`/`dismissed`. Not touched by `refreshActiveSurveyTranslations`, so a drop stays detectable.
         private var activeSurveyRenderedLanguage: String?
         private var activeSurveyQuestionTranslations: [PostHogSurveyQuestionTranslation?]?
         /// Question translations frozen at show time — the fallback text for questions never answered,
@@ -250,46 +252,13 @@
             }
         }
 
-        func decodeAndSetSurveys(remoteConfig: [String: Any]?, callback: @escaping SurveyCallback) {
-            let loadedSurveys: [PostHogSurvey] = decodeSurveys(from: remoteConfig ?? [:])
-
-            let eventMap = loadedSurveys.reduce(into: [String: [(surveyId: String, condition: PostHogEventCondition)]]()) { result, current in
-                if let surveyEvents = current.conditions?.events?.values {
-                    for eventCondition in surveyEvents {
-                        result[eventCondition.name, default: []].append(
-                            (surveyId: current.id, condition: eventCondition)
-                        )
-                    }
-                }
-            }
-
-            allSurveysLock.withLock {
-                self.allSurveys = loadedSurveys
-            }
-            eventsToSurveysLock.withLock {
-                self.eventsToSurveys = eventMap
-            }
-            reconcileEventActivations(with: loadedSurveys)
-
-            callback(loadedSurveys)
-        }
-
-        private func decodeSurveys(from remoteConfig: [String: Any]) -> [PostHogSurvey] {
-            guard let surveysJSON = remoteConfig["surveys"] as? [[String: Any]] else {
-                // surveys not json, disabled
-                return []
-            }
-
-            // Decode each survey individually so one malformed entry doesn't drop the entire list
-            return surveysJSON.compactMap { surveyJSON in
-                do {
-                    let jsonData = try JSONSerialization.data(withJSONObject: surveyJSON)
-                    return try PostHogApi.jsonDecoder.decode(PostHogSurvey.self, from: jsonData)
-                } catch {
-                    hedgeLog("Error decoding Survey: \(error)")
-                    return nil
-                }
-            }
+        func updateSurveyCache(
+            _ surveys: [PostHogSurvey],
+            events: [String: [(surveyId: String, condition: PostHogEventCondition)]]
+        ) {
+            allSurveysLock.withLock { allSurveys = surveys }
+            eventsToSurveysLock.withLock { eventsToSurveys = events }
+            reconcileEventActivations(with: surveys)
         }
 
         private func isSurveyFeatureFlagEnabled(flagKey: String?) -> Bool {

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -22,7 +22,7 @@
         private let kSurveySeenKeyPrefix = "seenSurvey_"
         private let kSurveyResponseKey = "$survey_response"
 
-        private var postHog: PostHogSDK?
+        var postHog: PostHogSDK?
         private var config: PostHogConfig? { postHog?.config }
         private var storage: PostHogStorage? { postHog?.storage }
         private var remoteConfig: PostHogRemoteConfig? { postHog?.remoteConfig }
@@ -36,14 +36,17 @@
         private var seenSurveyKeysLock = NSLock()
         private var seenSurveyKeys: [AnyHashable: Any]?
 
-        private var eventActivatedSurveysLock = NSLock()
-        private var eventActivatedSurveys: Set<String> = []
+        let eventActivatedSurveysLock = NSLock()
+        var eventActivatedSurveys: [String: [PostHogEventCondition]] = [:]
+        let freshFeatureFlagsLock = NSLock()
+        var surveysAwaitingFreshFeatureFlags = false
 
         private var didBecomeActiveToken: RegistrationToken?
         private var didLayoutViewToken: RegistrationToken?
         private var eventCapturedToken: RegistrationToken?
         private var personPropertiesChangedToken: RegistrationToken?
-        private var remoteConfigLoadedToken: RegistrationToken?
+        var remoteConfigLoadedToken: RegistrationToken?
+        var featureFlagsLoadedToken: RegistrationToken?
 
         private var activeSurveyLock = NSLock()
         private var activeSurvey: PostHogSurvey?
@@ -82,10 +85,7 @@
             personPropertiesChangedToken = postHog?.remoteConfig?.onPersonPropertiesForFlagsChanged.subscribe { [weak self] _ in
                 self?.refreshActiveSurveyTranslations()
             }
-            remoteConfigLoadedToken = postHog?.remoteConfig?.onRemoteConfigLoaded.subscribe { [weak self] remoteConfig in
-                guard let self, let remoteConfig else { return }
-                self.decodeAndSetSurveys(remoteConfig: remoteConfig) { _ in self.showNextSurvey() }
-            }
+            subscribeToRemoteConfigUpdates()
             #if os(iOS)
                 // Subscribe to event captures
                 eventCapturedToken = postHog?.onEventCaptured.subscribe { [weak self] event in
@@ -106,7 +106,7 @@
             didBecomeActiveToken = nil
             didLayoutViewToken = nil
             personPropertiesChangedToken = nil
-            remoteConfigLoadedToken = nil
+            unsubscribeFromRemoteConfigUpdates()
             #if os(iOS)
                 if #available(iOS 15.0, *) {
                     config?.surveysConfig.surveysDelegate.cleanupSurveys()
@@ -168,15 +168,14 @@
             let candidates = eventsToSurveysLock.withLock { eventsToSurveys[event.event] } ?? []
             guard !candidates.isEmpty else { return }
 
-            let matchingSurveyIds = candidates
+            let matchingSurveys = candidates
                 .filter { matchPropertyFilters($0.condition.propertyFilters, eventProperties: event.properties) }
-                .map(\.surveyId)
 
-            guard !matchingSurveyIds.isEmpty else { return }
+            guard !matchingSurveys.isEmpty else { return }
 
             eventActivatedSurveysLock.withLock {
-                for survey in matchingSurveyIds {
-                    eventActivatedSurveys.insert(survey)
+                for survey in matchingSurveys where eventActivatedSurveys[survey.surveyId]?.contains(survey.condition) != true {
+                    eventActivatedSurveys[survey.surveyId, default: []].append(survey.condition)
                 }
             }
 
@@ -250,7 +249,7 @@
             }
         }
 
-        private func decodeAndSetSurveys(remoteConfig: [String: Any]?, callback: @escaping SurveyCallback) {
+        func decodeAndSetSurveys(remoteConfig: [String: Any]?, callback: @escaping SurveyCallback) {
             let loadedSurveys: [PostHogSurvey] = decodeSurveys(from: remoteConfig ?? [:])
 
             let eventMap = loadedSurveys.reduce(into: [String: [(surveyId: String, condition: PostHogEventCondition)]]()) { result, current in
@@ -269,6 +268,7 @@
             eventsToSurveysLock.withLock {
                 self.eventsToSurveys = eventMap
             }
+            reconcileEventActivations(with: loadedSurveys)
 
             callback(loadedSurveys)
         }
@@ -305,16 +305,16 @@
         }
 
         /// Shows next survey in queue. No-op if a survey is already being shown
-        private func showNextSurvey() {
+        func showNextSurvey() {
             #if os(iOS)
                 guard #available(iOS 15.0, *) else {
                     hedgeLog("[Surveys] Surveys can be rendered only on iOS 15+")
                     return
                 }
 
-                guard canShowNextSurvey() else { return }
+                guard canShowNextSurvey(), canShowSurveyWithFreshFeatureFlags
+                else { return }
 
-                // Check if there is a new popover surveys to be displayed
                 getActiveMatchingSurveys { activeSurveys in
                     if let survey = activeSurveys.first(where: self.canRenderSurvey) {
                         let language = self.resolveDisplayLanguage()
@@ -506,9 +506,9 @@
 
         /// Checks if a survey has been previously activated by an associated event
         private func isSurveyEventActivated(survey: PostHogSurvey) -> Bool {
-            eventActivatedSurveysLock.withLock {
-                eventActivatedSurveys.contains(survey.id)
-            }
+            let activatedConditions = eventActivatedSurveysLock.withLock { eventActivatedSurveys[survey.id] } ?? []
+            let currentConditions = survey.conditions?.events?.values ?? []
+            return activatedConditions.contains { currentConditions.contains($0) }
         }
 
         /// Handle a survey that is shown
@@ -529,7 +529,7 @@
             // clear up event-activated surveys
             if activeSurvey.hasEvents {
                 eventActivatedSurveysLock.withLock {
-                    _ = eventActivatedSurveys.remove(activeSurvey.id)
+                    _ = eventActivatedSurveys.removeValue(forKey: activeSurvey.id)
                 }
             }
         }
@@ -1184,7 +1184,7 @@
 
             func testIsEventActivated(surveyId: String) -> Bool {
                 eventActivatedSurveysLock.withLock {
-                    eventActivatedSurveys.contains(surveyId)
+                    eventActivatedSurveys[surveyId] != nil
                 }
             }
 

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -51,6 +51,7 @@
         private var eventCapturedToken: RegistrationToken?
         private var personPropertiesChangedToken: RegistrationToken?
         var remoteConfigLoadedToken: RegistrationToken?
+        var featureFlagsLoadedToken: RegistrationToken?
 
         private var activeSurveyLock = NSLock()
         private var activeSurvey: PostHogSurvey?

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -43,6 +43,7 @@
         private var didLayoutViewToken: RegistrationToken?
         private var eventCapturedToken: RegistrationToken?
         private var personPropertiesChangedToken: RegistrationToken?
+        private var remoteConfigLoadedToken: RegistrationToken?
 
         private var activeSurveyLock = NSLock()
         private var activeSurvey: PostHogSurvey?
@@ -81,18 +82,19 @@
             personPropertiesChangedToken = postHog?.remoteConfig?.onPersonPropertiesForFlagsChanged.subscribe { [weak self] _ in
                 self?.refreshActiveSurveyTranslations()
             }
-
+            remoteConfigLoadedToken = postHog?.remoteConfig?.onRemoteConfigLoaded.subscribe { [weak self] remoteConfig in
+                guard let self, let remoteConfig else { return }
+                self.decodeAndSetSurveys(remoteConfig: remoteConfig) { _ in self.showNextSurvey() }
+            }
             #if os(iOS)
                 // Subscribe to event captures
                 eventCapturedToken = postHog?.onEventCaptured.subscribe { [weak self] event in
                     self?.onEvent(event: event)
                 }
-
                 // TODO: listen to screen view events
                 didLayoutViewToken = DI.main.viewLayoutPublisher.onViewLayout.subscribe(throttle: 5) { [weak self] in
                     self?.showNextSurvey()
                 }
-
                 didBecomeActiveToken = DI.main.appLifecyclePublisher.onDidBecomeActive.subscribe { [weak self] in
                     self?.showNextSurvey()
                 }
@@ -104,6 +106,7 @@
             didBecomeActiveToken = nil
             didLayoutViewToken = nil
             personPropertiesChangedToken = nil
+            remoteConfigLoadedToken = nil
             #if os(iOS)
                 if #available(iOS 15.0, *) {
                     config?.surveysConfig.surveysDelegate.cleanupSurveys()

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -285,8 +285,7 @@
                     DispatchQueue.main.async { [weak self] in self?.showNextSurvey() }
                     return
                 }
-                guard hasActiveSurveyWindow(), canShowNextSurvey(), canShowSurveyWithFreshFeatureFlags
-                else { return }
+                guard hasActiveSurveyWindow(), canShowNextSurvey() else { return }
 
                 let refreshGeneration = freshFeatureFlagsLock.withLock { surveyRefreshGeneration }
                 getActiveMatchingSurveys { activeSurveys in
@@ -295,7 +294,6 @@
                               self.freshFeatureFlagsLock.withLock({ self.surveyRefreshGeneration == refreshGeneration }),
                               self.hasActiveSurveyWindow(),
                               self.canShowNextSurvey(),
-                              self.canShowSurveyWithFreshFeatureFlags,
                               let survey = activeSurveys.first(where: self.canRenderSurvey)
                         else { return }
 

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -41,7 +41,7 @@
         let freshFeatureFlagsLock = NSLock()
         var surveyRefreshGeneration = 0
         var surveyAwaitingFeatureFlagsGeneration: Int?
-        var surveyFailedFeatureFlagsGeneration: Int?
+        var surveyFeatureFlagsUnavailable = false
         #if os(iOS)
             var hasActiveSurveyWindow: () -> Bool = { UIApplication.getCurrentWindow() != nil }
         #endif
@@ -51,7 +51,6 @@
         private var eventCapturedToken: RegistrationToken?
         private var personPropertiesChangedToken: RegistrationToken?
         var remoteConfigLoadedToken: RegistrationToken?
-        var featureFlagsLoadedToken: RegistrationToken?
 
         private var activeSurveyLock = NSLock()
         private var activeSurvey: PostHogSurvey?
@@ -144,6 +143,7 @@
                         self.hasWaitPeriodPassed(survey: survey)
                     }
                     .filter { survey in // 4. and match linked flags
+                        guard !survey.requiresFeatureFlagEvaluation || self.canEvaluateSurveyFeatureFlags else { return false }
                         let allKeys: [String?] = [
                             [survey.linkedFlagKey],
                             [survey.targetingFlagKey],

--- a/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
+++ b/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
@@ -37,6 +37,57 @@
             (conditions?.events?.repeatedActivation == true && hasEvents) ||
                 schedule == .always
         }
+
+        var requiresFeatureFlagEvaluation: Bool {
+            let keys = [linkedFlagKey, targetingFlagKey, canActivateRepeatedly ? nil : internalTargetingFlagKey] +
+                (featureFlagKeys?.map(\.value) ?? [])
+            return keys.contains { !($0?.isEmpty ?? true) }
+        }
+    }
+
+    extension PostHogSurveyIntegration {
+        var canShowSurveyWithFreshFeatureFlags: Bool {
+            freshFeatureFlagsLock.withLock { !surveysAwaitingFreshFeatureFlags }
+        }
+
+        func subscribeToRemoteConfigUpdates() {
+            remoteConfigLoadedToken = postHog?.remoteConfig?.onRemoteConfigLoaded.subscribe { [weak self] remoteConfig in
+                guard let self, let remoteConfig else { return }
+                self.decodeAndSetSurveys(remoteConfig: remoteConfig) { surveys in
+                    let reloadsFlags = self.postHog?.config.preloadFeatureFlags == true ||
+                        remoteConfig["hasFeatureFlags"] as? Bool == false
+                    let awaitingFlags = reloadsFlags && surveys.contains(where: \.requiresFeatureFlagEvaluation)
+                    self.freshFeatureFlagsLock.withLock { self.surveysAwaitingFreshFeatureFlags = awaitingFlags }
+                    if !awaitingFlags { self.showNextSurvey() }
+                }
+            }
+            featureFlagsLoadedToken = postHog?.remoteConfig?.onFeatureFlagsLoaded.subscribe { [weak self] flags in
+                guard let self, flags != nil else { return }
+                let shouldShow = self.freshFeatureFlagsLock.withLock {
+                    defer { self.surveysAwaitingFreshFeatureFlags = false }
+                    return self.surveysAwaitingFreshFeatureFlags
+                }
+                if shouldShow { self.showNextSurvey() }
+            }
+        }
+
+        func unsubscribeFromRemoteConfigUpdates() {
+            remoteConfigLoadedToken = nil
+            featureFlagsLoadedToken = nil
+            freshFeatureFlagsLock.withLock { surveysAwaitingFreshFeatureFlags = false }
+        }
+
+        func reconcileEventActivations(with surveys: [PostHogSurvey]) {
+            let current = surveys.reduce(into: [String: [PostHogEventCondition]]()) {
+                $0[$1.id] = $1.conditions?.events?.values ?? []
+            }
+            eventActivatedSurveysLock.withLock {
+                eventActivatedSurveys = eventActivatedSurveys.reduce(into: [:]) { result, activation in
+                    let retained = activation.value.filter { current[activation.key]?.contains($0) == true }
+                    if !retained.isEmpty { result[activation.key] = retained }
+                }
+            }
+        }
     }
 
     extension PostHogSurveyMatchType {

--- a/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
+++ b/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
@@ -40,7 +40,7 @@
 
         var requiresFeatureFlagEvaluation: Bool {
             let keys = [linkedFlagKey, targetingFlagKey, canActivateRepeatedly ? nil : internalTargetingFlagKey] +
-                (featureFlagKeys?.map(\.value) ?? [])
+                (featureFlagKeys?.compactMap { $0.key.isEmpty ? nil : $0.value } ?? [])
             return keys.contains { !($0?.isEmpty ?? true) }
         }
     }
@@ -91,13 +91,10 @@
             survey.type == .popover
         }
 
-        var canShowSurveyWithFreshFeatureFlags: Bool {
-            freshFeatureFlagsLock.withLock { surveyAwaitingFeatureFlagsGeneration == nil } &&
-                postHog?.remoteConfig?.isLoadingFeatureFlags != true
-        }
-
         var canEvaluateSurveyFeatureFlags: Bool {
-            freshFeatureFlagsLock.withLock { !surveyFeatureFlagsUnavailable }
+            freshFeatureFlagsLock.withLock {
+                surveyAwaitingFeatureFlagsGeneration == nil && !surveyFeatureFlagsUnavailable
+            } && postHog?.remoteConfig?.isLoadingFeatureFlags != true
         }
 
         func subscribeToRemoteConfigUpdates() {
@@ -110,7 +107,7 @@
                         beforeCacheUpdate: { _ in self.isCurrentSurveyRefresh(generation) },
                         callback: { surveys in
                             _ = self.refreshFeatureFlagsIfNeeded(for: surveys, generation: generation)
-                            if self.canShowSurveyWithFreshFeatureFlags { self.showNextSurvey() }
+                            self.showNextSurvey()
                         }
                     )
                 }

--- a/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
+++ b/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
@@ -48,11 +48,11 @@
     extension PostHogSurveyIntegration {
         func decodeAndSetSurveys(
             remoteConfig: [String: Any]?,
-            beforeCacheUpdate: SurveyCallback? = nil,
+            beforeCacheUpdate: (([PostHogSurvey]) -> Bool)? = nil,
             callback: @escaping SurveyCallback
         ) {
             let loadedSurveys: [PostHogSurvey] = decodeSurveys(from: remoteConfig ?? [:])
-            beforeCacheUpdate?(loadedSurveys)
+            guard beforeCacheUpdate?(loadedSurveys) != false else { return }
 
             let eventMap = loadedSurveys.reduce(into: [String: [(surveyId: String, condition: PostHogEventCondition)]]()) { result, current in
                 if let surveyEvents = current.conditions?.events?.values {
@@ -92,7 +92,8 @@
         }
 
         var canShowSurveyWithFreshFeatureFlags: Bool {
-            freshFeatureFlagsLock.withLock { surveyAwaitingFeatureFlagsGeneration == nil }
+            freshFeatureFlagsLock.withLock { surveyAwaitingFeatureFlagsGeneration == nil } &&
+                postHog?.remoteConfig?.isLoadingFeatureFlags != true
         }
 
         var canEvaluateSurveyFeatureFlags: Bool {
@@ -102,18 +103,25 @@
         func subscribeToRemoteConfigUpdates() {
             remoteConfigLoadedToken = postHog?.remoteConfig?.onRemoteConfigLoaded.subscribe { [weak self] remoteConfig in
                 guard let self, let remoteConfig else { return }
+                let generation = self.beginSurveyRefresh()
                 self.decodeAndSetSurveys(
                     remoteConfig: remoteConfig,
-                    beforeCacheUpdate: { surveys in self.refreshFeatureFlagsIfNeeded(for: surveys) },
+                    beforeCacheUpdate: { surveys in
+                        self.refreshFeatureFlagsIfNeeded(for: surveys, generation: generation)
+                    },
                     callback: { _ in
                         if self.canShowSurveyWithFreshFeatureFlags { self.showNextSurvey() }
                     }
                 )
             }
+            featureFlagsLoadedToken = postHog?.remoteConfig?.onFeatureFlagsLoaded.subscribe { [weak self] _ in
+                self?.showNextSurvey()
+            }
         }
 
         func unsubscribeFromRemoteConfigUpdates() {
             remoteConfigLoadedToken = nil
+            featureFlagsLoadedToken = nil
             freshFeatureFlagsLock.withLock {
                 surveyRefreshGeneration += 1
                 surveyAwaitingFeatureFlagsGeneration = nil
@@ -121,15 +129,23 @@
             }
         }
 
-        func refreshFeatureFlagsIfNeeded(for surveys: [PostHogSurvey]) {
-            let needsFlags = surveys.contains(where: \.requiresFeatureFlagEvaluation)
-            let generation = freshFeatureFlagsLock.withLock {
+        func beginSurveyRefresh() -> Int {
+            freshFeatureFlagsLock.withLock {
                 surveyRefreshGeneration += 1
-                surveyAwaitingFeatureFlagsGeneration = needsFlags ? surveyRefreshGeneration : nil
-                if !needsFlags { surveyFeatureFlagsUnavailable = false }
-                return surveyAwaitingFeatureFlagsGeneration
+                surveyAwaitingFeatureFlagsGeneration = surveyRefreshGeneration
+                return surveyRefreshGeneration
             }
-            guard let generation else { return }
+        }
+
+        func refreshFeatureFlagsIfNeeded(for surveys: [PostHogSurvey], generation: Int) -> Bool {
+            let needsFlags = surveys.contains(where: \.requiresFeatureFlagEvaluation)
+            let shouldRefresh = freshFeatureFlagsLock.withLock {
+                guard surveyRefreshGeneration == generation else { return false }
+                surveyAwaitingFeatureFlagsGeneration = needsFlags ? generation : nil
+                if !needsFlags { surveyFeatureFlagsUnavailable = false }
+                return needsFlags
+            }
+            guard shouldRefresh else { return freshFeatureFlagsLock.withLock { surveyRefreshGeneration == generation } }
 
             postHog?.remoteConfig?.reloadFeatureFlagsForSurvey { [weak self] flags in
                 guard let self else { return }
@@ -143,6 +159,7 @@
                     if shouldShow { self.showNextSurvey() }
                 }
             }
+            return true
         }
 
         func reconcileEventActivations(with surveys: [PostHogSurvey]) {

--- a/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
+++ b/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
@@ -162,15 +162,13 @@
 
             postHog?.remoteConfig?.reloadFeatureFlagsForSurvey { [weak self] flags in
                 guard let self else { return }
-                DispatchQueue.main.async {
-                    let shouldShow = self.freshFeatureFlagsLock.withLock {
-                        guard self.surveyAwaitingFeatureFlagsGeneration == generation else { return false }
-                        self.surveyAwaitingFeatureFlagsGeneration = nil
-                        self.surveyFeatureFlagsUnavailable = flags == nil
-                        return true
-                    }
-                    if shouldShow { self.showNextSurvey() }
+                let shouldShow = self.freshFeatureFlagsLock.withLock {
+                    guard self.surveyAwaitingFeatureFlagsGeneration == generation else { return false }
+                    self.surveyAwaitingFeatureFlagsGeneration = nil
+                    self.surveyFeatureFlagsUnavailable = flags == nil
+                    return true
                 }
+                if shouldShow { self.showNextSurvey() }
             }
             return true
         }

--- a/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
+++ b/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
@@ -46,6 +46,10 @@
     }
 
     extension PostHogSurveyIntegration {
+        func canRenderSurvey(survey: PostHogSurvey) -> Bool {
+            survey.type == .popover
+        }
+
         var canShowSurveyWithFreshFeatureFlags: Bool {
             freshFeatureFlagsLock.withLock { !surveysAwaitingFreshFeatureFlags }
         }

--- a/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
+++ b/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
@@ -103,16 +103,17 @@
         func subscribeToRemoteConfigUpdates() {
             remoteConfigLoadedToken = postHog?.remoteConfig?.onRemoteConfigLoaded.subscribe { [weak self] remoteConfig in
                 guard let self, let remoteConfig else { return }
-                let generation = self.beginSurveyRefresh()
-                self.decodeAndSetSurveys(
-                    remoteConfig: remoteConfig,
-                    beforeCacheUpdate: { surveys in
-                        self.refreshFeatureFlagsIfNeeded(for: surveys, generation: generation)
-                    },
-                    callback: { _ in
-                        if self.canShowSurveyWithFreshFeatureFlags { self.showNextSurvey() }
-                    }
-                )
+                self.surveyRefreshProcessingLock.withLock {
+                    let generation = self.beginSurveyRefresh()
+                    self.decodeAndSetSurveys(
+                        remoteConfig: remoteConfig,
+                        beforeCacheUpdate: { _ in self.isCurrentSurveyRefresh(generation) },
+                        callback: { surveys in
+                            _ = self.refreshFeatureFlagsIfNeeded(for: surveys, generation: generation)
+                            if self.canShowSurveyWithFreshFeatureFlags { self.showNextSurvey() }
+                        }
+                    )
+                }
             }
             featureFlagsLoadedToken = postHog?.remoteConfig?.onFeatureFlagsLoaded.subscribe { [weak self] flags in
                 guard let self else { return }
@@ -143,6 +144,10 @@
                 surveyAwaitingFeatureFlagsGeneration = surveyRefreshGeneration
                 return surveyRefreshGeneration
             }
+        }
+
+        func isCurrentSurveyRefresh(_ generation: Int) -> Bool {
+            freshFeatureFlagsLock.withLock { surveyRefreshGeneration == generation }
         }
 
         func refreshFeatureFlagsIfNeeded(for surveys: [PostHogSurvey], generation: Int) -> Bool {

--- a/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
+++ b/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
@@ -95,6 +95,10 @@
             freshFeatureFlagsLock.withLock { surveyAwaitingFeatureFlagsGeneration == nil }
         }
 
+        var canEvaluateSurveyFeatureFlags: Bool {
+            freshFeatureFlagsLock.withLock { !surveyFeatureFlagsUnavailable }
+        }
+
         func subscribeToRemoteConfigUpdates() {
             remoteConfigLoadedToken = postHog?.remoteConfig?.onRemoteConfigLoaded.subscribe { [weak self] remoteConfig in
                 guard let self, let remoteConfig else { return }
@@ -106,27 +110,14 @@
                     }
                 )
             }
-            featureFlagsLoadedToken = postHog?.remoteConfig?.onFeatureFlagsLoaded.subscribe { [weak self] flags in
-                guard let self, flags != nil else { return }
-                let shouldShow = self.freshFeatureFlagsLock.withLock {
-                    guard let failedGeneration = self.surveyFailedFeatureFlagsGeneration,
-                          failedGeneration == self.surveyAwaitingFeatureFlagsGeneration
-                    else { return false }
-                    self.surveyAwaitingFeatureFlagsGeneration = nil
-                    self.surveyFailedFeatureFlagsGeneration = nil
-                    return true
-                }
-                if shouldShow { self.showNextSurvey() }
-            }
         }
 
         func unsubscribeFromRemoteConfigUpdates() {
             remoteConfigLoadedToken = nil
-            featureFlagsLoadedToken = nil
             freshFeatureFlagsLock.withLock {
                 surveyRefreshGeneration += 1
                 surveyAwaitingFeatureFlagsGeneration = nil
-                surveyFailedFeatureFlagsGeneration = nil
+                surveyFeatureFlagsUnavailable = false
             }
         }
 
@@ -135,26 +126,18 @@
             let generation = freshFeatureFlagsLock.withLock {
                 surveyRefreshGeneration += 1
                 surveyAwaitingFeatureFlagsGeneration = needsFlags ? surveyRefreshGeneration : nil
-                surveyFailedFeatureFlagsGeneration = nil
+                if !needsFlags { surveyFeatureFlagsUnavailable = false }
                 return surveyAwaitingFeatureFlagsGeneration
             }
             guard let generation else { return }
 
-            postHog?.remoteConfig?.reloadFeatureFlags { [weak self] flags in
+            postHog?.remoteConfig?.reloadFeatureFlagsForSurvey { [weak self] flags in
                 guard let self else { return }
-                guard flags != nil else {
-                    self.freshFeatureFlagsLock.withLock {
-                        if self.surveyAwaitingFeatureFlagsGeneration == generation {
-                            self.surveyFailedFeatureFlagsGeneration = generation
-                        }
-                    }
-                    return
-                }
                 DispatchQueue.main.async {
                     let shouldShow = self.freshFeatureFlagsLock.withLock {
                         guard self.surveyAwaitingFeatureFlagsGeneration == generation else { return false }
                         self.surveyAwaitingFeatureFlagsGeneration = nil
-                        self.surveyFailedFeatureFlagsGeneration = nil
+                        self.surveyFeatureFlagsUnavailable = flags == nil
                         return true
                     }
                     if shouldShow { self.showNextSurvey() }

--- a/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
+++ b/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
@@ -46,39 +46,96 @@
     }
 
     extension PostHogSurveyIntegration {
+        func decodeAndSetSurveys(
+            remoteConfig: [String: Any]?,
+            beforeCacheUpdate: SurveyCallback? = nil,
+            callback: @escaping SurveyCallback
+        ) {
+            let loadedSurveys: [PostHogSurvey] = decodeSurveys(from: remoteConfig ?? [:])
+            beforeCacheUpdate?(loadedSurveys)
+
+            let eventMap = loadedSurveys.reduce(into: [String: [(surveyId: String, condition: PostHogEventCondition)]]()) { result, current in
+                if let surveyEvents = current.conditions?.events?.values {
+                    for eventCondition in surveyEvents {
+                        result[eventCondition.name, default: []].append(
+                            (surveyId: current.id, condition: eventCondition)
+                        )
+                    }
+                }
+            }
+
+            updateSurveyCache(loadedSurveys, events: eventMap)
+            callback(loadedSurveys)
+        }
+
+        func decodeSurveys(from remoteConfig: [String: Any]) -> [PostHogSurvey] {
+            guard let surveysJSON = remoteConfig["surveys"] as? [[String: Any]] else {
+                // surveys not json, disabled
+                return []
+            }
+
+            // Decode each survey individually so one malformed entry doesn't drop the entire list
+            return surveysJSON.compactMap { surveyJSON in
+                do {
+                    let jsonData = try JSONSerialization.data(withJSONObject: surveyJSON)
+                    return try PostHogApi.jsonDecoder.decode(PostHogSurvey.self, from: jsonData)
+                } catch {
+                    hedgeLog("Error decoding Survey: \(error)")
+                    return nil
+                }
+            }
+        }
+
         func canRenderSurvey(survey: PostHogSurvey) -> Bool {
+            // only render popover surveys for now
             survey.type == .popover
         }
 
         var canShowSurveyWithFreshFeatureFlags: Bool {
-            freshFeatureFlagsLock.withLock { !surveysAwaitingFreshFeatureFlags }
+            freshFeatureFlagsLock.withLock { surveyAwaitingFeatureFlagsGeneration == nil }
         }
 
         func subscribeToRemoteConfigUpdates() {
             remoteConfigLoadedToken = postHog?.remoteConfig?.onRemoteConfigLoaded.subscribe { [weak self] remoteConfig in
                 guard let self, let remoteConfig else { return }
-                self.decodeAndSetSurveys(remoteConfig: remoteConfig) { surveys in
-                    let reloadsFlags = self.postHog?.config.preloadFeatureFlags == true ||
-                        remoteConfig["hasFeatureFlags"] as? Bool == false
-                    let awaitingFlags = reloadsFlags && surveys.contains(where: \.requiresFeatureFlagEvaluation)
-                    self.freshFeatureFlagsLock.withLock { self.surveysAwaitingFreshFeatureFlags = awaitingFlags }
-                    if !awaitingFlags { self.showNextSurvey() }
-                }
-            }
-            featureFlagsLoadedToken = postHog?.remoteConfig?.onFeatureFlagsLoaded.subscribe { [weak self] flags in
-                guard let self, flags != nil else { return }
-                let shouldShow = self.freshFeatureFlagsLock.withLock {
-                    defer { self.surveysAwaitingFreshFeatureFlags = false }
-                    return self.surveysAwaitingFreshFeatureFlags
-                }
-                if shouldShow { self.showNextSurvey() }
+                self.decodeAndSetSurveys(
+                    remoteConfig: remoteConfig,
+                    beforeCacheUpdate: { surveys in self.refreshFeatureFlagsIfNeeded(for: surveys) },
+                    callback: { _ in
+                        if self.canShowSurveyWithFreshFeatureFlags { self.showNextSurvey() }
+                    }
+                )
             }
         }
 
         func unsubscribeFromRemoteConfigUpdates() {
             remoteConfigLoadedToken = nil
-            featureFlagsLoadedToken = nil
-            freshFeatureFlagsLock.withLock { surveysAwaitingFreshFeatureFlags = false }
+            freshFeatureFlagsLock.withLock {
+                surveyRefreshGeneration += 1
+                surveyAwaitingFeatureFlagsGeneration = nil
+            }
+        }
+
+        func refreshFeatureFlagsIfNeeded(for surveys: [PostHogSurvey]) {
+            let needsFlags = surveys.contains(where: \.requiresFeatureFlagEvaluation)
+            let generation = freshFeatureFlagsLock.withLock {
+                surveyRefreshGeneration += 1
+                surveyAwaitingFeatureFlagsGeneration = needsFlags ? surveyRefreshGeneration : nil
+                return surveyAwaitingFeatureFlagsGeneration
+            }
+            guard let generation else { return }
+
+            postHog?.remoteConfig?.reloadFeatureFlags { [weak self] flags in
+                guard let self, flags != nil else { return }
+                DispatchQueue.main.async {
+                    let shouldShow = self.freshFeatureFlagsLock.withLock {
+                        guard self.surveyAwaitingFeatureFlagsGeneration == generation else { return false }
+                        self.surveyAwaitingFeatureFlagsGeneration = nil
+                        return true
+                    }
+                    if shouldShow { self.showNextSurvey() }
+                }
+            }
         }
 
         func reconcileEventActivations(with surveys: [PostHogSurvey]) {

--- a/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
+++ b/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
@@ -114,8 +114,16 @@
                     }
                 )
             }
-            featureFlagsLoadedToken = postHog?.remoteConfig?.onFeatureFlagsLoaded.subscribe { [weak self] _ in
-                self?.showNextSurvey()
+            featureFlagsLoadedToken = postHog?.remoteConfig?.onFeatureFlagsLoaded.subscribe { [weak self] flags in
+                guard let self else { return }
+                if flags != nil {
+                    self.freshFeatureFlagsLock.withLock {
+                        if self.surveyAwaitingFeatureFlagsGeneration == nil {
+                            self.surveyFeatureFlagsUnavailable = false
+                        }
+                    }
+                }
+                self.showNextSurvey()
             }
         }
 

--- a/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
+++ b/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
@@ -106,13 +106,27 @@
                     }
                 )
             }
+            featureFlagsLoadedToken = postHog?.remoteConfig?.onFeatureFlagsLoaded.subscribe { [weak self] flags in
+                guard let self, flags != nil else { return }
+                let shouldShow = self.freshFeatureFlagsLock.withLock {
+                    guard let failedGeneration = self.surveyFailedFeatureFlagsGeneration,
+                          failedGeneration == self.surveyAwaitingFeatureFlagsGeneration
+                    else { return false }
+                    self.surveyAwaitingFeatureFlagsGeneration = nil
+                    self.surveyFailedFeatureFlagsGeneration = nil
+                    return true
+                }
+                if shouldShow { self.showNextSurvey() }
+            }
         }
 
         func unsubscribeFromRemoteConfigUpdates() {
             remoteConfigLoadedToken = nil
+            featureFlagsLoadedToken = nil
             freshFeatureFlagsLock.withLock {
                 surveyRefreshGeneration += 1
                 surveyAwaitingFeatureFlagsGeneration = nil
+                surveyFailedFeatureFlagsGeneration = nil
             }
         }
 
@@ -121,16 +135,26 @@
             let generation = freshFeatureFlagsLock.withLock {
                 surveyRefreshGeneration += 1
                 surveyAwaitingFeatureFlagsGeneration = needsFlags ? surveyRefreshGeneration : nil
+                surveyFailedFeatureFlagsGeneration = nil
                 return surveyAwaitingFeatureFlagsGeneration
             }
             guard let generation else { return }
 
             postHog?.remoteConfig?.reloadFeatureFlags { [weak self] flags in
-                guard let self, flags != nil else { return }
+                guard let self else { return }
+                guard flags != nil else {
+                    self.freshFeatureFlagsLock.withLock {
+                        if self.surveyAwaitingFeatureFlagsGeneration == generation {
+                            self.surveyFailedFeatureFlagsGeneration = generation
+                        }
+                    }
+                    return
+                }
                 DispatchQueue.main.async {
                     let shouldShow = self.freshFeatureFlagsLock.withLock {
                         guard self.surveyAwaitingFeatureFlagsGeneration == generation else { return false }
                         self.surveyAwaitingFeatureFlagsGeneration = nil
+                        self.surveyFailedFeatureFlagsGeneration = nil
                         return true
                     }
                     if shouldShow { self.showNextSurvey() }

--- a/PostHogTests/PostHogRemoteConfigTest.swift
+++ b/PostHogTests/PostHogRemoteConfigTest.swift
@@ -334,6 +334,24 @@ enum PostHogRemoteConfigTest {
             #expect(server.flagsRequests.count == 2)
         }
 
+        @Test("survey refresh coalesces with a matching in-flight request")
+        func surveyRefreshCoalescesWithMatchingRequest() async {
+            let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
+            config.preloadFeatureFlags = false
+            config.storageManager = PostHogStorageManager(config)
+            let sut = getSut(config: config)
+            sut.canReloadFlagsForTesting = true
+
+            server.flagsResponseDelay = 0.1
+            let bothDone = AsyncLatch(count: 2)
+
+            sut.reloadFeatureFlags { _ in bothDone.signal() }
+            sut.reloadFeatureFlagsForSurvey { _ in bothDone.signal() }
+            await bothDone.wait()
+
+            #expect(server.flagsRequests.count == 1)
+        }
+
         @Test("pending request uses correct identity after identify")
         func pendingRequestUsesCorrectIdentity() async {
             let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")

--- a/PostHogTests/PostHogSurveysTest.swift
+++ b/PostHogTests/PostHogSurveysTest.swift
@@ -1136,6 +1136,10 @@ enum PostHogSurveysTest {
             return sut
         }
 
+        private func parseSurveys(_ surveys: String) throws -> [[String: Any]] {
+            try #require(JSONSerialization.jsonObject(with: Data("[\(surveys)]".utf8)) as? [[String: Any]])
+        }
+
         @Test("returns surveys that are active")
         func returnsActiveSurveys() async {
             let surveys: [String] = [
@@ -1380,6 +1384,59 @@ enum PostHogSurveysTest {
                 _ = (sut, flagsToken)
             }
 
+            @Test("renders surveys without flag conditions while flags load")
+            func rendersSurveysWithoutFlagsWhileFlagsLoad() async throws {
+                let delegate = SpySurveysDelegate()
+                postHog.config._surveysConfig.surveysDelegate = delegate
+                let sut = getSut(surveys: [])
+                sut.hasActiveSurveyWindow = { true }
+
+                server.flagsResponseHandler = { _ in
+                    let response = HTTPStubsResponse(
+                        jsonObject: [
+                            "featureFlags": ["survey-flag": true],
+                            "featureFlagPayloads": [:],
+                            "flags": [:],
+                        ],
+                        statusCode: 200,
+                        headers: nil
+                    )
+                    response.responseTime = 0.2
+                    return response
+                }
+
+                let stateLock = NSLock()
+                var featureFlagsLoaded = false
+                var renderedBeforeFlagsLoaded = false
+                let flagsLoaded = AsyncLatch()
+                let flagsToken = try #require(postHog.remoteConfig?.onFeatureFlagsLoaded.subscribe { flags in
+                    guard flags != nil else { return }
+                    stateLock.withLock { featureFlagsLoaded = true }
+                    flagsLoaded.signal()
+                })
+                let rendered = AsyncLatch()
+                delegate.onRender = {
+                    stateLock.withLock { renderedBeforeFlagsLoaded = !featureFlagsLoaded }
+                    rendered.signal()
+                }
+
+                let flaggedSurvey = activeSurvey
+                    .replacingOccurrences(of: "active_id", with: "flagged_survey")
+                    .replacingOccurrences(
+                        of: "\"start_date\"",
+                        with: "\"linked_flag_key\": \"survey-flag\", \"start_date\""
+                    )
+                postHog.remoteConfig?.onRemoteConfigLoaded.invoke([
+                    "surveys": try parseSurveys("\(flaggedSurvey),\(activeSurvey)"),
+                ])
+                await rendered.wait()
+
+                #expect(delegate.renderedSurveyIds == ["active_id"])
+                #expect(stateLock.withLock { renderedBeforeFlagsLoaded })
+                await flagsLoaded.wait()
+                _ = (sut, flagsToken)
+            }
+
             @Test("recovers survey rendering after a feature flag refresh failure")
             func recoversSurveyRenderingAfterFeatureFlagRefreshFailure() async throws {
                 let delegate = SpySurveysDelegate()
@@ -1514,6 +1571,15 @@ enum PostHogSurveysTest {
             }
 
             #expect(matchedSurveys.isEmpty)
+        }
+
+        @Test("does not require flag evaluation for surveys with missing keys or values")
+        func doesNotRequireFlagsForMissingKeysOrValues() throws {
+            let surveys = PostHogSurveyIntegration().decodeSurveys(from: [
+                "surveys": try parseSurveys(surveysWithMissingKeysAndValues),
+            ])
+
+            #expect(surveys.allSatisfy { !$0.requiresFeatureFlagEvaluation })
         }
 
         @Test("skips checking flags for surveys with missing keys or values ")

--- a/PostHogTests/PostHogSurveysTest.swift
+++ b/PostHogTests/PostHogSurveysTest.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+import OHHTTPStubs
+import OHHTTPStubsSwift
 @testable import PostHog
 import Testing
 
@@ -1311,6 +1313,52 @@ enum PostHogSurveysTest {
                 await featureFlagsLoaded.wait()
                 #expect(delegate.renderedSurveyIds.isEmpty)
                 _ = (sut, remoteToken, flagsToken)
+            }
+
+            @Test("recovers survey rendering after a feature flag refresh failure")
+            func recoversSurveyRenderingAfterFeatureFlagRefreshFailure() async throws {
+                let delegate = SpySurveysDelegate()
+                postHog.config._surveysConfig.surveysDelegate = delegate
+                postHog.config.preloadFeatureFlags = false
+                let sut = getSut(surveys: [])
+                sut.hasActiveSurveyWindow = { true }
+                server.remoteConfigSurveys =
+                    """
+                    [{
+                        "id": "flagged_survey",
+                        "name": "Flagged Survey",
+                        "type": "popover",
+                        "questions": [{
+                            "id": "1",
+                            "type": "open",
+                            "question": "What do you think?",
+                            "originalQuestionIndex": 0
+                        }],
+                        "linked_flag_key": "survey-flag",
+                        "start_date": "2024-07-23T09:18:18.376000Z"
+                    }]
+                    """
+                server.flagsResponseHandler = { _ in
+                    HTTPStubsResponse(jsonObject: [:], statusCode: 200, headers: nil)
+                }
+
+                let failed = AsyncLatch()
+                let flagsToken = try #require(postHog.remoteConfig?.onFeatureFlagsLoaded.subscribe { flags in
+                    if flags == nil { failed.signal() }
+                })
+                postHog.remoteConfig?.reloadRemoteConfig()
+                await failed.wait()
+                #expect(delegate.renderedSurveyIds.isEmpty)
+
+                server.flagsResponseHandler = nil
+                server.featureFlags = ["survey-flag": true]
+                let rendered = AsyncLatch()
+                delegate.onRender = { rendered.signal() }
+                postHog.remoteConfig?.reloadFeatureFlags()
+                await rendered.wait()
+
+                #expect(delegate.renderedSurveyIds == ["flagged_survey"])
+                _ = (sut, flagsToken)
             }
         #endif
 

--- a/PostHogTests/PostHogSurveysTest.swift
+++ b/PostHogTests/PostHogSurveysTest.swift
@@ -773,9 +773,30 @@ enum PostHogSurveysTest {
         let server: MockPostHogServer
         let postHog: PostHogSDK
 
+        #if os(iOS)
+            final class SpySurveysDelegate: NSObject, PostHogSurveysDelegate {
+                var renderedSurveyIds: [String] = []
+
+                func renderSurvey(
+                    _ survey: PostHogDisplaySurvey,
+                    onSurveyShown _: @escaping OnPostHogSurveyShown,
+                    onSurveyResponse _: @escaping OnPostHogSurveyResponse,
+                    onSurveyClosed _: @escaping OnPostHogSurveyClosed
+                ) {
+                    renderedSurveyIds.append(survey.id)
+                }
+
+                func cleanupSurveys() {}
+            }
+        #endif
+
         init() {
-            let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost:9090")
+            let config = PostHogConfig(projectToken: "test_get_active_surveys", host: "http://localhost:9090")
             config._surveys = true
+            #if os(iOS)
+                config._surveysConfig.surveysDelegate = SpySurveysDelegate()
+            #endif
+            config.enableSwizzling = false
             config.disableFlushOnBackgroundForTesting = true
             config.disableRemoteConfigForTesting = true
             postHog = PostHogSDK.with(config)
@@ -1135,7 +1156,7 @@ enum PostHogSurveysTest {
             let refreshedSurvey =
                 """
                 {
-                    "id": "refreshed_id",
+                    "id": "active_id",
                     "name": "Refreshed Survey",
                     "type": "popover",
                     "questions": [
@@ -1156,14 +1177,32 @@ enum PostHogSurveysTest {
                     "start_date": "2024-07-23T09:18:18.376000Z"
                 }
                 """
+            let initialSurvey = refreshedSurvey
+                .replacingOccurrences(of: "Refreshed Survey", with: "Initial Survey")
+                .replacingOccurrences(of: "new-trigger", with: "old-trigger")
 
-            let sut = getSut(surveys: [activeSurvey])
+            let sut = getSut(surveys: [initialSurvey])
             let initialSurveys: [PostHogSurvey] = await withCheckedContinuation { continuation in
                 sut.getActiveMatchingSurveys(forceReload: true) {
                     continuation.resume(returning: $0)
                 }
             }
-            #expect(initialSurveys.map(\.id) == ["active_id"])
+            #expect(initialSurveys.isEmpty)
+
+            // Keep the test from presenting survey UI after activating an event.
+            sut.setShownSurvey(.testInstance(name: "Placeholder"))
+            sut.testOnEvent(event: PostHogEvent(
+                event: "old-trigger",
+                distinctId: "test",
+                properties: [:],
+                timestamp: Date()
+            ))
+            let activatedInitialSurveys: [PostHogSurvey] = await withCheckedContinuation { continuation in
+                sut.getActiveMatchingSurveys {
+                    continuation.resume(returning: $0)
+                }
+            }
+            #expect(activatedInitialSurveys.map(\.name) == ["Initial Survey"])
 
             server.remoteConfigSurveys = "[\(refreshedSurvey)]"
             let remoteConfigLoaded = AsyncLatch()
@@ -1175,22 +1214,75 @@ enum PostHogSurveysTest {
             postHog.remoteConfig?.reloadRemoteConfig()
             await remoteConfigLoaded.wait()
 
+            let surveysBeforeNewTrigger: [PostHogSurvey] = await withCheckedContinuation { continuation in
+                sut.getActiveMatchingSurveys {
+                    continuation.resume(returning: $0)
+                }
+            }
+            #expect(surveysBeforeNewTrigger.isEmpty)
+
             sut.testOnEvent(event: PostHogEvent(
                 event: "new-trigger",
                 distinctId: "test",
                 properties: [:],
                 timestamp: Date()
             ))
-            #expect(sut.testIsEventActivated(surveyId: "refreshed_id") == true)
-
             let refreshedSurveys: [PostHogSurvey] = await withCheckedContinuation { continuation in
                 sut.getActiveMatchingSurveys {
                     continuation.resume(returning: $0)
                 }
             }
-            #expect(refreshedSurveys.map(\.id) == ["refreshed_id"])
+            #expect(refreshedSurveys.map(\.name) == ["Refreshed Survey"])
             _ = token
         }
+
+        #if os(iOS)
+            @Test("waits for fresh feature flags before showing refreshed surveys")
+            func waitsForFreshFeatureFlagsBeforeShowingRefreshedSurveys() async throws {
+                server.featureFlags = ["survey-flag": true]
+                await withCheckedContinuation { continuation in
+                    postHog.remoteConfig?.reloadFeatureFlags { _ in continuation.resume() }
+                }
+
+                let delegate = SpySurveysDelegate()
+                postHog.config._surveysConfig.surveysDelegate = delegate
+                let sut = getSut(surveys: [])
+                server.remoteConfigSurveys =
+                    """
+                    [{
+                        "id": "flagged_survey",
+                        "name": "Flagged Survey",
+                        "type": "popover",
+                        "questions": [{
+                            "id": "1",
+                            "type": "open",
+                            "question": "What do you think?",
+                            "originalQuestionIndex": 0
+                        }],
+                        "linked_flag_key": "survey-flag",
+                        "start_date": "2024-07-23T09:18:18.376000Z"
+                    }]
+                    """
+
+                let remoteConfigLoaded = AsyncLatch()
+                let remoteToken = try #require(postHog.remoteConfig?.onRemoteConfigLoaded.subscribe { _ in
+                    DispatchQueue.main.async { DispatchQueue.main.async { remoteConfigLoaded.signal() } }
+                })
+                postHog.remoteConfig?.reloadRemoteConfig()
+                await remoteConfigLoaded.wait()
+                #expect(delegate.renderedSurveyIds.isEmpty)
+
+                server.featureFlags = ["survey-flag": false]
+                let featureFlagsLoaded = AsyncLatch()
+                let flagsToken = try #require(postHog.remoteConfig?.onFeatureFlagsLoaded.subscribe { _ in
+                    DispatchQueue.main.async { DispatchQueue.main.async { featureFlagsLoaded.signal() } }
+                })
+                postHog.remoteConfig?.reloadFeatureFlags()
+                await featureFlagsLoaded.wait()
+                #expect(delegate.renderedSurveyIds.isEmpty)
+                _ = (sut, remoteToken, flagsToken)
+            }
+        #endif
 
         @Test("returns surveys that match device type")
         func returnsSurveysThatMatchDeviceType() async {
@@ -1316,8 +1408,12 @@ enum PostHogSurveysTest {
         let storage: PostHogStorage
 
         init() {
-            let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost:9090")
+            let config = PostHogConfig(projectToken: "test_survey_wait_period", host: "http://localhost:9090")
             config._surveys = true
+            #if os(iOS)
+                config._surveysConfig.surveysDelegate = TestGetActiveSurveys.SpySurveysDelegate()
+            #endif
+            config.enableSwizzling = false
             config.disableFlushOnBackgroundForTesting = true
             postHog = PostHogSDK.with(config)
             storage = PostHogStorage(config)

--- a/PostHogTests/PostHogSurveysTest.swift
+++ b/PostHogTests/PostHogSurveysTest.swift
@@ -1276,6 +1276,7 @@ enum PostHogSurveysTest {
 
                 let delegate = SpySurveysDelegate()
                 postHog.config._surveysConfig.surveysDelegate = delegate
+                postHog.config.preloadFeatureFlags = false
                 let sut = getSut(surveys: [])
                 server.remoteConfigSurveys =
                     """
@@ -1294,6 +1295,11 @@ enum PostHogSurveysTest {
                     }]
                     """
 
+                server.featureFlags = ["survey-flag": false]
+                let featureFlagsLoaded = AsyncLatch()
+                let flagsToken = try #require(postHog.remoteConfig?.onFeatureFlagsLoaded.subscribe { _ in
+                    featureFlagsLoaded.signal()
+                })
                 let remoteConfigLoaded = AsyncLatch()
                 let remoteToken = try #require(postHog.remoteConfig?.onRemoteConfigLoaded.subscribe { _ in
                     DispatchQueue.main.async { DispatchQueue.main.async { remoteConfigLoaded.signal() } }
@@ -1302,12 +1308,6 @@ enum PostHogSurveysTest {
                 await remoteConfigLoaded.wait()
                 #expect(delegate.renderedSurveyIds.isEmpty)
 
-                server.featureFlags = ["survey-flag": false]
-                let featureFlagsLoaded = AsyncLatch()
-                let flagsToken = try #require(postHog.remoteConfig?.onFeatureFlagsLoaded.subscribe { _ in
-                    DispatchQueue.main.async { DispatchQueue.main.async { featureFlagsLoaded.signal() } }
-                })
-                postHog.remoteConfig?.reloadFeatureFlags()
                 await featureFlagsLoaded.wait()
                 #expect(delegate.renderedSurveyIds.isEmpty)
                 _ = (sut, remoteToken, flagsToken)

--- a/PostHogTests/PostHogSurveysTest.swift
+++ b/PostHogTests/PostHogSurveysTest.swift
@@ -776,6 +776,7 @@ enum PostHogSurveysTest {
         #if os(iOS)
             final class SpySurveysDelegate: NSObject, PostHogSurveysDelegate {
                 var renderedSurveyIds: [String] = []
+                var onRender: (() -> Void)?
 
                 func renderSurvey(
                     _ survey: PostHogDisplaySurvey,
@@ -784,6 +785,7 @@ enum PostHogSurveysTest {
                     onSurveyClosed _: @escaping OnPostHogSurveyClosed
                 ) {
                     renderedSurveyIds.append(survey.id)
+                    onRender?()
                 }
 
                 func cleanupSurveys() {}
@@ -1237,6 +1239,34 @@ enum PostHogSurveysTest {
         }
 
         #if os(iOS)
+            @Test("defers showing surveys until a foreground window exists")
+            func defersShowingSurveysUntilForegroundWindowExists() async {
+                let delegate = SpySurveysDelegate()
+                postHog.config._surveysConfig.surveysDelegate = delegate
+                let sut = getSut(surveys: [activeSurvey])
+                sut.hasActiveSurveyWindow = { false }
+
+                let matchingSurveys: [PostHogSurvey] = await withCheckedContinuation { continuation in
+                    sut.getActiveMatchingSurveys(forceReload: true) {
+                        continuation.resume(returning: $0)
+                    }
+                }
+                await withCheckedContinuation { continuation in
+                    DispatchQueue.main.async { DispatchQueue.main.async { continuation.resume() } }
+                }
+
+                #expect(matchingSurveys.map(\.id) == ["active_id"])
+                #expect(delegate.renderedSurveyIds.isEmpty)
+
+                let rendered = AsyncLatch()
+                delegate.onRender = { rendered.signal() }
+                sut.hasActiveSurveyWindow = { true }
+                DI.main.appLifecyclePublisher.onDidBecomeActive.invoke(())
+                await rendered.wait()
+
+                #expect(delegate.renderedSurveyIds == ["active_id"])
+            }
+
             @Test("waits for fresh feature flags before showing refreshed surveys")
             func waitsForFreshFeatureFlagsBeforeShowingRefreshedSurveys() async throws {
                 server.featureFlags = ["survey-flag": true]

--- a/PostHogTests/PostHogSurveysTest.swift
+++ b/PostHogTests/PostHogSurveysTest.swift
@@ -777,6 +777,7 @@ enum PostHogSurveysTest {
             let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost:9090")
             config._surveys = true
             config.disableFlushOnBackgroundForTesting = true
+            config.disableRemoteConfigForTesting = true
             postHog = PostHogSDK.with(config)
             let storage = PostHogStorage(config)
             storage.reset()
@@ -1127,6 +1128,68 @@ enum PostHogSurveysTest {
             }
 
             #expect(matchedSurveys.map(\.id) == ["active_id"])
+        }
+
+        @Test("refreshes cached surveys when remote config loads")
+        func refreshesCachedSurveysWhenRemoteConfigLoads() async throws {
+            let refreshedSurvey =
+                """
+                {
+                    "id": "refreshed_id",
+                    "name": "Refreshed Survey",
+                    "type": "popover",
+                    "questions": [
+                        {
+                            "id": "1",
+                            "type": "open",
+                            "question": "What do you think?",
+                            "originalQuestionIndex": 0
+                        }
+                    ],
+                    "conditions": {
+                        "events": {
+                            "values": [
+                                { "name": "new-trigger" }
+                            ]
+                        }
+                    },
+                    "start_date": "2024-07-23T09:18:18.376000Z"
+                }
+                """
+
+            let sut = getSut(surveys: [activeSurvey])
+            let initialSurveys: [PostHogSurvey] = await withCheckedContinuation { continuation in
+                sut.getActiveMatchingSurveys(forceReload: true) {
+                    continuation.resume(returning: $0)
+                }
+            }
+            #expect(initialSurveys.map(\.id) == ["active_id"])
+
+            server.remoteConfigSurveys = "[\(refreshedSurvey)]"
+            let remoteConfigLoaded = AsyncLatch()
+            let token = try #require(postHog.remoteConfig?.onRemoteConfigLoaded.subscribe { _ in
+                DispatchQueue.main.async {
+                    remoteConfigLoaded.signal()
+                }
+            })
+            postHog.remoteConfig?.reloadRemoteConfig()
+            await remoteConfigLoaded.wait()
+
+            sut.testOnEvent(event: PostHogEvent(
+                event: "new-trigger",
+                distinctId: "test",
+                properties: [:],
+                timestamp: Date()
+            ))
+            #expect(sut.testIsEventActivated(surveyId: "refreshed_id") == true)
+
+            let refreshedSurveys: [PostHogSurvey] = await withCheckedContinuation { continuation in
+                sut.getActiveMatchingSurveys {
+                    continuation.resume(returning: $0)
+                }
+            }
+            #expect(refreshedSurveys.map(\.id) == ["refreshed_id"])
+            _ = token
         }
 
         @Test("returns surveys that match device type")

--- a/PostHogTests/PostHogSurveysTest.swift
+++ b/PostHogTests/PostHogSurveysTest.swift
@@ -1315,6 +1315,70 @@ enum PostHogSurveysTest {
                 _ = (sut, remoteToken, flagsToken)
             }
 
+            @Test("does not use an older flag refresh for newer surveys")
+            func doesNotUseOlderFlagRefreshForNewerSurveys() async throws {
+                let delegate = SpySurveysDelegate()
+                postHog.config._surveysConfig.surveysDelegate = delegate
+                let sut = getSut(surveys: [])
+                sut.hasActiveSurveyWindow = { true }
+
+                let survey: [String: Any] = [
+                    "id": "flagged_survey",
+                    "name": "Flagged Survey",
+                    "type": "popover",
+                    "questions": [[
+                        "id": "1",
+                        "type": "open",
+                        "question": "What do you think?",
+                        "originalQuestionIndex": 0,
+                    ]],
+                    "linked_flag_key": "survey-flag",
+                    "start_date": "2024-07-23T09:18:18.376000Z",
+                ]
+                let requestLock = NSLock()
+                var requestCount = 0
+                server.flagsResponseHandler = { _ in
+                    let index = requestLock.withLock {
+                        requestCount += 1
+                        return requestCount
+                    }
+                    let response = HTTPStubsResponse(
+                        jsonObject: [
+                            "featureFlags": ["survey-flag": index == 1],
+                            "featureFlagPayloads": [:],
+                            "flags": [:],
+                        ],
+                        statusCode: 200,
+                        headers: nil
+                    )
+                    if index == 1 { response.responseTime = 0.1 }
+                    return response
+                }
+
+                let flagsLoaded = AsyncLatch()
+                let loadedLock = NSLock()
+                var loadedCount = 0
+                let flagsToken = try #require(postHog.remoteConfig?.onFeatureFlagsLoaded.subscribe { flags in
+                    guard flags != nil else { return }
+                    let isSecondLoad = loadedLock.withLock {
+                        loadedCount += 1
+                        return loadedCount == 2
+                    }
+                    if isSecondLoad { flagsLoaded.signal() }
+                })
+
+                postHog.remoteConfig?.onRemoteConfigLoaded.invoke(["surveys": [survey]])
+                postHog.remoteConfig?.onRemoteConfigLoaded.invoke(["surveys": [survey]])
+                await flagsLoaded.wait()
+                await withCheckedContinuation { continuation in
+                    DispatchQueue.main.async { DispatchQueue.main.async { continuation.resume() } }
+                }
+
+                #expect(requestLock.withLock { requestCount } == 2)
+                #expect(delegate.renderedSurveyIds.isEmpty)
+                _ = (sut, flagsToken)
+            }
+
             @Test("recovers survey rendering after a feature flag refresh failure")
             func recoversSurveyRenderingAfterFeatureFlagRefreshFailure() async throws {
                 let delegate = SpySurveysDelegate()
@@ -1354,7 +1418,7 @@ enum PostHogSurveysTest {
                 server.featureFlags = ["survey-flag": true]
                 let rendered = AsyncLatch()
                 delegate.onRender = { rendered.signal() }
-                postHog.remoteConfig?.reloadFeatureFlags()
+                postHog.remoteConfig?.reloadRemoteConfig()
                 await rendered.wait()
 
                 #expect(delegate.renderedSurveyIds == ["flagged_survey"])

--- a/PostHogTests/PostHogSurveysTest.swift
+++ b/PostHogTests/PostHogSurveysTest.swift
@@ -1369,6 +1369,7 @@ enum PostHogSurveysTest {
 
                 postHog.remoteConfig?.onRemoteConfigLoaded.invoke(["surveys": [survey]])
                 postHog.remoteConfig?.onRemoteConfigLoaded.invoke(["surveys": [survey]])
+                postHog.remoteConfig?.reloadFeatureFlags()
                 await flagsLoaded.wait()
                 await withCheckedContinuation { continuation in
                     DispatchQueue.main.async { DispatchQueue.main.async { continuation.resume() } }

--- a/PostHogTests/PostHogSurveysTest.swift
+++ b/PostHogTests/PostHogSurveysTest.swift
@@ -1419,7 +1419,7 @@ enum PostHogSurveysTest {
                 server.featureFlags = ["survey-flag": true]
                 let rendered = AsyncLatch()
                 delegate.onRender = { rendered.signal() }
-                postHog.remoteConfig?.reloadRemoteConfig()
+                postHog.remoteConfig?.reloadFeatureFlags()
                 await rendered.wait()
 
                 #expect(delegate.renderedSurveyIds == ["flagged_survey"])


### PR DESCRIPTION
## :bulb: Motivation and Context

The iOS SDK loads survey definitions from its disk cache before the first live remote config request finishes. The survey integration kept those definitions for the rest of the process, so dashboard changes appeared one cold start late and new event-triggered surveys remained unavailable.

This change refreshes survey definitions whenever fresh remote config arrives. It also:

- reconciles event activation against the refreshed event conditions,
- waits for the feature-flag response associated with the latest survey refresh,
- safely handles overlapping feature-flag and identity reloads,
- defers rendering until a foreground window is available, and
- recovers after transient feature-flag failures without evaluating targeted surveys against stale flags.

Closes #761.

## :green_heart: How did you test it?

- Added regression coverage for refreshed definitions and changed event triggers.
- Added iOS coverage for stale feature flags, overlapping flag refreshes, transient flag failures, and foreground-window availability.
- `make test` — 750 tests passed.
- `make testOniOSSimulator` — 188 tests passed.
- `make lint` — passed with existing warnings.
- `make buildSdk` — passed for iOS, macOS, Mac Catalyst, tvOS, watchOS, and visionOS.
- Autoreview — clean.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent. The survey refresh path now keeps definitions, event activation, feature-flag targeting, lifecycle readiness, and overlapping refreshes consistent.

