### PR TITLE
fix(push): forward APNs callbacks to UIApplicationDelegateAdaptor

### DIFF
--- a/.changeset/swiftui-push-forwarding.md
+++ b/.changeset/swiftui-push-forwarding.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Fix APNs registration callbacks being swallowed in SwiftUI apps that use `@UIApplicationDelegateAdaptor` (#768).

--- a/PostHog/PushNotifications/PushNotificationPublisher.swift
+++ b/PostHog/PushNotifications/PushNotificationPublisher.swift
@@ -197,9 +197,28 @@
                 }
             #endif
 
+            swizzleAppDelegateMethods(on: appDelegateClass)
+        }
+
+        func swizzleAppDelegateMethods(on appDelegateClass: AnyClass) {
             swizzledAppDelegateClass = appDelegateClass
-            swizzleAddingIfNeeded(on: appDelegateClass, original: Self.didRegisterSelector, swizzled: Self.swizzledDidRegisterSelector)
-            swizzleAddingIfNeeded(on: appDelegateClass, original: Self.didFailSelector, swizzled: Self.swizzledDidFailSelector)
+            #if os(iOS)
+                swizzleAddingIfNeeded(
+                    on: appDelegateClass,
+                    original: Self.didRegisterSelector,
+                    swizzled: Self.swizzledDidRegisterSelector,
+                    noop: Self.forwardedDidRegisterSelector
+                )
+                swizzleAddingIfNeeded(
+                    on: appDelegateClass,
+                    original: Self.didFailSelector,
+                    swizzled: Self.swizzledDidFailSelector,
+                    noop: Self.forwardedDidFailSelector
+                )
+            #elseif os(macOS)
+                swizzleAddingIfNeeded(on: appDelegateClass, original: Self.didRegisterSelector, swizzled: Self.swizzledDidRegisterSelector)
+                swizzleAddingIfNeeded(on: appDelegateClass, original: Self.didFailSelector, swizzled: Self.swizzledDidFailSelector)
+            #endif
         }
 
         private func unswizzleAppDelegateMethods() {
@@ -224,11 +243,17 @@
             private static let swizzledDidRegisterSelector = #selector(
                 NSObject.ph_swizzled_application(_:didRegisterForRemoteNotificationsWithDeviceToken:)
             )
+            private static let forwardedDidRegisterSelector = #selector(
+                NSObject.ph_forwarded_application(_:didRegisterForRemoteNotificationsWithDeviceToken:)
+            )
             private static let didFailSelector = #selector(
                 UIApplicationDelegate.application(_:didFailToRegisterForRemoteNotificationsWithError:)
             )
             private static let swizzledDidFailSelector = #selector(
                 NSObject.ph_swizzled_application(_:didFailToRegisterForRemoteNotificationsWithError:)
+            )
+            private static let forwardedDidFailSelector = #selector(
+                NSObject.ph_forwarded_application(_:didFailToRegisterForRemoteNotificationsWithError:)
             )
         #elseif os(macOS)
             private static let didRegisterSelector = #selector(
@@ -275,6 +300,24 @@
             ) {
                 hedgeLog("Failed to register for remote notifications: \(error.localizedDescription)")
                 ph_swizzled_application(application, didFailToRegisterForRemoteNotificationsWithError: error)
+            }
+
+            @objc func ph_forwarded_application(
+                _ application: UIApplication,
+                didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+            ) {
+                let selector = #selector(UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:))
+                let target = forwardingTarget(for: selector) as? UIApplicationDelegate
+                target?.application?(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+            }
+
+            @objc func ph_forwarded_application(
+                _ application: UIApplication,
+                didFailToRegisterForRemoteNotificationsWithError error: Error
+            ) {
+                let selector = #selector(UIApplicationDelegate.application(_:didFailToRegisterForRemoteNotificationsWithError:))
+                let target = forwardingTarget(for: selector) as? UIApplicationDelegate
+                target?.application?(application, didFailToRegisterForRemoteNotificationsWithError: error)
             }
         #elseif os(macOS)
             @objc func ph_swizzled_application(

--- a/PostHogTests/PostHogPushNotificationSwizzlingTest.swift
+++ b/PostHogTests/PostHogPushNotificationSwizzlingTest.swift
@@ -6,11 +6,42 @@
     #endif
     import Testing
     import UserNotifications
+    #if os(iOS)
+        import UIKit
+    #endif
 
     private final class TestPushNotificationPublisher: PushNotificationPublishing {
         let onNotificationResponse = PostHogMulticastCallback<UNNotificationResponse>()
         let onDeviceToken = PostHogMulticastCallback<String>()
     }
+
+    #if os(iOS)
+        private final class ForwardedApplicationDelegate: NSObject, UIApplicationDelegate {
+            var deviceToken: Data?
+            var registrationError: Error?
+
+            func application(_: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+                self.deviceToken = deviceToken
+            }
+
+            func application(_: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+                registrationError = error
+            }
+        }
+
+        private final class ForwardingApplicationDelegate: NSObject, UIApplicationDelegate {
+            let forwardedDelegate = ForwardedApplicationDelegate()
+
+            override func forwardingTarget(for selector: Selector!) -> Any? {
+                if selector == #selector(UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)) ||
+                    selector == #selector(UIApplicationDelegate.application(_:didFailToRegisterForRemoteNotificationsWithError:))
+                {
+                    return forwardedDelegate
+                }
+                return nil
+            }
+        }
+    #endif
 
     @Suite("Push Notification Swizzling Tests", .serialized)
     final class PostHogPushNotificationSwizzlingTest {
@@ -31,6 +62,29 @@
         private var selector: Selector {
             #selector(UNUserNotificationCenterDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:))
         }
+
+        #if os(iOS)
+            @Test("forwards app delegate callbacks to a UIApplicationDelegateAdaptor-style target")
+            @MainActor
+            func forwardsApplicationDelegateCallbacks() {
+                let delegate = ForwardingApplicationDelegate()
+                PushNotificationPublisher.shared.swizzleAppDelegateMethods(on: type(of: delegate))
+
+                let appDelegate: UIApplicationDelegate = delegate
+                let deviceToken = Data([0x01, 0x23, 0xFF])
+                var capturedToken: String?
+                let token = publisher.onDeviceToken.subscribe { capturedToken = $0 }
+                appDelegate.application?(UIApplication.shared, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+
+                let error = NSError(domain: "PostHogPushNotificationSwizzlingTest", code: 1)
+                appDelegate.application?(UIApplication.shared, didFailToRegisterForRemoteNotificationsWithError: error)
+                withExtendedLifetime(token) {}
+
+                #expect(capturedToken == "0123ff")
+                #expect(delegate.forwardedDelegate.deviceToken == deviceToken)
+                #expect(delegate.forwardedDelegate.registrationError as? NSError == error)
+            }
+        #endif
 
         @Test("captures and calls an Objective-C delegate with the original selector")
         func callsObjectiveCDelegate() {


### PR DESCRIPTION
## :bulb: Motivation and Context

SwiftUI apps that use `@UIApplicationDelegateAdaptor` receive APNs registration callbacks through Objective-C message forwarding. PostHog added the callbacks directly to SwiftUI's private app delegate, which stopped that forwarding and prevented the app's delegate methods from running.

Closes #768.

## :green_heart: How did you test it?

Added an iOS regression test that models the forwarding used by `@UIApplicationDelegateAdaptor` and verifies both successful and failed APNs registration callbacks reach the app delegate.

Ran:

- `make test` - 750 tests passed.
- `make testOniOSSimulator` - 817 tests passed.
- `make build` - all SDK and example builds passed.
- `make lint` - passed with existing warnings.

The existing Objective-C notification delegate regression test for #748 also passes on macOS and iOS.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi. The fix keeps the direct Objective-C delegate forwarding added for #748 unchanged. It adds a fallback only when the SwiftUI app delegate does not implement the APNs callback and forwards that callback to the target returned by `forwardingTarget(for:)`.
