### PR TITLE
feat: skip push registration when the project has no integration for the app_id

### DIFF
--- a/.changeset/push-app-ids-gate.md
+++ b/.changeset/push-app-ids-gate.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Skip push token registration when the project has no push integration for the app_id, using the `push.appIds` list published in remote config. A device whose project configures push later re-registers on the next config load rather than staying unreachable.

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -29,6 +29,13 @@ class PostHogRemoteConfig {
     private var recordingMinimumDuration: TimeInterval?
 
     private let errorTrackingLock = NSLock()
+    private let pushLock = NSLock()
+    /// The app_ids this project accepts push registrations for, or nil when no server has told us.
+    /// Nil is not the empty list: it means attempt the registration, because a server older than
+    /// the key cannot be told apart from a project with push disabled.
+    private var pushAppIds: [String]?
+    /// app_ids that became registerable on the most recent /config read, drained by the handler.
+    private var newlyRegisterablePushAppIds: Set<String> = []
     private var autoCaptureExceptions = false
 
     private var flags: [String: Any]?
@@ -139,6 +146,7 @@ class PostHogRemoteConfig {
 
         preloadSessionReplay()
         preloadErrorTrackingConfig()
+        preloadPushConfig()
 
         // Remote config is always loaded (config.remoteConfig is now a no-op)
         preloadRemoteConfig()
@@ -236,6 +244,11 @@ class PostHogRemoteConfig {
 
                 // process error tracking config
                 self.processErrorTrackingConfig(config)
+
+                // process push config. Unlike the others this is not re-armed from cache on the
+                // /flags paths below: the in-memory list already holds the cached value, and a
+                // re-arm would compare the list against itself and find no transition.
+                self.processPushConfig(config)
 
                 // notify
                 DispatchQueue.main.async {
@@ -649,6 +662,53 @@ class PostHogRemoteConfig {
             errorTrackingLock.withLock {
                 autoCaptureExceptions = enabled
             }
+        }
+    }
+
+    /// Parses the `push` slice and records the app_ids that became registerable since the last read,
+    /// so the push handler can re-register a device that was stuck.
+    ///
+    /// A missing key clears the list rather than keeping it: a server that stops sending the key is
+    /// treated as one that never sent it, which means attempt the registration and never silently
+    /// withholds a device from a project that has push.
+    private func processPushConfig(_ data: [String: Any]?) {
+        let appIds = (data?["push"] as? [String: Any])?["appIds"] as? [String]
+
+        pushLock.withLock {
+            // Absent for the comparison means the empty set, not unknown. The first launch that ever
+            // sees the key therefore treats every configured app_id as new, which re-registers a
+            // device that recorded a success while its project had no integration. That costs one
+            // request per device, once, and it is the only way to reach a device whose project was
+            // configured before it updated to a version that reads this key.
+            let previous = Set(pushAppIds ?? [])
+            pushAppIds = appIds
+            newlyRegisterablePushAppIds = Set(appIds ?? []).subtracting(previous)
+        }
+    }
+
+    private func preloadPushConfig() {
+        let push = remoteConfigLock.withLock {
+            getCachedRemoteConfig()?["push"] as? [String: Any]
+        }
+        if let appIds = push?["appIds"] as? [String] {
+            pushLock.withLock {
+                pushAppIds = appIds
+            }
+        }
+    }
+
+    /// The app_ids this project accepts push registrations for, or nil when no server has told us.
+    func getPushAppIds() -> [String]? {
+        pushLock.withLock { pushAppIds }
+    }
+
+    /// app_ids that became registerable on the most recent /config read, cleared by reading them.
+    /// Draining rather than peeking keeps a device from re-registering on every subsequent load.
+    func consumeNewlyRegisterablePushAppIds() -> Set<String> {
+        pushLock.withLock { () -> Set<String> in
+            let newlyRegisterable = newlyRegisterablePushAppIds
+            newlyRegisterablePushAppIds = []
+            return newlyRegisterable
         }
     }
 

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -683,8 +683,26 @@ class PostHogRemoteConfig {
             // configured before it updated to a version that reads this key.
             let previous = Set(pushAppIds ?? [])
             pushAppIds = appIds
-            newlyRegisterablePushAppIds = Set(appIds ?? []).subtracting(previous)
+            let live = Set(appIds ?? [])
+            var newly = live.subtracting(previous)
+            // Upgrade recovery: an older SDK cached the whole remote-config blob including push.appIds,
+            // so preloadPushConfig seeds pushAppIds and the live response shows no transition. A device
+            // stranded by that older SDK would keep its delivered marker forever. The first load after
+            // this gate ships treats every currently-registerable app_id as newly registerable so the
+            // recovery runs once. The migrated flag is persisted only after the marker clear is durable
+            // (see markPushAppIdsMigrated), so a crash in that window re-runs recovery rather than
+            // stranding the device.
+            if storage.getBool(forKey: .pushAppIdsMigrated) != true {
+                newly.formUnion(live)
+            }
+            newlyRegisterablePushAppIds = newly
         }
+    }
+
+    /// Records that the one-time upgrade recovery has run. Called by the push handler once it has
+    /// durably cleared any delivered marker, so the flag never advances ahead of the recovery.
+    func markPushAppIdsMigrated() {
+        storage.setBool(forKey: .pushAppIdsMigrated, contents: true)
     }
 
     private func preloadPushConfig() {

--- a/PostHog/PostHogRemoteConfig.swift
+++ b/PostHog/PostHogRemoteConfig.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 //
 //  PostHogRemoteConfig.swift
 //  PostHog

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -84,6 +84,7 @@ let maxRetryDelay = 30.0
     let onEventContextChanged = PostHogMulticastCallback<[String: Any]>()
     private var sessionIdChangedToken: RegistrationToken?
     private var didEnterBackgroundToken: RegistrationToken?
+    private var pushRemoteConfigToken: RegistrationToken?
 
     /// Logger facade exposing `trace/debug/info/warn/error/fatal(_:attributes:)`.
     /// `nil` before `setup(_:)` is called.
@@ -191,8 +192,20 @@ let maxRetryDelay = 30.0
                     self.map { $0.isEnabled() && !$0.isOptOutState() } ?? false
                 },
                 isEnabledProvider: { [weak self] in self?.isEnabled() ?? false },
+                pushAppIdsProvider: { [weak self] in self?.remoteConfig?.getPushAppIds() },
                 onEventContextChanged: onEventContextChanged
             )
+
+            // A device whose project had no push integration was answered 200 and stopped asking.
+            // Draining the transition here is the only signal that reaches it.
+            pushRemoteConfigToken = remoteConfig?.onRemoteConfigLoaded.subscribe { [weak self] _ in
+                guard let self, let newlyRegisterable = self.remoteConfig?.consumeNewlyRegisterablePushAppIds(),
+                      !newlyRegisterable.isEmpty
+                else {
+                    return
+                }
+                self.pushSubscriptionHandler?.onPushAppIdsChanged(newlyRegisterable)
+            }
 
             optOutLock.withLock {
                 let optOut = theStorage.getBool(forKey: .optOut)

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -204,7 +204,11 @@ let maxRetryDelay = 30.0
                 else {
                     return
                 }
-                self.pushSubscriptionHandler?.onPushAppIdsChanged(newlyRegisterable)
+                // Mark the one-time upgrade recovery done only after the handler has durably cleared
+                // any delivered marker, so a crash in between re-runs recovery instead of stranding.
+                self.pushSubscriptionHandler?.onPushAppIdsChanged(newlyRegisterable) { [weak self] in
+                    self?.remoteConfig?.markPushAppIdsMigrated()
+                }
             }
 
             optOutLock.withLock {

--- a/PostHog/PostHogStorage.swift
+++ b/PostHog/PostHogStorage.swift
@@ -256,6 +256,7 @@ class PostHogStorage {
         case deviceId = "posthog.deviceId"
         case pushSubscription = "posthog.pushSubscription"
         case pushPendingUnregister = "posthog.pushPendingUnregister"
+        case pushAppIdsMigrated = "posthog.pushAppIdsMigrated"
     }
 
     // The location for storing data that we always want to keep

--- a/PostHog/PushNotifications/PostHogPushSubscriptionHandler.swift
+++ b/PostHog/PushNotifications/PostHogPushSubscriptionHandler.swift
@@ -63,6 +63,7 @@ final class PostHogPushSubscriptionHandler {
     /// `isAllowedProvider` this ignores opt-out, because a DELETE removes data rather than collecting
     /// it, so opt-out must not strand it (posthog-ios#746).
     private let isEnabledProvider: () -> Bool
+    private let pushAppIdsProvider: () -> [String]?
 
     /// Guards `retryCount`, `pausedUntil`, `isSending`, `pendingResend`, `halted`,
     /// `cachedIdentityToken`, and `didAuthRetry`.
@@ -121,6 +122,9 @@ final class PostHogPushSubscriptionHandler {
         isConnectedProvider: @escaping () -> Bool,
         isAllowedProvider: @escaping () -> Bool,
         isEnabledProvider: @escaping () -> Bool,
+        // The app_ids the project accepts registrations for, or nil when no server has said.
+        // Nil means attempt: a server older than the key must not stop a device registering.
+        pushAppIdsProvider: @escaping () -> [String]? = { nil },
         onEventContextChanged: PostHogMulticastCallback<[String: Any]>
     ) {
         self.api = api
@@ -130,6 +134,7 @@ final class PostHogPushSubscriptionHandler {
         self.isConnectedProvider = isConnectedProvider
         self.isAllowedProvider = isAllowedProvider
         self.isEnabledProvider = isEnabledProvider
+        self.pushAppIdsProvider = pushAppIdsProvider
 
         contextChangedToken = onEventContextChanged.subscribe { [weak self] context in
             guard let self, let distinctId = context["distinct_id"] as? String, !distinctId.isEmpty else { return }
@@ -388,6 +393,36 @@ final class PostHogPushSubscriptionHandler {
         attemptIfAllowed(deviceToken: record.deviceToken, appId: record.appId)
     }
 
+    /// Called when remote config resolves. `newlyRegisterable` are the app_ids that were not
+    /// registerable the last time we looked and are now.
+    ///
+    /// A device that registered while its project had no push integration was answered 200 and had its
+    /// token discarded, but still recorded the send as delivered and stopped asking. Clearing that
+    /// marker for an app_id that just became registerable is the only thing that reaches it.
+    func onPushAppIdsChanged(_ newlyRegisterable: Set<String>) {
+        workQueue.async { [weak self] in
+            guard let self else { return }
+
+            let record = recordLock.withLock { loadRecordLocked() }
+            guard let record, newlyRegisterable.contains(record.appId) else {
+                // Either nothing changed for this device, or the app_id was already registerable and
+                // the existing delivered marker is honest. Re-sending here would put the request back
+                // on every launch, which is what the marker exists to prevent.
+                return
+            }
+
+            if record.deliveredForDistinctId != nil {
+                recordLock.withLock {
+                    writeRecord(deviceToken: record.deviceToken, appId: record.appId)
+                }
+            }
+
+            resetRetryState()
+            hedgeLog("Push app_id \(record.appId) became registerable; re-registering.")
+            attemptIfAllowed(deviceToken: record.deviceToken, appId: record.appId)
+        }
+    }
+
     private func resetRetryState() {
         stateLock.withLock {
             retryCount = 0
@@ -397,9 +432,23 @@ final class PostHogPushSubscriptionHandler {
         }
     }
 
+    /// Nil means no server has published the list, so we cannot rule the app_id out and must try.
+    private func isRegisterable(_ appId: String) -> Bool {
+        guard let appIds = pushAppIdsProvider() else { return true }
+        return appIds.contains(appId)
+    }
+
     private func attemptIfAllowed(deviceToken: String, appId: String) {
         if !isAllowedProvider() {
             hedgeLog("Push subscription not sent: SDK is disabled or opted out.")
+            return
+        }
+
+        if !isRegisterable(appId) {
+            // The project publishes no push integration for this app_id, so the server would accept
+            // the request and throw the token away. The record stays on disk, so onPushAppIdsChanged
+            // has a token to register once the project does configure push.
+            hedgeLog("Push subscription skipped: app_id \(appId) is not configured for this project.")
             return
         }
 

--- a/PostHog/PushNotifications/PostHogPushSubscriptionHandler.swift
+++ b/PostHog/PushNotifications/PostHogPushSubscriptionHandler.swift
@@ -401,7 +401,10 @@ final class PostHogPushSubscriptionHandler {
     /// marker for an app_id that just became registerable is the only thing that reaches it.
     func onPushAppIdsChanged(_ newlyRegisterable: Set<String>, onComplete: @escaping () -> Void = {}) {
         workQueue.async { [weak self] in
-            guard let self else { onComplete(); return }
+            guard let self else {
+                onComplete()
+                return
+            }
 
             // onComplete advances the durable one-time migration flag. It must run only after any
             // delivered-marker clear below is persisted, and on every path (including the early

--- a/PostHog/PushNotifications/PostHogPushSubscriptionHandler.swift
+++ b/PostHog/PushNotifications/PostHogPushSubscriptionHandler.swift
@@ -399,23 +399,33 @@ final class PostHogPushSubscriptionHandler {
     /// A device that registered while its project had no push integration was answered 200 and had its
     /// token discarded, but still recorded the send as delivered and stopped asking. Clearing that
     /// marker for an app_id that just became registerable is the only thing that reaches it.
-    func onPushAppIdsChanged(_ newlyRegisterable: Set<String>) {
+    func onPushAppIdsChanged(_ newlyRegisterable: Set<String>, onComplete: @escaping () -> Void = {}) {
         workQueue.async { [weak self] in
-            guard let self else { return }
+            guard let self else { onComplete(); return }
 
-            let record = recordLock.withLock { self.loadRecordLocked() }
-            guard let record, newlyRegisterable.contains(record.appId) else {
-                // Either nothing changed for this device, or the app_id was already registerable and
-                // the existing delivered marker is honest. Re-sending here would put the request back
-                // on every launch, which is what the marker exists to prevent.
-                return
-            }
+            // onComplete advances the durable one-time migration flag. It must run only after any
+            // delivered-marker clear below is persisted, and on every path (including the early
+            // returns), so the flag never advances ahead of the recovery.
+            defer { onComplete() }
 
-            if record.deliveredForDistinctId != nil {
-                recordLock.withLock {
-                    self.writeRecord(deviceToken: record.deviceToken, appId: record.appId)
+            // Read, verify, and clear the delivered marker in a single lock acquisition. A separate
+            // read then write would let a newer token stored by send() in between be overwritten with
+            // the stale snapshot, losing the latest token.
+            let record: PendingRecord? = recordLock.withLock {
+                guard let current = self.loadRecordLocked(),
+                      newlyRegisterable.contains(current.appId)
+                else {
+                    // Either nothing changed for this device, or the app_id was already registerable
+                    // and the existing delivered marker is honest. Re-sending here would put the
+                    // request back on every launch, which is what the marker exists to prevent.
+                    return nil
                 }
+                if current.deliveredForDistinctId != nil {
+                    self.writeRecord(deviceToken: current.deviceToken, appId: current.appId)
+                }
+                return current
             }
+            guard let record else { return }
 
             resetRetryState()
             hedgeLog("Push app_id \(record.appId) became registerable; re-registering.")

--- a/PostHog/PushNotifications/PostHogPushSubscriptionHandler.swift
+++ b/PostHog/PushNotifications/PostHogPushSubscriptionHandler.swift
@@ -514,6 +514,22 @@ final class PostHogPushSubscriptionHandler {
                 }
                 return
             }
+            // Eligibility can also flip during the mint: remote config may resolve and drop this
+            // app_id. Re-check so a config that arrived mid-mint isn't ignored, which would POST a
+            // token the server discards and then record it as delivered, suppressing retries.
+            guard isRegisterable(appId) else {
+                hedgeLog("Push subscription skipped: app_id \(appId) is not configured for this project.")
+                let hadPendingResend = stateLock.withLock { () -> Bool in
+                    self.isSending = false
+                    let pending = self.pendingResend
+                    self.pendingResend = false
+                    return pending
+                }
+                if hadPendingResend {
+                    servicePendingResend()
+                }
+                return
+            }
             performSerialized { done in
                 self.api.pushSubscription(
                     distinctId: distinctId, deviceToken: deviceToken, appId: appId, identityToken: identityToken,

--- a/PostHog/PushNotifications/PostHogPushSubscriptionHandler.swift
+++ b/PostHog/PushNotifications/PostHogPushSubscriptionHandler.swift
@@ -403,7 +403,7 @@ final class PostHogPushSubscriptionHandler {
         workQueue.async { [weak self] in
             guard let self else { return }
 
-            let record = recordLock.withLock { loadRecordLocked() }
+            let record = recordLock.withLock { self.loadRecordLocked() }
             guard let record, newlyRegisterable.contains(record.appId) else {
                 // Either nothing changed for this device, or the app_id was already registerable and
                 // the existing delivered marker is honest. Re-sending here would put the request back
@@ -413,7 +413,7 @@ final class PostHogPushSubscriptionHandler {
 
             if record.deliveredForDistinctId != nil {
                 recordLock.withLock {
-                    writeRecord(deviceToken: record.deviceToken, appId: record.appId)
+                    self.writeRecord(deviceToken: record.deviceToken, appId: record.appId)
                 }
             }
 

--- a/PostHogTests/PostHogPushNotificationTest.swift
+++ b/PostHogTests/PostHogPushNotificationTest.swift
@@ -1866,7 +1866,7 @@
             appIds = []
             parked.release("jwt")
             #expect(await waitFor { self.record(storage) != nil })
-            #expect(!self.delivered(storage))
+            #expect(!delivered(storage))
             #expect(server.pushSubscriptionRequests.isEmpty)
 
             // The record survives, so configuring push later still reaches the device with one POST.

--- a/PostHogTests/PostHogPushNotificationTest.swift
+++ b/PostHogTests/PostHogPushNotificationTest.swift
@@ -112,6 +112,7 @@
             isConnectedProvider: @escaping () -> Bool = { true },
             isAllowedProvider: @escaping () -> Bool = { true },
             isEnabledProvider: @escaping () -> Bool = { true },
+            pushAppIdsProvider: @escaping () -> [String]? = { nil },
             onEventContextChanged: PostHogMulticastCallback<[String: Any]> = .init(),
             resetStorage: Bool = true
         ) -> (handler: PostHogPushSubscriptionHandler, storage: PostHogStorage, config: PostHogConfig) {
@@ -136,6 +137,7 @@
                 isConnectedProvider: isConnectedProvider,
                 isAllowedProvider: isAllowedProvider,
                 isEnabledProvider: isEnabledProvider,
+                pushAppIdsProvider: pushAppIdsProvider,
                 onEventContextChanged: onEventContextChanged
             )
             return (handler, storage, config)
@@ -1788,6 +1790,78 @@
             // server-side subscription active for the whole opted-out period.
             let sawDelete = await waitFor { deletes() == 1 }
             #expect(sawDelete, "posthog-ios#746: opt-out stranded the unregister DELETE; subscription stays active")
+        }
+
+        @Test("does not send when the app_id is not configured for the project")
+        func skipsUnconfiguredAppId() async {
+            let (handler, storage, _) = makeHandler(pushAppIdsProvider: { ["another.app"] })
+
+            handler.send(deviceToken: "abcdef", appId: "com.example.app")
+
+            #expect(await waitFor { self.record(storage) != nil })
+            #expect(server.pushSubscriptionRequests.isEmpty)
+            // The record is still persisted: onPushAppIdsChanged needs a token to register once the
+            // project configures push, rather than waiting for the app to hand us one again.
+            #expect(record(storage)?["deviceToken"] == "abcdef")
+            #expect(!delivered(storage))
+        }
+
+        @Test("sends when no app_id list has been published")
+        func sendsWhenNoListPublished() async {
+            // A server older than the push config key sends nothing, and an SDK cannot tell that apart
+            // from a project with push disabled. Failing closed here would silently disable push
+            // against every deployment that predates the key.
+            let (handler, storage, _) = makeHandler(pushAppIdsProvider: { nil })
+
+            handler.send(deviceToken: "abcdef", appId: "com.example.app")
+
+            #expect(await waitFor { self.delivered(storage) })
+            #expect(server.pushSubscriptionRequests.count == 1)
+        }
+
+        @Test("sends when the app_id is configured for the project")
+        func sendsWhenAppIdConfigured() async {
+            let (handler, storage, _) = makeHandler(pushAppIdsProvider: { ["com.example.app"] })
+
+            handler.send(deviceToken: "abcdef", appId: "com.example.app")
+
+            #expect(await waitFor { self.delivered(storage) })
+            #expect(server.pushSubscriptionRequests.count == 1)
+        }
+
+        @Test("an app_id becoming registerable clears the delivered marker and re-registers")
+        func reregistersWhenAppIdBecomesRegisterable() async {
+            // The device registered while the project had no integration: the server answered 200 and
+            // discarded the token, but the SDK recorded a delivery and stopped asking. Clearing that
+            // marker is the only thing that reaches the device once the project configures push.
+            var appIds: [String]? = []
+            let (handler, storage, _) = makeHandler(pushAppIdsProvider: { appIds })
+
+            handler.send(deviceToken: "abcdef", appId: "com.example.app")
+            #expect(await waitFor { self.record(storage) != nil })
+            #expect(server.pushSubscriptionRequests.isEmpty)
+
+            appIds = ["com.example.app"]
+            handler.onPushAppIdsChanged(["com.example.app"])
+
+            #expect(await waitFor { self.delivered(storage) })
+            #expect(server.pushSubscriptionRequests.count == 1)
+        }
+
+        @Test("an unrelated app_id becoming registerable does not re-register")
+        func doesNotReregisterForUnrelatedAppId() async {
+            let (handler, storage, _) = makeHandler(pushAppIdsProvider: { ["com.example.app"] })
+
+            handler.send(deviceToken: "abcdef", appId: "com.example.app")
+            #expect(await waitFor { self.delivered(storage) })
+            #expect(server.pushSubscriptionRequests.count == 1)
+
+            // Firing on every config load would put the request back on every launch, which is exactly
+            // what the delivered marker exists to prevent.
+            handler.onPushAppIdsChanged(["some.other.app"])
+
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            #expect(server.pushSubscriptionRequests.count == 1)
         }
     }
 

--- a/PostHogTests/PostHogPushNotificationTest.swift
+++ b/PostHogTests/PostHogPushNotificationTest.swift
@@ -1848,6 +1848,20 @@
             #expect(server.pushSubscriptionRequests.count == 1)
         }
 
+        @Test("onPushAppIdsChanged runs its completion even when there is nothing to recover")
+        func onPushAppIdsChangedRunsCompletionOnEarlyReturn() async {
+            // The completion advances the durable one-time upgrade-recovery flag. It must run on every
+            // path, including this one where no record exists, so the flag never stalls unset (which
+            // would force recovery on every launch) nor advances ahead of a marker clear.
+            let (handler, _, _) = makeHandler(pushAppIdsProvider: { ["com.example.app"] })
+            let lock = NSLock()
+            var completions = 0
+
+            handler.onPushAppIdsChanged(["com.example.app"]) { lock.withLock { completions += 1 } }
+
+            #expect(await waitFor { lock.withLock { completions } == 1 })
+        }
+
         @Test("eligibility revoked during the identity token mint skips the send")
         func skipsSendWhenEligibilityRevokedDuringMint() async {
             // Registerable at send() time; remote config drops the app_id while the identity-token mint

--- a/PostHogTests/PostHogPushNotificationTest.swift
+++ b/PostHogTests/PostHogPushNotificationTest.swift
@@ -1848,6 +1848,34 @@
             #expect(server.pushSubscriptionRequests.count == 1)
         }
 
+        @Test("eligibility revoked during the identity token mint skips the send")
+        func skipsSendWhenEligibilityRevokedDuringMint() async {
+            // Registerable at send() time; remote config drops the app_id while the identity-token mint
+            // is still outstanding. Without a post-mint re-check the token would POST, get discarded,
+            // and be marked delivered, suppressing retries.
+            var appIds: [String]? = ["com.example.app"]
+            let (handler, storage, config) = makeHandler(pushAppIdsProvider: { appIds })
+            let parked = ParkedMint()
+            config.pushIdentityProvider = { _, _, completion in
+                if !parked.parkFirst(completion) { completion("jwt") }
+            }
+
+            handler.send(deviceToken: "abcdef", appId: "com.example.app")
+            #expect(await waitFor { parked.isParked })
+
+            appIds = []
+            parked.release("jwt")
+            #expect(await waitFor { self.record(storage) != nil })
+            #expect(!self.delivered(storage))
+            #expect(server.pushSubscriptionRequests.isEmpty)
+
+            // The record survives, so configuring push later still reaches the device with one POST.
+            appIds = ["com.example.app"]
+            handler.onPushAppIdsChanged(["com.example.app"])
+            #expect(await waitFor { self.delivered(storage) })
+            #expect(server.pushSubscriptionRequests.count == 1)
+        }
+
         @Test("an unrelated app_id becoming registerable does not re-register")
         func doesNotReregisterForUnrelatedAppId() async {
             let (handler, storage, _) = makeHandler(pushAppIdsProvider: { ["com.example.app"] })


### PR DESCRIPTION
## :bulb: Motivation and Context

A device on a project without push configured makes a registration request on every app open that the server can only throw away, and a project that turns push on afterwards never reaches the devices it already has.

- The SDK registers its token at startup whenever push capture is on, against every project it reports to. It has no way to know whether that project opted in.
- `/api/push_subscriptions/` answers those with `200 {"stored": false, "push_enabled": false}` and discards the token.
- Because any 2xx writes `deliveredForDistinctId`, the device then records a success for a token the server never kept and stops asking. No response reaches a client that has stopped asking, so a project that configures push later reaches nothing installed before it — until a token rotation, an `identify()` to a different distinct id, or a reinstall.

Mirrors PostHog/posthog-android#703. Field names and the three client rules are kept identical between the two SDKs, the same way PostHog/posthog-ios#735 and PostHog/posthog-android#656 were.

Server side is merged: PostHog/posthog#83148 publishes the list, and the contract is `docs/internal/push-subscription-registration.md` there.

## Changes

Remote config now carries `push.appIds` — the Firebase project ids and APNs bundle ids a project accepts registrations for.

- **The send is gated in `attemptIfAllowed`**, the choke point every caller already goes through. The record is still persisted when the send is gated, so `onPushAppIdsChanged` has a token to register later rather than waiting for the app to hand us one again.
- **Absent stays permissive.** A server older than the key sends nothing, which an SDK cannot tell apart from a project with push disabled, so `nil` means attempt. Only a published empty list means skip.
- **`onPushAppIdsChanged` clears the delivered marker** for an `app_id` that just became registerable, and re-registers. It fires only on that transition — firing on every config load would put the request back on every launch, which is what the marker exists to prevent.

Two places where iOS legitimately differs from the Android PR, rather than diverging by accident:

- **No per-slice disk cache is needed.** Android caches each config slice separately, so it needed a new `push` preference to survive a cold start. iOS already persists the whole remote config blob, so `preloadPushConfig` reads the slice from it on launch, before the first registration attempt.
- **`processPushConfig` is not re-armed on the `/flags` paths**, where `processErrorTrackingConfig(nil)` is. The in-memory list already holds the cached value there, and a re-arm would compare the list against itself and find no transition.

On the first launch that ever sees the key, the previous list is treated as empty rather than unknown, so every configured `app_id` counts as new. That costs one request per device, once, and it is the only way to reach a device whose project was configured before it updated to a version that reads this key.

## :green_heart: How did you test it?

New cases in `PostHogPushNotificationTest`, mirroring the Android set one for one:

- An `app_id` outside the list sends nothing but still persists the record. Catches the gate being dropped, and catches the record not being persisted, which would leave `onPushAppIdsChanged` with no token.
- A nil list still registers. Catches the gate failing closed against a server older than the key, which would silently disable push on every such deployment.
- An `app_id` inside the list registers. Catches the gate being inverted.
- An `app_id` becoming registerable clears the delivered marker and re-registers. This is the un-stranding path.
- An unrelated `app_id` becoming registerable does not re-register. Catches over-firing.





### Manual E2E on a simulator against a local server

Ran the six-scenario verification brief on an iPhone 17 Pro simulator (PostHogExample as `com.posthog.pushtest`) against a local PostHog serving real `push.appIds` remote config for a team with a togglable APNs integration.

- Compile fix first: the branch did not build (two `self.` capture errors in `onPushAppIdsChanged`). Fixed in this PR; the 83 `PostHogPushNotificationTest` cases then pass on the simulator.
- Configured launch: one POST, server store, person property `$device_push_subscription_com.posthog.pushtest` set.
- Unconfigured launch: no POST, "skipped: not configured", pending record written without a delivered marker.
- Cold start unconfigured: skip logged before a deliberately delayed `/config` responded, so the disk-cached slice gated it, not the fresh fetch.
- Un-stranding: after the integration was added, the next launch logged "became registerable; re-registering" and sent exactly one POST.
- No repeat: three further relaunches sent nothing.
- Old server: with the `push` key removed from the response, the SDK registered.

Simulated, labeled: the iOS simulator does not mint an APNs token, so the token was fed through `registerPushNotificationToken`, the same `handler.send()` gate the swizzled path uses, with a fixed literal. The swizzled auto-registration itself needs a physical device.

**Real-device follow-up (iPhone 16 Pro, iOS 26.6, real APNs token via the swizzle path):** configured launch registered once and stored the token (person property `$device_push_subscription_com.posthog.pushtest` set); after removing the APNs integration a fresh launch registered nothing server-side. This exercises the swizzled auto-registration the simulator can't, so the token substitution above no longer applies to the configured/unconfigured paths.


## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context


Authored with Claude Code, after PostHog/posthog-android#703 landed the reference implementation. Android went first deliberately: its module builds on the JVM, so the design got a compile check there before being mirrored to a platform I cannot build at all.

I confirmed the scope rather than assuming it — a code search across the org for callers of `/api/push_subscriptions` returns only posthog-android and posthog-ios. posthog-flutter forwards to both natives and inherits the gate with no change; posthog-react-native has been emptied and points at posthog-js, which has no caller.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbav6vE7Tm24KkdRhZmvNM)_

