### PR TITLE
fix: wait for current dSYM before uploading symbols

### DIFF
--- a/.changeset/calm-dsyms-wait.md
+++ b/.changeset/calm-dsyms-wait.md
@@ -2,4 +2,4 @@
 "posthog-ios": patch
 ---
 
-Wait for the current app dSYM and use source Info.plist versions before uploading symbols.
+Upload symbols under the app version reported by Info.plist, including custom build settings. Wait for the current dSYM and fail after a configurable timeout instead of uploading invalid symbols.

--- a/.changeset/calm-dsyms-wait.md
+++ b/.changeset/calm-dsyms-wait.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Wait for the current app dSYM and use source Info.plist versions before uploading symbols.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build buildSdk buildExamples format swiftLint swiftFormat swiftLintCheck swiftFormatCheck installSwiftLint installSwiftFormat test recordEventShapeSnapshots testDowngradeCompatibility testOniOSSimulator testOnMacSimulator maskSnapshots recordMaskSnapshots checkMaskSnapshotRuntime lint bootstrap releaseCocoaPods api apiCheck apiUpdate buildIOS
+.PHONY: build buildSdk buildExamples format swiftLint swiftFormat swiftLintCheck swiftFormatCheck installSwiftLint installSwiftFormat test testUploadSymbols recordEventShapeSnapshots testDowngradeCompatibility testOniOSSimulator testOnMacSimulator maskSnapshots recordMaskSnapshots checkMaskSnapshotRuntime lint bootstrap releaseCocoaPods api apiCheck apiUpdate buildIOS
 
 build: buildSdk buildExamples
 
@@ -154,7 +154,10 @@ recordMaskSnapshots: checkMaskSnapshotRuntime
 # Examples:
 #   make test                              						# Run all tests
 #   make test filter=PostHogPropertiesSerializationTests        # Run specific test suite, class or method
-test:
+testUploadSymbols:
+	build-tools/upload-symbols.test.sh
+
+test: testUploadSymbols
 	set -o pipefail && swift test --no-parallel -Xswiftc -DTESTING $(if $(filter),--filter $(filter))
 
 recordEventShapeSnapshots:

--- a/build-tools/upload-symbols.sh
+++ b/build-tools/upload-symbols.sh
@@ -40,6 +40,38 @@ if [ -n "${CONFIGURATION}" ] && [ "${CONFIGURATION}" != "Release" ]; then
     exit 0
 fi
 
+# Xcode can start this phase before dsymutil finishes. Declaring the dSYM as an input can create
+# dependency cycles for apps with embedded extensions, so wait until the dSYM belongs to the current
+# executable instead. If it never becomes ready, skip the upload rather than sending stale symbols.
+if [ "${DEBUG_INFORMATION_FORMAT:-}" = "dwarf-with-dsym" ] && [ -n "${DWARF_DSYM_FOLDER_PATH:-}" ] && [ -n "${DWARF_DSYM_FILE_NAME:-}" ] && [ -n "${EXECUTABLE_NAME:-}" ] && [ -n "${TARGET_BUILD_DIR:-}" ] && [ -n "${EXECUTABLE_PATH:-}" ]; then
+    POSTHOG_MAIN_DWARF="${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${EXECUTABLE_NAME}"
+    POSTHOG_APP_EXECUTABLE="${TARGET_BUILD_DIR}/${EXECUTABLE_PATH}"
+    POSTHOG_DSYM_ATTEMPT=1
+    POSTHOG_DSYM_MAX_ATTEMPTS=60
+    POSTHOG_DSYM_READY=0
+
+    while [ "$POSTHOG_DSYM_ATTEMPT" -le "$POSTHOG_DSYM_MAX_ATTEMPTS" ]; do
+        if [ -s "$POSTHOG_MAIN_DWARF" ] && [ -s "$POSTHOG_APP_EXECUTABLE" ]; then
+            POSTHOG_DSYM_UUIDS=$(xcrun dwarfdump --uuid "$POSTHOG_MAIN_DWARF" 2>/dev/null | awk '/^UUID: / {print $2}' | sort)
+            POSTHOG_APP_UUIDS=$(xcrun dwarfdump --uuid "$POSTHOG_APP_EXECUTABLE" 2>/dev/null | awk '/^UUID: / {print $2}' | sort)
+            if [ -n "$POSTHOG_DSYM_UUIDS" ] && [ "$POSTHOG_DSYM_UUIDS" = "$POSTHOG_APP_UUIDS" ]; then
+                POSTHOG_DSYM_READY=1
+                break
+            fi
+        fi
+
+        if [ "$POSTHOG_DSYM_ATTEMPT" -lt "$POSTHOG_DSYM_MAX_ATTEMPTS" ]; then
+            sleep 1
+        fi
+        POSTHOG_DSYM_ATTEMPT=$((POSTHOG_DSYM_ATTEMPT + 1))
+    done
+
+    if [ "$POSTHOG_DSYM_READY" -ne 1 ]; then
+        echo "warning: Main app dSYM was not ready after ${POSTHOG_DSYM_MAX_ATTEMPTS} attempts; skipping upload: $POSTHOG_MAIN_DWARF"
+        exit 0
+    fi
+fi
+
 # Validate environment
 if [ -z "${DWARF_DSYM_FOLDER_PATH}" ]; then
     echo "warning: DWARF_DSYM_FOLDER_PATH not set"
@@ -110,6 +142,34 @@ if [ "$LOWEST" != "$MIN_POSTHOG_CLI_VERSION" ]; then
     exit 1
 fi
 
+resolve_source_plist_value() {
+    local key="$1"
+    local plist_path="${INFOPLIST_FILE:-}"
+    local value
+
+    if [ -z "$plist_path" ]; then
+        return
+    fi
+    if [[ "$plist_path" != /* ]]; then
+        if [ -z "${SRCROOT:-}" ]; then
+            return
+        fi
+        plist_path="${SRCROOT}/${plist_path}"
+    fi
+    if [ ! -f "$plist_path" ]; then
+        return
+    fi
+
+    value=$(/usr/libexec/PlistBuddy -c "Print :${key}" "$plist_path" 2>/dev/null) || return
+    if [ -z "$value" ] || [[ "$value" == *"\$("* ]] || [[ "$value" == *"\${"* ]]; then
+        return
+    fi
+    printf '%s' "$value"
+}
+
+POSTHOG_RELEASE_VERSION=$(resolve_source_plist_value "CFBundleShortVersionString")
+POSTHOG_BUILD_VERSION=$(resolve_source_plist_value "CFBundleVersion")
+
 # Build CLI arguments as an array so paths with spaces are preserved.
 CLI_ARGS=(--directory "${DWARF_DSYM_FOLDER_PATH}")
 
@@ -118,14 +178,19 @@ if [ -n "${DWARF_DSYM_FILE_NAME}" ]; then
     CLI_ARGS+=(--main-dsym "${DWARF_DSYM_FILE_NAME}")
 fi
 
-# Pass version info from Xcode build settings (overrides plist extraction)
+# Prefer literal values from the source Info.plist. EAS remote versioning can update these values
+# without changing MARKETING_VERSION or CURRENT_PROJECT_VERSION.
 if [ -n "${PRODUCT_BUNDLE_IDENTIFIER}" ]; then
     CLI_ARGS+=(--release-name "${PRODUCT_BUNDLE_IDENTIFIER}")
 fi
-if [ -n "${MARKETING_VERSION}" ]; then
+if [ -n "$POSTHOG_RELEASE_VERSION" ]; then
+    CLI_ARGS+=(--release-version "$POSTHOG_RELEASE_VERSION")
+elif [ -n "${MARKETING_VERSION}" ]; then
     CLI_ARGS+=(--release-version "${MARKETING_VERSION}")
 fi
-if [ -n "${CURRENT_PROJECT_VERSION}" ]; then
+if [ -n "$POSTHOG_BUILD_VERSION" ]; then
+    CLI_ARGS+=(--build "$POSTHOG_BUILD_VERSION")
+elif [ -n "${CURRENT_PROJECT_VERSION}" ]; then
     CLI_ARGS+=(--build "${CURRENT_PROJECT_VERSION}")
 fi
 # Include source if requested via env var

--- a/build-tools/upload-symbols.sh
+++ b/build-tools/upload-symbols.sh
@@ -107,7 +107,7 @@ if [ "${DEBUG_INFORMATION_FORMAT:-}" = "dwarf-with-dsym" ] && [ -n "${DWARF_DSYM
         if [ -s "$POSTHOG_MAIN_DWARF" ] && [ -s "$POSTHOG_APP_EXECUTABLE" ]; then
             POSTHOG_DSYM_UUIDS=$(xcrun dwarfdump --uuid "$POSTHOG_MAIN_DWARF" 2>/dev/null | awk '/^UUID: / {print $2}' | sort)
             POSTHOG_APP_UUIDS=$(xcrun dwarfdump --uuid "$POSTHOG_APP_EXECUTABLE" 2>/dev/null | awk '/^UUID: / {print $2}' | sort)
-            if [ -n "$POSTHOG_DSYM_UUIDS" ] && [ "$POSTHOG_DSYM_UUIDS" = "$POSTHOG_APP_UUIDS" ] && ! "$POSTHOG_LSOF_PATH" -a -d 0-9 -F a -- "$POSTHOG_MAIN_DWARF" 2>/dev/null | grep -Eq '^a[uw]$'; then
+            if [ -n "$POSTHOG_DSYM_UUIDS" ] && [ "$POSTHOG_DSYM_UUIDS" = "$POSTHOG_APP_UUIDS" ] && ! "$POSTHOG_LSOF_PATH" -F a -- "$POSTHOG_MAIN_DWARF" 2>/dev/null | grep -Eq '^a[uw]$'; then
                 POSTHOG_DSYM_READY=1
                 break
             fi
@@ -161,52 +161,38 @@ fi
 
 resolve_source_plist_value() {
     local key="$1"
-    local source_plist_path="${INFOPLIST_FILE:-}"
-    local processed_plist_path=""
-    local plist_path=""
-    local name
+    local plist_path="${INFOPLIST_FILE:-}"
     local value
+    local token
+    local name
+    local replacement
+    local prefix
+    local suffix
 
-    if [ -n "$source_plist_path" ] && [[ "$source_plist_path" != /* ]]; then
-        if [ -n "${SRCROOT:-}" ]; then
-            source_plist_path="${SRCROOT}/${source_plist_path}"
-        else
-            source_plist_path=""
+    # Bare C preprocessor macros cannot be expanded safely here, and the product plist may belong to
+    # a previous build. Preserve the existing Xcode-setting fallback for preprocessed plists.
+    if [ "${INFOPLIST_PREPROCESS:-}" = "YES" ] || [ -z "$plist_path" ]; then
+        return
+    fi
+    if [[ "$plist_path" != /* ]]; then
+        if [ -z "${SRCROOT:-}" ]; then
+            return
         fi
+        plist_path="${SRCROOT}/${plist_path}"
     fi
-    if [ -n "${TARGET_BUILD_DIR:-}" ] && [ -n "${INFOPLIST_PATH:-}" ]; then
-        processed_plist_path="${TARGET_BUILD_DIR}/${INFOPLIST_PATH}"
-    fi
-
-    # Plist preprocessing can replace bare macros that cannot be resolved from the shell environment.
-    # Otherwise prefer the source plist to avoid reading a stale product from a previous build.
-    if [ "${INFOPLIST_PREPROCESS:-}" = "YES" ] && [ -f "$processed_plist_path" ]; then
-        plist_path="$processed_plist_path"
-    elif [ -f "$source_plist_path" ]; then
-        plist_path="$source_plist_path"
-    elif [ -f "$processed_plist_path" ]; then
-        plist_path="$processed_plist_path"
-    else
+    if [ ! -f "$plist_path" ]; then
         return
     fi
 
     value=$(/usr/libexec/PlistBuddy -c "Print :${key}" "$plist_path" 2>/dev/null) || return
-    case "$value" in
-        \$\(*\))
-            name=${value#\$(}
-            value=$(printenv "${name%)}" 2>/dev/null) || true
-            ;;
-        \$\{*\})
-            name=${value#\$\{}
-            value=$(printenv "${name%\}}" 2>/dev/null) || true
-            ;;
-    esac
-
-    # Compound substitutions such as $(MAJOR).$(MINOR) are expanded by ProcessInfoPlistFile. Use
-    # that product only when the source value could not be resolved, so stale products never win.
-    if { [ -z "$value" ] || [[ "$value" == *"\$("* ]] || [[ "$value" == *"\${"* ]]; } && [ "$plist_path" != "$processed_plist_path" ] && [ -f "$processed_plist_path" ]; then
-        value=$(/usr/libexec/PlistBuddy -c "Print :${key}" "$processed_plist_path" 2>/dev/null) || return
-    fi
+    while [[ "$value" =~ (\$\(([A-Za-z_][A-Za-z0-9_]*)\)|\$\{([A-Za-z_][A-Za-z0-9_]*)\}) ]]; do
+        token=${BASH_REMATCH[1]}
+        name=${BASH_REMATCH[2]:-${BASH_REMATCH[3]}}
+        replacement=$(printenv "$name" 2>/dev/null) || return
+        prefix=${value%%"$token"*}
+        suffix=${value#*"$token"}
+        value="${prefix}${replacement}${suffix}"
+    done
     if [ -z "$value" ] || [[ "$value" == *"\$("* ]] || [[ "$value" == *"\${"* ]]; then
         return
     fi

--- a/build-tools/upload-symbols.sh
+++ b/build-tools/upload-symbols.sh
@@ -47,6 +47,13 @@ if [ -z "${DWARF_DSYM_FOLDER_PATH}" ]; then
     exit 0
 fi
 
+# A configured Xcode build that only emits DWARF has no dSYM to upload. Keep this check before CLI
+# discovery so builds without symbols do not require posthog-cli.
+if [ -n "${DEBUG_INFORMATION_FORMAT:-}" ] && [ "${DEBUG_INFORMATION_FORMAT}" != "dwarf-with-dsym" ]; then
+    echo "info: Skipping dSYM upload for debug information format '${DEBUG_INFORMATION_FORMAT}'."
+    exit 0
+fi
+
 # Find posthog-cli (Xcode doesn't load shell profiles)
 # Priority: env var override > well-known location > npm global > PATH fallback
 if [ -f "$HOME/.posthog/posthog-cli" ]; then
@@ -154,20 +161,32 @@ fi
 
 resolve_source_plist_value() {
     local key="$1"
-    local plist_path="${INFOPLIST_FILE:-}"
+    local source_plist_path="${INFOPLIST_FILE:-}"
+    local processed_plist_path=""
+    local plist_path=""
     local name
     local value
 
-    if [ -z "$plist_path" ]; then
-        return
-    fi
-    if [[ "$plist_path" != /* ]]; then
-        if [ -z "${SRCROOT:-}" ]; then
-            return
+    if [ -n "$source_plist_path" ] && [[ "$source_plist_path" != /* ]]; then
+        if [ -n "${SRCROOT:-}" ]; then
+            source_plist_path="${SRCROOT}/${source_plist_path}"
+        else
+            source_plist_path=""
         fi
-        plist_path="${SRCROOT}/${plist_path}"
     fi
-    if [ ! -f "$plist_path" ]; then
+    if [ -n "${TARGET_BUILD_DIR:-}" ] && [ -n "${INFOPLIST_PATH:-}" ]; then
+        processed_plist_path="${TARGET_BUILD_DIR}/${INFOPLIST_PATH}"
+    fi
+
+    # Plist preprocessing can replace bare macros that cannot be resolved from the shell environment.
+    # Otherwise prefer the source plist to avoid reading a stale product from a previous build.
+    if [ "${INFOPLIST_PREPROCESS:-}" = "YES" ] && [ -f "$processed_plist_path" ]; then
+        plist_path="$processed_plist_path"
+    elif [ -f "$source_plist_path" ]; then
+        plist_path="$source_plist_path"
+    elif [ -f "$processed_plist_path" ]; then
+        plist_path="$processed_plist_path"
+    else
         return
     fi
 

--- a/build-tools/upload-symbols.sh
+++ b/build-tools/upload-symbols.sh
@@ -194,13 +194,19 @@ resolve_source_plist_value() {
     case "$value" in
         \$\(*\))
             name=${value#\$(}
-            value=$(printenv "${name%)}" 2>/dev/null) || return
+            value=$(printenv "${name%)}" 2>/dev/null) || true
             ;;
         \$\{*\})
             name=${value#\$\{}
-            value=$(printenv "${name%\}}" 2>/dev/null) || return
+            value=$(printenv "${name%\}}" 2>/dev/null) || true
             ;;
     esac
+
+    # Compound substitutions such as $(MAJOR).$(MINOR) are expanded by ProcessInfoPlistFile. Use
+    # that product only when the source value could not be resolved, so stale products never win.
+    if { [ -z "$value" ] || [[ "$value" == *"\$("* ]] || [[ "$value" == *"\${"* ]]; } && [ "$plist_path" != "$processed_plist_path" ] && [ -f "$processed_plist_path" ]; then
+        value=$(/usr/libexec/PlistBuddy -c "Print :${key}" "$processed_plist_path" 2>/dev/null) || return
+    fi
     if [ -z "$value" ] || [[ "$value" == *"\$("* ]] || [[ "$value" == *"\${"* ]]; then
         return
     fi

--- a/build-tools/upload-symbols.sh
+++ b/build-tools/upload-symbols.sh
@@ -23,6 +23,7 @@
 #   POSTHOG_INCLUDE_SOURCE - Set to "1" to include source files in dSYM upload
 #   POSTHOG_SKIP_ON_CONFLICT - Set to "1" to skip symbol sets that already exist
 #                              with different content instead of failing the build
+#   POSTHOG_DSYM_TIMEOUT - Seconds to wait for the current app dSYM before failing (default: 60)
 #   POSTHOG_NO_RELEASE_BIND - Set to "1" to upload symbol sets without binding them to the created
 #                              release (via `dsym upload --no-release-bind`). The release is still
 #                              created; the server resolves it from the `$app_version` /
@@ -40,52 +41,9 @@ if [ -n "${CONFIGURATION}" ] && [ "${CONFIGURATION}" != "Release" ]; then
     exit 0
 fi
 
-# Xcode can start this phase before dsymutil finishes. Declaring the dSYM as an input can create
-# dependency cycles for apps with embedded extensions, so wait until the dSYM belongs to the current
-# executable instead. If it never becomes ready, skip the upload rather than sending stale symbols.
-if [ "${DEBUG_INFORMATION_FORMAT:-}" = "dwarf-with-dsym" ] && [ -n "${DWARF_DSYM_FOLDER_PATH:-}" ] && [ -n "${DWARF_DSYM_FILE_NAME:-}" ] && [ -n "${EXECUTABLE_NAME:-}" ] && [ -n "${TARGET_BUILD_DIR:-}" ] && [ -n "${EXECUTABLE_PATH:-}" ]; then
-    POSTHOG_MAIN_DWARF="${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${EXECUTABLE_NAME}"
-    POSTHOG_APP_EXECUTABLE="${TARGET_BUILD_DIR}/${EXECUTABLE_PATH}"
-    POSTHOG_DSYM_ATTEMPT=1
-    POSTHOG_DSYM_MAX_ATTEMPTS=60
-    POSTHOG_DSYM_READY=0
-
-    while [ "$POSTHOG_DSYM_ATTEMPT" -le "$POSTHOG_DSYM_MAX_ATTEMPTS" ]; do
-        if [ -s "$POSTHOG_MAIN_DWARF" ] && [ -s "$POSTHOG_APP_EXECUTABLE" ]; then
-            POSTHOG_DSYM_UUIDS=$(xcrun dwarfdump --uuid "$POSTHOG_MAIN_DWARF" 2>/dev/null | awk '/^UUID: / {print $2}' | sort)
-            POSTHOG_APP_UUIDS=$(xcrun dwarfdump --uuid "$POSTHOG_APP_EXECUTABLE" 2>/dev/null | awk '/^UUID: / {print $2}' | sort)
-            if [ -n "$POSTHOG_DSYM_UUIDS" ] && [ "$POSTHOG_DSYM_UUIDS" = "$POSTHOG_APP_UUIDS" ]; then
-                POSTHOG_DSYM_READY=1
-                break
-            fi
-        fi
-
-        if [ "$POSTHOG_DSYM_ATTEMPT" -lt "$POSTHOG_DSYM_MAX_ATTEMPTS" ]; then
-            sleep 1
-        fi
-        POSTHOG_DSYM_ATTEMPT=$((POSTHOG_DSYM_ATTEMPT + 1))
-    done
-
-    if [ "$POSTHOG_DSYM_READY" -ne 1 ]; then
-        echo "warning: Main app dSYM was not ready after ${POSTHOG_DSYM_MAX_ATTEMPTS} attempts; skipping upload: $POSTHOG_MAIN_DWARF"
-        exit 0
-    fi
-fi
-
-# Validate environment
+# Validate the path before looking for posthog-cli.
 if [ -z "${DWARF_DSYM_FOLDER_PATH}" ]; then
     echo "warning: DWARF_DSYM_FOLDER_PATH not set"
-    exit 0
-fi
-
-if [ ! -d "${DWARF_DSYM_FOLDER_PATH}" ]; then
-    echo "warning: dSYM folder not found: ${DWARF_DSYM_FOLDER_PATH}"
-    exit 0
-fi
-
-# Check if folder contains any dSYM bundles
-if [ -z "$(find "${DWARF_DSYM_FOLDER_PATH}" -name '*.dSYM' -type d 2>/dev/null)" ]; then
-    echo "info: No dSYM bundles found in ${DWARF_DSYM_FOLDER_PATH}"
     exit 0
 fi
 
@@ -120,6 +78,57 @@ if [ -z "$PH_CLI_PATH" ] || [ ! -x "$PH_CLI_PATH" ]; then
     exit 1
 fi
 
+# Xcode can start this phase before dsymutil finishes. Declaring the dSYM as an input can create
+# dependency cycles for apps with embedded extensions, so wait until the dSYM belongs to the current
+# executable instead. Fail on timeout rather than letting a release ship without its symbols.
+if [ "${DEBUG_INFORMATION_FORMAT:-}" = "dwarf-with-dsym" ] && [ -n "${DWARF_DSYM_FILE_NAME:-}" ] && [ -n "${EXECUTABLE_NAME:-}" ] && [ -n "${TARGET_BUILD_DIR:-}" ] && [ -n "${EXECUTABLE_PATH:-}" ]; then
+    POSTHOG_MAIN_DWARF="${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${EXECUTABLE_NAME}"
+    POSTHOG_APP_EXECUTABLE="${TARGET_BUILD_DIR}/${EXECUTABLE_PATH}"
+    POSTHOG_DSYM_TIMEOUT="${POSTHOG_DSYM_TIMEOUT:-60}"
+    POSTHOG_DSYM_WAITED=0
+    POSTHOG_DSYM_READY=0
+
+    case "$POSTHOG_DSYM_TIMEOUT" in
+        ''|*[!0-9]*)
+            echo "error: POSTHOG_DSYM_TIMEOUT must be a non-negative integer"
+            exit 1
+            ;;
+    esac
+
+    while [ "$POSTHOG_DSYM_WAITED" -le "$POSTHOG_DSYM_TIMEOUT" ]; do
+        if [ -s "$POSTHOG_MAIN_DWARF" ] && [ -s "$POSTHOG_APP_EXECUTABLE" ]; then
+            POSTHOG_DSYM_UUIDS=$(xcrun dwarfdump --uuid "$POSTHOG_MAIN_DWARF" 2>/dev/null | awk '/^UUID: / {print $2}' | sort)
+            POSTHOG_APP_UUIDS=$(xcrun dwarfdump --uuid "$POSTHOG_APP_EXECUTABLE" 2>/dev/null | awk '/^UUID: / {print $2}' | sort)
+            if [ -n "$POSTHOG_DSYM_UUIDS" ] && [ "$POSTHOG_DSYM_UUIDS" = "$POSTHOG_APP_UUIDS" ]; then
+                POSTHOG_DSYM_READY=1
+                break
+            fi
+        fi
+
+        if [ "$POSTHOG_DSYM_WAITED" -lt "$POSTHOG_DSYM_TIMEOUT" ]; then
+            sleep 1
+        fi
+        POSTHOG_DSYM_WAITED=$((POSTHOG_DSYM_WAITED + 1))
+    done
+
+    if [ "$POSTHOG_DSYM_READY" -ne 1 ]; then
+        echo "error: Main app dSYM was not ready after ${POSTHOG_DSYM_TIMEOUT} seconds: $POSTHOG_MAIN_DWARF"
+        exit 1
+    fi
+fi
+
+if [ ! -d "${DWARF_DSYM_FOLDER_PATH}" ]; then
+    echo "warning: dSYM folder not found: ${DWARF_DSYM_FOLDER_PATH}"
+    exit 0
+fi
+
+# Check if folder contains any dSYM bundles. This must run after the readiness wait because dsymutil
+# may not have created the bundle when the upload phase starts.
+if [ -z "$(find "${DWARF_DSYM_FOLDER_PATH}" -name '*.dSYM' -type d 2>/dev/null)" ]; then
+    echo "info: No dSYM bundles found in ${DWARF_DSYM_FOLDER_PATH}"
+    exit 0
+fi
+
 # Enforce minimum posthog-cli version (required for --release-name / --release-version flags)
 MIN_POSTHOG_CLI_VERSION="0.7.7"
 if [ "${POSTHOG_SKIP_ON_CONFLICT}" = "1" ]; then
@@ -145,6 +154,7 @@ fi
 resolve_source_plist_value() {
     local key="$1"
     local plist_path="${INFOPLIST_FILE:-}"
+    local name
     local value
 
     if [ -z "$plist_path" ]; then
@@ -161,6 +171,16 @@ resolve_source_plist_value() {
     fi
 
     value=$(/usr/libexec/PlistBuddy -c "Print :${key}" "$plist_path" 2>/dev/null) || return
+    case "$value" in
+        \$\(*\))
+            name=${value#\$(}
+            value=$(printenv "${name%)}" 2>/dev/null) || return
+            ;;
+        \$\{*\})
+            name=${value#\$\{}
+            value=$(printenv "${name%\}}" 2>/dev/null) || return
+            ;;
+    esac
     if [ -z "$value" ] || [[ "$value" == *"\$("* ]] || [[ "$value" == *"\${"* ]]; then
         return
     fi

--- a/build-tools/upload-symbols.sh
+++ b/build-tools/upload-symbols.sh
@@ -85,6 +85,7 @@ if [ "${DEBUG_INFORMATION_FORMAT:-}" = "dwarf-with-dsym" ] && [ -n "${DWARF_DSYM
     POSTHOG_MAIN_DWARF="${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${EXECUTABLE_NAME}"
     POSTHOG_APP_EXECUTABLE="${TARGET_BUILD_DIR}/${EXECUTABLE_PATH}"
     POSTHOG_DSYM_TIMEOUT="${POSTHOG_DSYM_TIMEOUT:-60}"
+    POSTHOG_LSOF_PATH="${POSTHOG_LSOF_PATH:-/usr/sbin/lsof}"
     POSTHOG_DSYM_WAITED=0
     POSTHOG_DSYM_READY=0
 
@@ -99,7 +100,7 @@ if [ "${DEBUG_INFORMATION_FORMAT:-}" = "dwarf-with-dsym" ] && [ -n "${DWARF_DSYM
         if [ -s "$POSTHOG_MAIN_DWARF" ] && [ -s "$POSTHOG_APP_EXECUTABLE" ]; then
             POSTHOG_DSYM_UUIDS=$(xcrun dwarfdump --uuid "$POSTHOG_MAIN_DWARF" 2>/dev/null | awk '/^UUID: / {print $2}' | sort)
             POSTHOG_APP_UUIDS=$(xcrun dwarfdump --uuid "$POSTHOG_APP_EXECUTABLE" 2>/dev/null | awk '/^UUID: / {print $2}' | sort)
-            if [ -n "$POSTHOG_DSYM_UUIDS" ] && [ "$POSTHOG_DSYM_UUIDS" = "$POSTHOG_APP_UUIDS" ]; then
+            if [ -n "$POSTHOG_DSYM_UUIDS" ] && [ "$POSTHOG_DSYM_UUIDS" = "$POSTHOG_APP_UUIDS" ] && ! "$POSTHOG_LSOF_PATH" -a -d 0-9 -F a -- "$POSTHOG_MAIN_DWARF" 2>/dev/null | grep -Eq '^a[uw]$'; then
                 POSTHOG_DSYM_READY=1
                 break
             fi

--- a/build-tools/upload-symbols.test.sh
+++ b/build-tools/upload-symbols.test.sh
@@ -33,6 +33,7 @@ create_fixture() {
     APP_EXECUTABLE="${TARGET_BUILD_DIR}/${EXECUTABLE_PATH}"
     CLI_ARGS_FILE="${FIXTURE_DIR}/cli-args"
     DWARFDUMP_ATTEMPTS="${FIXTURE_DIR}/dwarfdump-attempts"
+    LSOF_ATTEMPTS="${FIXTURE_DIR}/lsof-attempts"
     XCRUN_MARKER="${FIXTURE_DIR}/xcrun-ran"
     TEST_CONFIGURATION="Release"
     TEST_DEBUG_INFORMATION_FORMAT="dwarf-with-dsym"
@@ -59,6 +60,12 @@ EOF
 exit 0
 EOF
     chmod +x "$FAKE_BIN/sleep"
+
+    cat > "$FAKE_BIN/lsof" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+    chmod +x "$FAKE_BIN/lsof"
 }
 
 write_plist() {
@@ -87,6 +94,7 @@ run_upload() {
         CONFIGURATION="$TEST_CONFIGURATION" \
         DEBUG_INFORMATION_FORMAT="$TEST_DEBUG_INFORMATION_FORMAT" \
         POSTHOG_DSYM_TIMEOUT="$TEST_DSYM_TIMEOUT" \
+        POSTHOG_LSOF_PATH="$FAKE_BIN/lsof" \
         DWARF_DSYM_FOLDER_PATH="$DSYM_FOLDER" \
         DWARF_DSYM_FILE_NAME="$DSYM_NAME" \
         EXECUTABLE_NAME="$EXECUTABLE_NAME" \
@@ -101,6 +109,7 @@ run_upload() {
         BUILD_NUMBER="$TEST_BUILD_NUMBER" \
         TEST_CLI_ARGS_FILE="$CLI_ARGS_FILE" \
         TEST_DWARFDUMP_ATTEMPTS="$DWARFDUMP_ATTEMPTS" \
+        TEST_LSOF_ATTEMPTS="$LSOF_ATTEMPTS" \
         TEST_XCRUN_MARKER="$XCRUN_MARKER" \
         bash "$UPLOAD_SCRIPT" 2>&1)
     STATUS=$?
@@ -139,6 +148,37 @@ EOF
     assert_file_contains_line "$CLI_ARGS_FILE" "2.10.0"
     assert_file_contains_line "$CLI_ARGS_FILE" "--build"
     assert_file_contains_line "$CLI_ARGS_FILE" "154"
+}
+
+test_waits_until_matching_dsym_is_closed_for_writing() {
+    create_fixture "still-writing"
+    write_plist "$SRC_ROOT/Config/Info.plist" "2.10.0" "154"
+    TEST_INFOPLIST_FILE="Config/Info.plist"
+
+    cat > "$FAKE_BIN/xcrun" <<'EOF'
+#!/bin/sh
+printf 'UUID: CURRENT-UUID (arm64) %s\n' "$3"
+EOF
+    chmod +x "$FAKE_BIN/xcrun"
+
+    cat > "$FAKE_BIN/lsof" <<'EOF'
+#!/bin/sh
+attempts=$(cat "$TEST_LSOF_ATTEMPTS" 2>/dev/null || printf 0)
+attempts=$((attempts + 1))
+printf '%s' "$attempts" > "$TEST_LSOF_ATTEMPTS"
+if [ "$attempts" -lt 3 ]; then
+    printf 'p123\nf4\naw\n'
+    exit 0
+fi
+exit 1
+EOF
+    chmod +x "$FAKE_BIN/lsof"
+
+    run_upload
+
+    [ "$STATUS" -eq 0 ] || fail "Expected upload to wait for the dSYM writer: $OUTPUT"
+    [ "$(cat "$LSOF_ATTEMPTS")" = "3" ] || fail "Expected three checks for an active dSYM writer"
+    [ -f "$CLI_ARGS_FILE" ] || fail "Expected posthog-cli to run after the writer closed"
 }
 
 test_fails_when_dsym_never_matches() {
@@ -215,6 +255,7 @@ test_falls_back_for_unresolved_source_plist_versions() {
 
 bash -n "$UPLOAD_SCRIPT"
 test_waits_for_current_dsym_and_uses_source_plist_versions
+test_waits_until_matching_dsym_is_closed_for_writing
 test_fails_when_dsym_never_matches
 test_checks_for_cli_before_waiting_for_dsym
 test_resolves_custom_build_setting_references

--- a/build-tools/upload-symbols.test.sh
+++ b/build-tools/upload-symbols.test.sh
@@ -262,6 +262,20 @@ test_prefers_processed_plist_when_preprocessing_is_enabled() {
     assert_file_contains_line "$CLI_ARGS_FILE" "154"
 }
 
+test_uses_processed_plist_for_compound_build_settings() {
+    create_fixture "compound-build-settings"
+    write_plist "$SRC_ROOT/Config/Info.plist" "\$(VERSION_MAJOR).\$(VERSION_MINOR)" "\$(BUILD_PREFIX)\$(BUILD_NUMBER)"
+    TEST_INFOPLIST_FILE="$SRC_ROOT/Config/Info.plist"
+    TEST_INFOPLIST_PATH="ExampleApp.app/Info.plist"
+    write_plist "$TARGET_BUILD_DIR/$TEST_INFOPLIST_PATH" "2.10.0" "154"
+
+    run_upload
+
+    [ "$STATUS" -eq 0 ] || fail "Expected processed compound versions to resolve: $OUTPUT"
+    assert_file_contains_line "$CLI_ARGS_FILE" "2.10.0"
+    assert_file_contains_line "$CLI_ARGS_FILE" "154"
+}
+
 test_skips_cli_lookup_when_build_does_not_emit_dsyms() {
     create_fixture "dwarf-only"
     write_plist "$SRC_ROOT/Config/Info.plist" "2.10.0" "154"
@@ -296,6 +310,7 @@ test_fails_when_dsym_never_matches
 test_checks_for_cli_before_waiting_for_dsym
 test_resolves_custom_build_setting_references
 test_prefers_processed_plist_when_preprocessing_is_enabled
+test_uses_processed_plist_for_compound_build_settings
 test_skips_cli_lookup_when_build_does_not_emit_dsyms
 test_falls_back_for_unresolved_source_plist_versions
 

--- a/build-tools/upload-symbols.test.sh
+++ b/build-tools/upload-symbols.test.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+UPLOAD_SCRIPT="${ROOT_DIR}/build-tools/upload-symbols.sh"
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+fail() {
+    echo "error: $*" >&2
+    exit 1
+}
+
+assert_file_contains_line() {
+    local file="$1"
+    local expected="$2"
+    grep -Fxq -- "$expected" "$file" || fail "Expected '$expected' in $file"
+}
+
+create_fixture() {
+    local name="$1"
+    FIXTURE_DIR="${TEMP_DIR}/${name}"
+    HOME_DIR="${FIXTURE_DIR}/home"
+    FAKE_BIN="${FIXTURE_DIR}/bin"
+    SRC_ROOT="${FIXTURE_DIR}/source"
+    DSYM_FOLDER="${FIXTURE_DIR}/dSYMs"
+    DSYM_NAME="ExampleApp.app.dSYM"
+    EXECUTABLE_NAME="ExampleApp"
+    MAIN_DWARF="${DSYM_FOLDER}/${DSYM_NAME}/Contents/Resources/DWARF/${EXECUTABLE_NAME}"
+    TARGET_BUILD_DIR="${FIXTURE_DIR}/build"
+    EXECUTABLE_PATH="ExampleApp.app/ExampleApp"
+    APP_EXECUTABLE="${TARGET_BUILD_DIR}/${EXECUTABLE_PATH}"
+    CLI_ARGS_FILE="${FIXTURE_DIR}/cli-args"
+    DWARFDUMP_ATTEMPTS="${FIXTURE_DIR}/dwarfdump-attempts"
+
+    mkdir -p "$HOME_DIR/.posthog" "$FAKE_BIN" "$SRC_ROOT/Config" "$(dirname "$MAIN_DWARF")" "$(dirname "$APP_EXECUTABLE")"
+    printf 'dwarf' > "$MAIN_DWARF"
+    printf 'executable' > "$APP_EXECUTABLE"
+
+    cat > "$HOME_DIR/.posthog/posthog-cli" <<'EOF'
+#!/bin/sh
+if [ "$1" = "--version" ]; then
+    echo "posthog-cli 0.10.0"
+    exit 0
+fi
+printf '%s\n' "$@" > "$TEST_CLI_ARGS_FILE"
+EOF
+    chmod +x "$HOME_DIR/.posthog/posthog-cli"
+
+    cat > "$FAKE_BIN/sleep" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+    chmod +x "$FAKE_BIN/sleep"
+}
+
+write_plist() {
+    local path="$1"
+    local release_version="$2"
+    local build_version="$3"
+    cat > "$path" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleShortVersionString</key>
+    <string>${release_version}</string>
+    <key>CFBundleVersion</key>
+    <string>${build_version}</string>
+</dict>
+</plist>
+EOF
+}
+
+run_upload() {
+    set +e
+    OUTPUT=$(env \
+        HOME="$HOME_DIR" \
+        PATH="$FAKE_BIN:$PATH" \
+        CONFIGURATION="${TEST_CONFIGURATION:-Release}" \
+        DEBUG_INFORMATION_FORMAT="${TEST_DEBUG_INFORMATION_FORMAT:-dwarf-with-dsym}" \
+        DWARF_DSYM_FOLDER_PATH="$DSYM_FOLDER" \
+        DWARF_DSYM_FILE_NAME="$DSYM_NAME" \
+        EXECUTABLE_NAME="$EXECUTABLE_NAME" \
+        TARGET_BUILD_DIR="$TARGET_BUILD_DIR" \
+        EXECUTABLE_PATH="$EXECUTABLE_PATH" \
+        SRCROOT="$SRC_ROOT" \
+        INFOPLIST_FILE="$TEST_INFOPLIST_FILE" \
+        PRODUCT_BUNDLE_IDENTIFIER="com.example.app" \
+        MARKETING_VERSION="1.0" \
+        CURRENT_PROJECT_VERSION="1" \
+        TEST_CLI_ARGS_FILE="$CLI_ARGS_FILE" \
+        TEST_DWARFDUMP_ATTEMPTS="$DWARFDUMP_ATTEMPTS" \
+        bash "$UPLOAD_SCRIPT" 2>&1)
+    STATUS=$?
+    set -e
+}
+
+test_waits_for_current_dsym_and_uses_source_plist_versions() {
+    create_fixture "ready"
+    write_plist "$SRC_ROOT/Config/Info.plist" "2.10.0" "154"
+    TEST_INFOPLIST_FILE="Config/Info.plist"
+
+    cat > "$FAKE_BIN/xcrun" <<'EOF'
+#!/bin/sh
+case "$3" in
+    *.dSYM/*)
+        attempts=$(cat "$TEST_DWARFDUMP_ATTEMPTS" 2>/dev/null || printf 0)
+        attempts=$((attempts + 1))
+        printf '%s' "$attempts" > "$TEST_DWARFDUMP_ATTEMPTS"
+        if [ "$attempts" -lt 3 ]; then
+            printf 'UUID: OLD-UUID (arm64) %s\n' "$3"
+        else
+            printf 'UUID: CURRENT-UUID (arm64) %s\n' "$3"
+        fi
+        ;;
+    *) printf 'UUID: CURRENT-UUID (arm64) %s\n' "$3" ;;
+esac
+EOF
+    chmod +x "$FAKE_BIN/xcrun"
+
+    run_upload
+
+    [ "$STATUS" -eq 0 ] || fail "Expected upload to succeed, got status $STATUS: $OUTPUT"
+    [ "$(cat "$DWARFDUMP_ATTEMPTS")" = "3" ] || fail "Expected three dSYM readiness attempts"
+    [ -f "$CLI_ARGS_FILE" ] || fail "Expected posthog-cli to run"
+    assert_file_contains_line "$CLI_ARGS_FILE" "--release-version"
+    assert_file_contains_line "$CLI_ARGS_FILE" "2.10.0"
+    assert_file_contains_line "$CLI_ARGS_FILE" "--build"
+    assert_file_contains_line "$CLI_ARGS_FILE" "154"
+}
+
+test_skips_upload_when_dsym_never_matches() {
+    create_fixture "not-ready"
+    write_plist "$SRC_ROOT/Config/Info.plist" "2.10.0" "154"
+    TEST_INFOPLIST_FILE="Config/Info.plist"
+
+    cat > "$FAKE_BIN/xcrun" <<'EOF'
+#!/bin/sh
+case "$3" in
+    *.dSYM/*) printf 'UUID: OLD-UUID (arm64) %s\n' "$3" ;;
+    *) printf 'UUID: CURRENT-UUID (arm64) %s\n' "$3" ;;
+esac
+EOF
+    chmod +x "$FAKE_BIN/xcrun"
+
+    run_upload
+
+    [ "$STATUS" -eq 0 ] || fail "Expected an unavailable dSYM to skip without failing the build"
+    [[ "$OUTPUT" == *"skipping upload"* ]] || fail "Expected a warning when the dSYM stays unavailable"
+    [ ! -f "$CLI_ARGS_FILE" ] || fail "posthog-cli must not run with a stale dSYM"
+}
+
+test_falls_back_for_unresolved_source_plist_versions() {
+    create_fixture "fallback"
+    write_plist "$SRC_ROOT/Config/Info.plist" "\${MARKETING_VERSION}" "\$(CURRENT_PROJECT_VERSION)"
+    TEST_INFOPLIST_FILE="$SRC_ROOT/Config/Info.plist"
+    TEST_DEBUG_INFORMATION_FORMAT="dwarf"
+
+    run_upload
+
+    [ "$STATUS" -eq 0 ] || fail "Expected upload with fallback versions to succeed: $OUTPUT"
+    assert_file_contains_line "$CLI_ARGS_FILE" "--release-version"
+    assert_file_contains_line "$CLI_ARGS_FILE" "1.0"
+    assert_file_contains_line "$CLI_ARGS_FILE" "--build"
+    assert_file_contains_line "$CLI_ARGS_FILE" "1"
+}
+
+bash -n "$UPLOAD_SCRIPT"
+test_waits_for_current_dsym_and_uses_source_plist_versions
+test_skips_upload_when_dsym_never_matches
+test_falls_back_for_unresolved_source_plist_versions
+
+echo "upload-symbols tests passed"

--- a/build-tools/upload-symbols.test.sh
+++ b/build-tools/upload-symbols.test.sh
@@ -33,6 +33,12 @@ create_fixture() {
     APP_EXECUTABLE="${TARGET_BUILD_DIR}/${EXECUTABLE_PATH}"
     CLI_ARGS_FILE="${FIXTURE_DIR}/cli-args"
     DWARFDUMP_ATTEMPTS="${FIXTURE_DIR}/dwarfdump-attempts"
+    XCRUN_MARKER="${FIXTURE_DIR}/xcrun-ran"
+    TEST_CONFIGURATION="Release"
+    TEST_DEBUG_INFORMATION_FORMAT="dwarf-with-dsym"
+    TEST_DSYM_TIMEOUT="60"
+    TEST_APP_VERSION=""
+    TEST_BUILD_NUMBER=""
 
     mkdir -p "$HOME_DIR/.posthog" "$FAKE_BIN" "$SRC_ROOT/Config" "$(dirname "$MAIN_DWARF")" "$(dirname "$APP_EXECUTABLE")"
     printf 'dwarf' > "$MAIN_DWARF"
@@ -77,9 +83,10 @@ run_upload() {
     set +e
     OUTPUT=$(env \
         HOME="$HOME_DIR" \
-        PATH="$FAKE_BIN:$PATH" \
-        CONFIGURATION="${TEST_CONFIGURATION:-Release}" \
-        DEBUG_INFORMATION_FORMAT="${TEST_DEBUG_INFORMATION_FORMAT:-dwarf-with-dsym}" \
+        PATH="$FAKE_BIN:/usr/bin:/bin" \
+        CONFIGURATION="$TEST_CONFIGURATION" \
+        DEBUG_INFORMATION_FORMAT="$TEST_DEBUG_INFORMATION_FORMAT" \
+        POSTHOG_DSYM_TIMEOUT="$TEST_DSYM_TIMEOUT" \
         DWARF_DSYM_FOLDER_PATH="$DSYM_FOLDER" \
         DWARF_DSYM_FILE_NAME="$DSYM_NAME" \
         EXECUTABLE_NAME="$EXECUTABLE_NAME" \
@@ -90,8 +97,11 @@ run_upload() {
         PRODUCT_BUNDLE_IDENTIFIER="com.example.app" \
         MARKETING_VERSION="1.0" \
         CURRENT_PROJECT_VERSION="1" \
+        APP_VERSION="$TEST_APP_VERSION" \
+        BUILD_NUMBER="$TEST_BUILD_NUMBER" \
         TEST_CLI_ARGS_FILE="$CLI_ARGS_FILE" \
         TEST_DWARFDUMP_ATTEMPTS="$DWARFDUMP_ATTEMPTS" \
+        TEST_XCRUN_MARKER="$XCRUN_MARKER" \
         bash "$UPLOAD_SCRIPT" 2>&1)
     STATUS=$?
     set -e
@@ -131,10 +141,11 @@ EOF
     assert_file_contains_line "$CLI_ARGS_FILE" "154"
 }
 
-test_skips_upload_when_dsym_never_matches() {
+test_fails_when_dsym_never_matches() {
     create_fixture "not-ready"
     write_plist "$SRC_ROOT/Config/Info.plist" "2.10.0" "154"
     TEST_INFOPLIST_FILE="Config/Info.plist"
+    TEST_DSYM_TIMEOUT="2"
 
     cat > "$FAKE_BIN/xcrun" <<'EOF'
 #!/bin/sh
@@ -147,14 +158,49 @@ EOF
 
     run_upload
 
-    [ "$STATUS" -eq 0 ] || fail "Expected an unavailable dSYM to skip without failing the build"
-    [[ "$OUTPUT" == *"skipping upload"* ]] || fail "Expected a warning when the dSYM stays unavailable"
+    [ "$STATUS" -eq 1 ] || fail "Expected an unavailable dSYM to fail the build"
+    [[ "$OUTPUT" == *"was not ready after 2 seconds"* ]] || fail "Expected a timeout error when the dSYM stays unavailable"
     [ ! -f "$CLI_ARGS_FILE" ] || fail "posthog-cli must not run with a stale dSYM"
+}
+
+test_checks_for_cli_before_waiting_for_dsym() {
+    create_fixture "missing-cli"
+    write_plist "$SRC_ROOT/Config/Info.plist" "2.10.0" "154"
+    TEST_INFOPLIST_FILE="Config/Info.plist"
+    rm "$HOME_DIR/.posthog/posthog-cli"
+
+    cat > "$FAKE_BIN/xcrun" <<'EOF'
+#!/bin/sh
+touch "$TEST_XCRUN_MARKER"
+exit 1
+EOF
+    chmod +x "$FAKE_BIN/xcrun"
+
+    run_upload
+
+    [ "$STATUS" -eq 1 ] || fail "Expected a missing CLI to fail the build"
+    [[ "$OUTPUT" == *"posthog-cli not found"* ]] || fail "Expected the missing CLI error"
+    [ ! -f "$XCRUN_MARKER" ] || fail "dSYM polling must not run before checking for posthog-cli"
+}
+
+test_resolves_custom_build_setting_references() {
+    create_fixture "custom-build-settings"
+    write_plist "$SRC_ROOT/Config/Info.plist" "\$(APP_VERSION)" "\${BUILD_NUMBER}"
+    TEST_INFOPLIST_FILE="$SRC_ROOT/Config/Info.plist"
+    TEST_DEBUG_INFORMATION_FORMAT="dwarf"
+    TEST_APP_VERSION="9.9.9"
+    TEST_BUILD_NUMBER="321"
+
+    run_upload
+
+    [ "$STATUS" -eq 0 ] || fail "Expected custom build-setting versions to resolve: $OUTPUT"
+    assert_file_contains_line "$CLI_ARGS_FILE" "9.9.9"
+    assert_file_contains_line "$CLI_ARGS_FILE" "321"
 }
 
 test_falls_back_for_unresolved_source_plist_versions() {
     create_fixture "fallback"
-    write_plist "$SRC_ROOT/Config/Info.plist" "\${MARKETING_VERSION}" "\$(CURRENT_PROJECT_VERSION)"
+    write_plist "$SRC_ROOT/Config/Info.plist" "\$(MISSING_VERSION)" "\$(A)-\$(B)"
     TEST_INFOPLIST_FILE="$SRC_ROOT/Config/Info.plist"
     TEST_DEBUG_INFORMATION_FORMAT="dwarf"
 
@@ -169,7 +215,9 @@ test_falls_back_for_unresolved_source_plist_versions() {
 
 bash -n "$UPLOAD_SCRIPT"
 test_waits_for_current_dsym_and_uses_source_plist_versions
-test_skips_upload_when_dsym_never_matches
+test_fails_when_dsym_never_matches
+test_checks_for_cli_before_waiting_for_dsym
+test_resolves_custom_build_setting_references
 test_falls_back_for_unresolved_source_plist_versions
 
 echo "upload-symbols tests passed"

--- a/build-tools/upload-symbols.test.sh
+++ b/build-tools/upload-symbols.test.sh
@@ -40,6 +40,8 @@ create_fixture() {
     TEST_DSYM_TIMEOUT="60"
     TEST_APP_VERSION=""
     TEST_BUILD_NUMBER=""
+    TEST_INFOPLIST_PREPROCESS="NO"
+    TEST_INFOPLIST_PATH=""
 
     mkdir -p "$HOME_DIR/.posthog" "$FAKE_BIN" "$SRC_ROOT/Config" "$(dirname "$MAIN_DWARF")" "$(dirname "$APP_EXECUTABLE")"
     printf 'dwarf' > "$MAIN_DWARF"
@@ -66,6 +68,12 @@ EOF
 exit 1
 EOF
     chmod +x "$FAKE_BIN/lsof"
+
+    cat > "$FAKE_BIN/xcrun" <<'EOF'
+#!/bin/sh
+printf 'UUID: CURRENT-UUID (arm64) %s\n' "$3"
+EOF
+    chmod +x "$FAKE_BIN/xcrun"
 }
 
 write_plist() {
@@ -102,6 +110,8 @@ run_upload() {
         EXECUTABLE_PATH="$EXECUTABLE_PATH" \
         SRCROOT="$SRC_ROOT" \
         INFOPLIST_FILE="$TEST_INFOPLIST_FILE" \
+        INFOPLIST_PREPROCESS="$TEST_INFOPLIST_PREPROCESS" \
+        INFOPLIST_PATH="$TEST_INFOPLIST_PATH" \
         PRODUCT_BUNDLE_IDENTIFIER="com.example.app" \
         MARKETING_VERSION="1.0" \
         CURRENT_PROJECT_VERSION="1" \
@@ -227,7 +237,6 @@ test_resolves_custom_build_setting_references() {
     create_fixture "custom-build-settings"
     write_plist "$SRC_ROOT/Config/Info.plist" "\$(APP_VERSION)" "\${BUILD_NUMBER}"
     TEST_INFOPLIST_FILE="$SRC_ROOT/Config/Info.plist"
-    TEST_DEBUG_INFORMATION_FORMAT="dwarf"
     TEST_APP_VERSION="9.9.9"
     TEST_BUILD_NUMBER="321"
 
@@ -238,11 +247,38 @@ test_resolves_custom_build_setting_references() {
     assert_file_contains_line "$CLI_ARGS_FILE" "321"
 }
 
+test_prefers_processed_plist_when_preprocessing_is_enabled() {
+    create_fixture "preprocessed"
+    write_plist "$SRC_ROOT/Config/Info.plist" "APP_VERSION" "APP_BUILD"
+    TEST_INFOPLIST_FILE="$SRC_ROOT/Config/Info.plist"
+    TEST_INFOPLIST_PREPROCESS="YES"
+    TEST_INFOPLIST_PATH="ExampleApp.app/Info.plist"
+    write_plist "$TARGET_BUILD_DIR/$TEST_INFOPLIST_PATH" "2.10.0" "154"
+
+    run_upload
+
+    [ "$STATUS" -eq 0 ] || fail "Expected preprocessed versions to resolve: $OUTPUT"
+    assert_file_contains_line "$CLI_ARGS_FILE" "2.10.0"
+    assert_file_contains_line "$CLI_ARGS_FILE" "154"
+}
+
+test_skips_cli_lookup_when_build_does_not_emit_dsyms() {
+    create_fixture "dwarf-only"
+    write_plist "$SRC_ROOT/Config/Info.plist" "2.10.0" "154"
+    TEST_INFOPLIST_FILE="$SRC_ROOT/Config/Info.plist"
+    TEST_DEBUG_INFORMATION_FORMAT="dwarf"
+    rm "$HOME_DIR/.posthog/posthog-cli"
+
+    run_upload
+
+    [ "$STATUS" -eq 0 ] || fail "Expected a DWARF-only build to skip symbol upload"
+    [[ "$OUTPUT" == *"Skipping dSYM upload for debug information format 'dwarf'"* ]] || fail "Expected the DWARF-only skip message"
+}
+
 test_falls_back_for_unresolved_source_plist_versions() {
     create_fixture "fallback"
     write_plist "$SRC_ROOT/Config/Info.plist" "\$(MISSING_VERSION)" "\$(A)-\$(B)"
     TEST_INFOPLIST_FILE="$SRC_ROOT/Config/Info.plist"
-    TEST_DEBUG_INFORMATION_FORMAT="dwarf"
 
     run_upload
 
@@ -259,6 +295,8 @@ test_waits_until_matching_dsym_is_closed_for_writing
 test_fails_when_dsym_never_matches
 test_checks_for_cli_before_waiting_for_dsym
 test_resolves_custom_build_setting_references
+test_prefers_processed_plist_when_preprocessing_is_enabled
+test_skips_cli_lookup_when_build_does_not_emit_dsyms
 test_falls_back_for_unresolved_source_plist_versions
 
 echo "upload-symbols tests passed"

--- a/build-tools/upload-symbols.test.sh
+++ b/build-tools/upload-symbols.test.sh
@@ -40,6 +40,9 @@ create_fixture() {
     TEST_DSYM_TIMEOUT="60"
     TEST_APP_VERSION=""
     TEST_BUILD_NUMBER=""
+    TEST_VERSION_MAJOR=""
+    TEST_VERSION_MINOR=""
+    TEST_BUILD_PREFIX=""
     TEST_INFOPLIST_PREPROCESS="NO"
     TEST_INFOPLIST_PATH=""
 
@@ -117,6 +120,9 @@ run_upload() {
         CURRENT_PROJECT_VERSION="1" \
         APP_VERSION="$TEST_APP_VERSION" \
         BUILD_NUMBER="$TEST_BUILD_NUMBER" \
+        VERSION_MAJOR="$TEST_VERSION_MAJOR" \
+        VERSION_MINOR="$TEST_VERSION_MINOR" \
+        BUILD_PREFIX="$TEST_BUILD_PREFIX" \
         TEST_CLI_ARGS_FILE="$CLI_ARGS_FILE" \
         TEST_DWARFDUMP_ATTEMPTS="$DWARFDUMP_ATTEMPTS" \
         TEST_LSOF_ATTEMPTS="$LSOF_ATTEMPTS" \
@@ -247,31 +253,31 @@ test_resolves_custom_build_setting_references() {
     assert_file_contains_line "$CLI_ARGS_FILE" "321"
 }
 
-test_prefers_processed_plist_when_preprocessing_is_enabled() {
+test_falls_back_for_preprocessed_plist_values() {
     create_fixture "preprocessed"
     write_plist "$SRC_ROOT/Config/Info.plist" "APP_VERSION" "APP_BUILD"
     TEST_INFOPLIST_FILE="$SRC_ROOT/Config/Info.plist"
     TEST_INFOPLIST_PREPROCESS="YES"
-    TEST_INFOPLIST_PATH="ExampleApp.app/Info.plist"
-    write_plist "$TARGET_BUILD_DIR/$TEST_INFOPLIST_PATH" "2.10.0" "154"
 
     run_upload
 
-    [ "$STATUS" -eq 0 ] || fail "Expected preprocessed versions to resolve: $OUTPUT"
-    assert_file_contains_line "$CLI_ARGS_FILE" "2.10.0"
-    assert_file_contains_line "$CLI_ARGS_FILE" "154"
+    [ "$STATUS" -eq 0 ] || fail "Expected preprocessed plist values to use Xcode fallbacks: $OUTPUT"
+    assert_file_contains_line "$CLI_ARGS_FILE" "1.0"
+    assert_file_contains_line "$CLI_ARGS_FILE" "1"
 }
 
-test_uses_processed_plist_for_compound_build_settings() {
+test_resolves_compound_build_settings() {
     create_fixture "compound-build-settings"
     write_plist "$SRC_ROOT/Config/Info.plist" "\$(VERSION_MAJOR).\$(VERSION_MINOR)" "\$(BUILD_PREFIX)\$(BUILD_NUMBER)"
     TEST_INFOPLIST_FILE="$SRC_ROOT/Config/Info.plist"
-    TEST_INFOPLIST_PATH="ExampleApp.app/Info.plist"
-    write_plist "$TARGET_BUILD_DIR/$TEST_INFOPLIST_PATH" "2.10.0" "154"
+    TEST_VERSION_MAJOR="2"
+    TEST_VERSION_MINOR="10.0"
+    TEST_BUILD_PREFIX="1"
+    TEST_BUILD_NUMBER="54"
 
     run_upload
 
-    [ "$STATUS" -eq 0 ] || fail "Expected processed compound versions to resolve: $OUTPUT"
+    [ "$STATUS" -eq 0 ] || fail "Expected compound build settings to resolve: $OUTPUT"
     assert_file_contains_line "$CLI_ARGS_FILE" "2.10.0"
     assert_file_contains_line "$CLI_ARGS_FILE" "154"
 }
@@ -309,8 +315,8 @@ test_waits_until_matching_dsym_is_closed_for_writing
 test_fails_when_dsym_never_matches
 test_checks_for_cli_before_waiting_for_dsym
 test_resolves_custom_build_setting_references
-test_prefers_processed_plist_when_preprocessing_is_enabled
-test_uses_processed_plist_for_compound_build_settings
+test_falls_back_for_preprocessed_plist_values
+test_resolves_compound_build_settings
 test_skips_cli_lookup_when_build_does_not_emit_dsyms
 test_falls_back_for_unresolved_source_plist_versions
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Xcode can start the symbol upload phase while `dsymutil` is still producing the app dSYM. Uploading at that point can fail or send incomplete symbols. Declaring the dSYM as an Xcode input is not safe because it can create dependency cycles in apps with embedded extensions.

The upload script can also use `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` even when EAS remote versioning writes the shipped values directly to the source Info.plist.

This moves the native part of [PostHog/posthog-js#4602](https://github.com/PostHog/posthog-js/pull/4602) into the shared iOS upload script. It addresses [PostHog/posthog-js#4574](https://github.com/PostHog/posthog-js/issues/4574) for native iOS and React Native integrations.

The script now waits until the app executable and main dSYM have matching UUIDs and no process has the dSYM open for writing. It fails after 60 seconds by default so a release cannot succeed without its native symbols. `POSTHOG_DSYM_TIMEOUT` can change that timeout.

It also resolves literal, custom, and compound Xcode build settings from the source Info.plist. Existing Xcode version settings remain the fallback for missing, unresolved, or C-preprocessed plist values.

## :green_heart: How did you test it?

- Added shell tests for delayed and actively written dSYMs, timeout failure, CLI preflight ordering, Info.plist versions, custom and compound build settings, preprocessing fallback, and missing values.
- Built the `PostHogExampleWithSPM` sample for a Release iOS device with XcodeBuildMCP and posthog-cli 0.14.1. The real CLI uploaded the generated dSYM successfully.
- Rebuilt the sample with source plist values `$(APP_VERSION)` and `${BUILD_NUMBER}` while `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` remained `1.0` and `1`. The app, dSYM, and uploaded release all used `2.10.0+154`.
- Ran `make test`. All 763 SDK tests passed.
- Ran ShellCheck and Bash syntax validation for the upload scripts.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented and tested the change. The dSYM input-path approach was rejected because it can create Xcode dependency cycles. The upload script uses UUID, writer, and timeout checks instead. Shared Info.plist handling in posthog-cli is tracked in [PostHog/posthog#87775](https://github.com/PostHog/posthog/issues/87775).

