### PR TITLE
fix: Drop events and logs when Objective-C beforeSend callbacks raise

### DIFF
--- a/.changeset/safe-hooks-close.md
+++ b/.changeset/safe-hooks-close.md
@@ -2,4 +2,4 @@
 'posthog-ios': patch
 ---
 
-Drop events when Objective-C beforeSend callbacks raise exceptions.
+Drop events and logs when Objective-C beforeSend callbacks raise exceptions.

--- a/.changeset/safe-hooks-close.md
+++ b/.changeset/safe-hooks-close.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': patch
+---
+
+Drop events when Objective-C beforeSend callbacks raise exceptions.

--- a/PostHog.podspec
+++ b/PostHog.podspec
@@ -48,6 +48,7 @@ Pod::Spec.new do |s|
   # Only PostHog's umbrella header should be public; vendored implementation headers stay private.
   s.public_header_files = 'PostHog/PostHog.h'
   s.private_header_files = [
+    'PostHog/ObjCExceptionSupport/PHObjCExceptionCatcher.h',
     'PostHog/ObjCExceptionSupport/PHURLSessionTaskSafeAccess.h',
     'vendor/libwebp/**/*.h',
     'vendor/PHPLCrashReporter/Source/**/*.{h,hpp}'

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		B74800000000000000000001 /* PostHogPushNotificationSwizzlingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B74800000000000000000003 /* PostHogPushNotificationSwizzlingTest.swift */; };
 		B74800000000000000000002 /* PHNotificationDelegateTestFixture.m in Sources */ = {isa = PBXBuildFile; fileRef = B74800000000000000000006 /* PHNotificationDelegateTestFixture.m */; };
+		BF5E00000000000000000001 /* PHBeforeSendExceptionTestFixture.m in Sources */ = {isa = PBXBuildFile; fileRef = BF5E00000000000000000005 /* PHBeforeSendExceptionTestFixture.m */; };
+		BF5E00000000000000000002 /* PHObjCExceptionCatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = BF5E00000000000000000006 /* PHObjCExceptionCatcher.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BF5E00000000000000000003 /* PHObjCExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = BF5E00000000000000000007 /* PHObjCExceptionCatcher.m */; };
 		D0E500012FA0000100000002 /* PostHogEventSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E500012FA0000100000001 /* PostHogEventSnapshotTests.swift */; };
 		D0E500012FA0000100000021 /* event-shapes-batch.json in Resources */ = {isa = PBXBuildFile; fileRef = D0E500012FA0000100000011 /* event-shapes-batch.json */; };
 		D0E500012FA0000100000022 /* feature-flags-request.json in Resources */ = {isa = PBXBuildFile; fileRef = D0E500012FA0000100000012 /* feature-flags-request.json */; };
@@ -774,6 +777,10 @@
 		B74800000000000000000004 /* PostHogTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PostHogTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		B74800000000000000000005 /* PHNotificationDelegateTestFixture.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PHNotificationDelegateTestFixture.h; sourceTree = "<group>"; };
 		B74800000000000000000006 /* PHNotificationDelegateTestFixture.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PHNotificationDelegateTestFixture.m; sourceTree = "<group>"; };
+		BF5E00000000000000000004 /* PHBeforeSendExceptionTestFixture.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PHBeforeSendExceptionTestFixture.h; sourceTree = "<group>"; };
+		BF5E00000000000000000005 /* PHBeforeSendExceptionTestFixture.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PHBeforeSendExceptionTestFixture.m; sourceTree = "<group>"; };
+		BF5E00000000000000000006 /* PHObjCExceptionCatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PHObjCExceptionCatcher.h; sourceTree = "<group>"; };
+		BF5E00000000000000000007 /* PHObjCExceptionCatcher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PHObjCExceptionCatcher.m; sourceTree = "<group>"; };
 		D0E500012FA0000100000001 /* PostHogEventSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogEventSnapshotTests.swift; sourceTree = "<group>"; };
 		D0E500012FA0000100000011 /* event-shapes-batch.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = "event-shapes-batch.json"; sourceTree = "<group>"; };
 		D0E500012FA0000100000012 /* feature-flags-request.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = "feature-flags-request.json"; sourceTree = "<group>"; };
@@ -1581,6 +1588,8 @@
 		B74800000000000000000007 /* PostHogTestsObjC */ = {
 			isa = PBXGroup;
 			children = (
+				BF5E00000000000000000004 /* PHBeforeSendExceptionTestFixture.h */,
+				BF5E00000000000000000005 /* PHBeforeSendExceptionTestFixture.m */,
 				B74800000000000000000005 /* PHNotificationDelegateTestFixture.h */,
 				B74800000000000000000006 /* PHNotificationDelegateTestFixture.m */,
 			);
@@ -1676,6 +1685,8 @@
 		E1A0B0053A0B000100000001 /* ObjCExceptionSupport */ = {
 			isa = PBXGroup;
 			children = (
+				BF5E00000000000000000006 /* PHObjCExceptionCatcher.h */,
+				BF5E00000000000000000007 /* PHObjCExceptionCatcher.m */,
 				E1A0B0023A0B000100000001 /* PHURLSessionTaskSafeAccess.h */,
 				E1A0B0033A0B000100000001 /* PHURLSessionTaskSafeAccess.m */,
 			);
@@ -2606,6 +2617,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3AC745C6296D6FE60025C109 /* PostHog.h in Headers */,
+				BF5E00000000000000000002 /* PHObjCExceptionCatcher.h in Headers */,
 				E1A0B0063A0B000100000001 /* PHURLSessionTaskSafeAccess.h in Headers */,
 				DA0B66A52D64EC00006F5FF3 /* ph_sharpyuv_csp.h in Headers */,
 				DA0B66A62D64EC00006F5FF3 /* ph_sharpyuv_dsp.h in Headers */,
@@ -3163,6 +3175,7 @@
 				DAB9E23D2DE8901D00E62DB9 /* URLSessionExtension.swift in Sources */,
 				DAB9E23E2DE8901D00E62DB9 /* URLSessionSwizzler.swift in Sources */,
 				DAB9E23F2DE8901D00E62DB9 /* URLSessionInterceptor.swift in Sources */,
+				BF5E00000000000000000003 /* PHObjCExceptionCatcher.m in Sources */,
 				E1A0B0013A0B000100000001 /* PHURLSessionTaskSafeAccess.m in Sources */,
 				DA5175B32F6C4CEA00F0E00A /* PostHogReplayBufferDelegate.swift in Sources */,
 				DA5175B42F6C4CEA00F0E00A /* PostHogReplayBufferQueue.swift in Sources */,
@@ -3456,6 +3469,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B74800000000000000000001 /* PostHogPushNotificationSwizzlingTest.swift in Sources */,
+				BF5E00000000000000000001 /* PHBeforeSendExceptionTestFixture.m in Sources */,
 				B74800000000000000000002 /* PHNotificationDelegateTestFixture.m in Sources */,
 				D0E500012FA0000100000002 /* PostHogEventSnapshotTests.swift in Sources */,
 				DA979D7B2CD370B700F56BAE /* PostHogAutocaptureEventTrackerSpec.swift in Sources */,

--- a/PostHog/Logs/PostHogLogsConfig.swift
+++ b/PostHog/Logs/PostHogLogsConfig.swift
@@ -104,7 +104,9 @@ public typealias PostHogBeforeSendLogBlock = (PostHogLogRecord) -> PostHogLogRec
     /// - Parameter blocks: Ordered Objective-C callback boxes.
     @available(swift, obsoleted: 1.0, message: "Use setBeforeSend(_ blocks: PostHogBeforeSendLogBlock...) instead")
     @objc public func setBeforeSend(_ blocks: [BoxedBeforeSendLogBlock]) {
-        setBeforeSend(blocks.map(\.block))
+        setBeforeSend(blocks.map { box in
+            { record in box.invokeSafely(with: record) }
+        })
     }
 
     func runBeforeSend(_ record: PostHogLogRecord) -> PostHogLogRecord? {

--- a/PostHog/ObjCExceptionSupport/PHObjCExceptionCatcher.h
+++ b/PostHog/ObjCExceptionSupport/PHObjCExceptionCatcher.h
@@ -1,0 +1,14 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PHObjCExceptionCatcher : NSObject
+
++ (nullable id)invokeBlockFromBox:(id)box
+                         withValue:(id)value
+                       onException:(void (^)(NSException *exception))onException
+    NS_SWIFT_NAME(invokeBlock(from:with:onException:));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/PostHog/ObjCExceptionSupport/PHObjCExceptionCatcher.m
+++ b/PostHog/ObjCExceptionSupport/PHObjCExceptionCatcher.m
@@ -10,6 +10,9 @@ typedef id _Nullable (^PHObjectTransformBlock)(id value);
                          withValue:(id)value
                        onException:(void (^)(NSException *exception))onException {
     @try {
+        // The box types are generated from Swift in this target, so this file cannot import
+        // PostHog-Swift.h. Resolve their @objc block accessor dynamically and invoke it here so
+        // an NSException never unwinds through a Swift frame.
         PHObjectTransformBlock block = ((id (*)(id, SEL))objc_msgSend)(box, NSSelectorFromString(@"block"));
         return block(value);
     } @catch (NSException *exception) {

--- a/PostHog/ObjCExceptionSupport/PHObjCExceptionCatcher.m
+++ b/PostHog/ObjCExceptionSupport/PHObjCExceptionCatcher.m
@@ -1,0 +1,21 @@
+#import "PHObjCExceptionCatcher.h"
+
+#import <objc/message.h>
+
+typedef id _Nullable (^PHObjectTransformBlock)(id value);
+
+@implementation PHObjCExceptionCatcher
+
++ (nullable id)invokeBlockFromBox:(id)box
+                         withValue:(id)value
+                       onException:(void (^)(NSException *exception))onException {
+    @try {
+        PHObjectTransformBlock block = ((id (*)(id, SEL))objc_msgSend)(box, NSSelectorFromString(@"block"));
+        return block(value);
+    } @catch (NSException *exception) {
+        onException(exception);
+        return nil;
+    }
+}
+
+@end

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -605,7 +605,9 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
     /// - Parameter blocks: Ordered Objective-C callback boxes.
     @available(swift, obsoleted: 1.0, message: "Use setBeforeSend(_ blocks: BeforeSendBlock...) instead")
     @objc public func setBeforeSend(_ blocks: [BoxedBeforeSendBlock]) {
-        setBeforeSend(blocks.map(\.block))
+        setBeforeSend(blocks.map { box in
+            { event in box.invokeSafely(with: event) }
+        })
     }
 
     func runBeforeSend(_ event: PostHogEvent) -> PostHogEvent? {

--- a/PostHog/PrivateModules/PostHogObjCExceptionSupport/module.modulemap
+++ b/PostHog/PrivateModules/PostHogObjCExceptionSupport/module.modulemap
@@ -1,4 +1,5 @@
 module PostHogObjCExceptionSupport {
+  header "../../ObjCExceptionSupport/PHObjCExceptionCatcher.h"
   header "../../ObjCExceptionSupport/PHURLSessionTaskSafeAccess.h"
   export *
 }

--- a/PostHog/Utils/BoxedBeforeSend.swift
+++ b/PostHog/Utils/BoxedBeforeSend.swift
@@ -50,4 +50,11 @@ import Foundation
     public init(block: @escaping PostHogBeforeSendLogBlock) {
         self.block = block
     }
+
+    func invokeSafely(with record: PostHogLogRecord) -> PostHogLogRecord? {
+        PHObjCExceptionCatcher.invokeBlock(from: self, with: record) { exception in
+            let reason = exception.reason ?? "No reason provided"
+            hedgeLog("Objective-C log beforeSend callback raised \(exception.name.rawValue): \(reason). The log was dropped.")
+        } as? PostHogLogRecord
+    }
 }

--- a/PostHog/Utils/BoxedBeforeSend.swift
+++ b/PostHog/Utils/BoxedBeforeSend.swift
@@ -4,6 +4,11 @@
 //
 
 import Foundation
+#if compiler(>=6.0)
+    internal import PostHogObjCExceptionSupport
+#else
+    @_implementationOnly import PostHogObjCExceptionSupport
+#endif
 
 /// ObjC wrappers for the Swift function-typed `beforeSend` chains: Swift
 /// function types aren't `@objc`-bridgeable, and `@objc` classes can't be
@@ -22,6 +27,13 @@ import Foundation
     @objc(block:)
     public init(block: @escaping BeforeSendBlock) {
         self.block = block
+    }
+
+    func invokeSafely(with event: PostHogEvent) -> PostHogEvent? {
+        PHObjCExceptionCatcher.invokeBlock(from: self, with: event) { exception in
+            let reason = exception.reason ?? "No reason provided"
+            hedgeLog("Objective-C beforeSend callback raised \(exception.name.rawValue): \(reason). The event was dropped.")
+        } as? PostHogEvent
     }
 }
 

--- a/PostHogTests/PostHogLogsCaptureTest.swift
+++ b/PostHogTests/PostHogLogsCaptureTest.swift
@@ -7,6 +7,9 @@ import Foundation
 import OHHTTPStubs
 import OHHTTPStubsSwift
 @testable import PostHog
+#if SWIFT_PACKAGE
+    import PostHogTestsObjC
+#endif
 import Testing
 import XCTest
 
@@ -339,6 +342,34 @@ final class PostHogLogsCaptureTests {
 
         waitForLogsRequests(count: 1)
         #expect(server.logsRequests.count == 1)
+    }
+
+    // MARK: - beforeSend
+
+    @Test("Objective-C beforeSend exceptions drop logs and stop the chain")
+    func objcBeforeSendExceptionDropsLog() {
+        let sdk = setupSdk()
+        defer { sdk.close() }
+        var laterCallbackInvoked = false
+        let throwingBox = PHBeforeSendExceptionTestFixture.makeThrowingBox(BoxedBeforeSendLogBlock.self)
+        let boxes: [NSObject] = [
+            throwingBox,
+            BoxedBeforeSendLogBlock { record in
+                laterCallbackInvoked = true
+                return record
+            },
+        ]
+        PHBeforeSendExceptionTestFixture.setBeforeSend(boxes, on: sdk.config.logs)
+
+        let returnedNormally = PHBeforeSendExceptionTestFixture.invokeWithoutException {
+            sdk.captureLog("objc_exception_log")
+        }
+        sdk.flush()
+
+        #expect(returnedNormally)
+        #expect(!laterCallbackInvoked)
+        #expect(sdk.logsQueue?.depth == 0)
+        #expect(server.logsRequests.isEmpty)
     }
 
     // MARK: - Trace context

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -8,6 +8,9 @@
 import Foundation
 import Nimble
 @testable import PostHog
+#if SWIFT_PACKAGE
+    import PostHogTestsObjC
+#endif
 import Quick
 
 class PostHogSDKTest: QuickSpec {
@@ -1328,6 +1331,35 @@ class PostHogSDKTest: QuickSpec {
                 let events = getBatchedEvents(server)
                 expect(events.count).to(equal(1))
                 expect(events[0].event).to(equal("other_test"))
+            }
+
+            it("contains Objective-C exceptions from boxed callbacks") {
+                sut = self.getSut(flushAt: 1)
+                var laterCallbackInvoked = false
+                let throwingBox = PHBeforeSendExceptionTestFixture.makeThrowingBox(BoxedBeforeSendBlock.self)
+                let boxes: [NSObject] = [
+                    throwingBox,
+                    BoxedBeforeSendBlock { event in
+                        laterCallbackInvoked = true
+                        return event
+                    },
+                ]
+                PHBeforeSendExceptionTestFixture.setBeforeSend(boxes, on: sut.config)
+
+                let returnedNormally = PHBeforeSendExceptionTestFixture.invokeWithoutException {
+                    sut.capture("objc_exception_event")
+                }
+                sut.flush()
+
+                guard let storage = sut.storage else {
+                    fail("Expected analytics storage to be configured")
+                    return
+                }
+                let persistedQueue = PostHogFileBackedQueue(queue: storage.url(forKey: .queue))
+                expect(returnedNormally).to(beTrue())
+                expect(laterCallbackInvoked).to(beFalse())
+                expect(persistedQueue.depth).to(equal(0))
+                expect(server.batchRequests).to(beEmpty())
             }
 
             describe("array edge cases") {

--- a/PostHogTests/PostHogSDKTest.swift
+++ b/PostHogTests/PostHogSDKTest.swift
@@ -1333,6 +1333,23 @@ class PostHogSDKTest: QuickSpec {
                 expect(events[0].event).to(equal("other_test"))
             }
 
+            it("runs boxed Objective-C callbacks through the exception boundary") {
+                sut = self.getSut(flushAt: 1)
+                let boxes: [NSObject] = [
+                    BoxedBeforeSendBlock { event in
+                        event.event = "boxed_modified_event"
+                        return event
+                    },
+                ]
+                PHBeforeSendExceptionTestFixture.setBeforeSend(boxes, on: sut.config)
+
+                sut.capture("original_event")
+
+                let events = getBatchedEvents(server)
+                expect(events.count).to(equal(1))
+                expect(events[0].event).to(equal("boxed_modified_event"))
+            }
+
             it("contains Objective-C exceptions from boxed callbacks") {
                 sut = self.getSut(flushAt: 1)
                 var laterCallbackInvoked = false

--- a/PostHogTests/PostHogTests-Bridging-Header.h
+++ b/PostHogTests/PostHogTests-Bridging-Header.h
@@ -1,1 +1,2 @@
+#import "../PostHogTestsObjC/PHBeforeSendExceptionTestFixture.h"
 #import "../PostHogTestsObjC/PHNotificationDelegateTestFixture.h"

--- a/PostHogTestsObjC/PHBeforeSendExceptionTestFixture.h
+++ b/PostHogTestsObjC/PHBeforeSendExceptionTestFixture.h
@@ -1,0 +1,14 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PHBeforeSendExceptionTestFixture : NSObject
+
++ (NSObject *)makeThrowingBox:(Class)boxClass;
++ (BOOL)invokeWithoutException:(void (^)(void))block;
++ (void)setBeforeSendBlocks:(NSArray *)blocks onConfig:(NSObject *)config
+    NS_SWIFT_NAME(setBeforeSend(_:on:));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/PostHogTestsObjC/PHBeforeSendExceptionTestFixture.m
+++ b/PostHogTestsObjC/PHBeforeSendExceptionTestFixture.m
@@ -1,0 +1,29 @@
+#import "PHBeforeSendExceptionTestFixture.h"
+
+#import <objc/message.h>
+
+@implementation PHBeforeSendExceptionTestFixture
+
++ (NSObject *)makeThrowingBox:(Class)boxClass {
+    id block = ^id(__unused id event) {
+        [NSException raise:@"PHBeforeSendTestException" format:@"Objective-C beforeSend failure"];
+        return nil;
+    };
+    return ((id (*)(id, SEL, id))objc_msgSend)([boxClass alloc], NSSelectorFromString(@"block:"), block);
+}
+
++ (BOOL)invokeWithoutException:(void (^)(void))block {
+    @try {
+        block();
+        return YES;
+    } @catch (__unused NSException *exception) {
+        return NO;
+    }
+}
+
++ (void)setBeforeSendBlocks:(NSArray *)blocks onConfig:(NSObject *)config {
+    SEL selector = NSSelectorFromString(@"setBeforeSend:");
+    ((void (*)(id, SEL, NSArray *))objc_msgSend)(config, selector, blocks);
+}
+
+@end


### PR DESCRIPTION
## :bulb: Motivation and Context

Swift `BeforeSendBlock` callbacks are non-throwing, but boxed event and log callbacks supplied from Objective-C can raise `NSException`. Those exceptions previously escaped the Swift callback chain and could crash capture instead of safely rejecting the item.

This change invokes boxed Objective-C callbacks through an Objective-C exception boundary. If a callback raises, the SDK logs the exception, stops the callback chain, and drops the event or log without queueing or sending it. Native Swift callback behavior is unchanged.

## :green_heart: How did you test it?

- Focused `PostHogSDKTest` run through XcodeBuildMCP using the `Testing` configuration - 97 tests passed
- Focused `PostHogLogsCaptureTests` run through XcodeBuildMCP using the `Testing` configuration - 17 tests passed
- `make swiftLintCheck`
- `make swiftFormatCheck`
- `pnpm changeset status`
- `git diff --check`

The regression tests raise Objective-C exceptions, verify capture returns normally, confirm later callbacks do not run, and check queues and network requests remain empty. A positive event test also proves a working boxed callback executes through the dynamic Objective-C accessor and modifies the sent event.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent helped audit the Objective-C bridge, add the exception boundary and regression fixtures, run validation, and prepare this PR. Reviewer feedback prompted positive callback coverage, protection for boxed log callbacks, and documentation of why the Objective-C accessor is resolved dynamically. The generated Swift Objective-C header was checked to confirm the exported selector.
