### PR TITLE
fix(replay): mask React Native New Architecture (Fabric) text and image views

### DIFF
--- a/.changeset/fabric-replay-masking.md
+++ b/.changeset/fabric-replay-masking.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': patch
+---
+
+Mask React Native New Architecture (Fabric) text and image component views (RCTParagraphComponentView, RCTImageComponentView) and react-native-svg root views (RNSVGSvgView) during session replay, matching the existing legacy RCTTextView/RCTImageView handling.

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		1E875F8082365A917419B1B4 /* PLCrashSignalHandler.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6423E3B086633C68584B5558 /* PLCrashSignalHandler.mm */; };
 		1F5558262DFC4802007643C0 /* PostHogStorageMergeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F55581F2DFC47E8007643C0 /* PostHogStorageMergeTest.swift */; };
 		A1A1A1A1A1A1A1A1A1A10002 /* PostHogMaskScenarioTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A10001 /* PostHogMaskScenarioTest.swift */; };
+		B2B2B2B2B2B2B2B2B2B20002 /* PostHogReactNativeMaskingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B2B2B2B2B2B2B2B2B20001 /* PostHogReactNativeMaskingTest.swift */; };
 		A1A1A1A1A1A1A1A1A1A10004 /* PostHogMaskSnapshotTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A10003 /* PostHogMaskSnapshotTest.swift */; };
 		236B94DD004B67F9EAA98C2B /* PLCrashFrameCompactUnwind.c in Sources */ = {isa = PBXBuildFile; fileRef = 61CBAB800ACCB63AB4491646 /* PLCrashFrameCompactUnwind.c */; };
 		238D24DE5A56F04CE3FF0928 /* PLCrashReportExceptionInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = F9BB47DFE51AFE8F516B8550 /* PLCrashReportExceptionInfo.m */; };
@@ -799,6 +800,7 @@
 		1E41CC6ED20D266FB2357B81 /* PostHogSurveyTranslation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostHogSurveyTranslation.swift; sourceTree = "<group>"; };
 		1F55581F2DFC47E8007643C0 /* PostHogStorageMergeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogStorageMergeTest.swift; sourceTree = "<group>"; };
 		A1A1A1A1A1A1A1A1A1A10001 /* PostHogMaskScenarioTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogMaskScenarioTest.swift; sourceTree = "<group>"; };
+		B2B2B2B2B2B2B2B2B2B20001 /* PostHogReactNativeMaskingTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogReactNativeMaskingTest.swift; sourceTree = "<group>"; };
 		A1A1A1A1A1A1A1A1A1A10003 /* PostHogMaskSnapshotTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogMaskSnapshotTest.swift; sourceTree = "<group>"; };
 		20C01091B0ACF69D36D3B7AE /* PLCrashAsyncMachExceptionInfo.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = PLCrashAsyncMachExceptionInfo.c; path = vendor/PHPLCrashReporter/Source/PLCrashAsyncMachExceptionInfo.c; sourceTree = "<group>"; };
 		26E974D4AD3C438FAE6FE0C5 /* RageClickDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RageClickDetector.swift; sourceTree = "<group>"; };
@@ -1705,6 +1707,7 @@
 				DB72000A2F80000100000001 /* PostHogSessionReplayRemoteConfigBufferTest.swift */,
 				1F55581F2DFC47E8007643C0 /* PostHogStorageMergeTest.swift */,
 				A1A1A1A1A1A1A1A1A1A10001 /* PostHogMaskScenarioTest.swift */,
+				B2B2B2B2B2B2B2B2B2B20001 /* PostHogReactNativeMaskingTest.swift */,
 				A1A1A1A1A1A1A1A1A1A10003 /* PostHogMaskSnapshotTest.swift */,
 				DA4FFBB42DAD5AF9006BAEEA /* PostHogIdentityTests.swift */,
 				DA0F98A12D940E7D009AB6F5 /* ApplicationViewLayoutPublisherTest.swift */,
@@ -3507,6 +3510,7 @@
 				693E977D2C6257F9004B1030 /* ExampleSanitizer.swift in Sources */,
 				1F5558262DFC4802007643C0 /* PostHogStorageMergeTest.swift in Sources */,
 				A1A1A1A1A1A1A1A1A1A10002 /* PostHogMaskScenarioTest.swift in Sources */,
+				B2B2B2B2B2B2B2B2B2B20002 /* PostHogReactNativeMaskingTest.swift in Sources */,
 				A1A1A1A1A1A1A1A1A1A10004 /* PostHogMaskSnapshotTest.swift in Sources */,
 				DA4FFB152DA93C78006BAEEA /* PostHogSessionReplayTest.swift in Sources */,
 				DA4FFB192DA93C78006BAEEA /* PostHogReplayScreenshotDedupTest.swift in Sources */,

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -137,10 +137,13 @@
         private let reactNativeTextView: AnyClass? = NSClassFromString("RCTTextView")
         private let reactNativeImageView: AnyClass? = NSClassFromString("RCTImageView")
         // React Native New Architecture (Fabric) renders text and images with these component views
-        // instead of RCTTextView/RCTImageView; react-native-svg draws into RNSVGSvgView
+        // instead of RCTTextView/RCTImageView; react-native-svg draws its node hierarchy into RNSVGSvgView
         private let reactNativeParagraphView: AnyClass? = NSClassFromString("RCTParagraphComponentView")
         private let reactNativeImageComponentView: AnyClass? = NSClassFromString("RCTImageComponentView")
         private let reactNativeSvgView: AnyClass? = NSClassFromString("RNSVGSvgView")
+        private let reactNativeSvgRenderableView: AnyClass? = NSClassFromString("RNSVGRenderable")
+        private let reactNativeSvgGroupView: AnyClass? = NSClassFromString("RNSVGGroup")
+        private let reactNativeSvgTextView: AnyClass? = NSClassFromString("RNSVGText")
         // These are usually views that don't belong to the current process and are most likely sensitive
         private let systemSandboxedView: AnyClass? = NSClassFromString("_UIRemoteView")
 
@@ -834,6 +837,31 @@
             return wireframe
         }
 
+        private func reactNativeSvgContent(in view: UIView) -> (hasText: Bool, hasGraphic: Bool) {
+            var hasText = false
+            var hasGraphic = false
+
+            for subview in view.subviews {
+                if let reactNativeSvgTextView, subview.isKind(of: reactNativeSvgTextView) {
+                    hasText = true
+                    continue
+                }
+
+                if let reactNativeSvgRenderableView, subview.isKind(of: reactNativeSvgRenderableView) {
+                    let isGroup = reactNativeSvgGroupView.map { subview.isKind(of: $0) } ?? false
+                    if !isGroup {
+                        hasGraphic = true
+                    }
+                }
+
+                let nestedContent = reactNativeSvgContent(in: subview)
+                hasText = hasText || nestedContent.hasText
+                hasGraphic = hasGraphic || nestedContent.hasGraphic
+            }
+
+            return (hasText, hasGraphic)
+        }
+
         private func findMaskableWidgets(_ view: UIView, _ window: UIWindow, _ maskableWidgets: inout [CGRect], _ maskChildren: inout Bool) {
             // User explicitly marked this view (and its subviews) as non-maskable through `.postHogNoMask()` view modifier
             if view.postHogNoMask {
@@ -891,8 +919,12 @@
                 }
             }
 
-            if let reactNativeSvgView = reactNativeSvgView {
-                if view.isKind(of: reactNativeSvgView), config?.sessionReplayConfig.maskAllImages == true {
+            if let reactNativeSvgView, view.isKind(of: reactNativeSvgView) {
+                let content = reactNativeSvgContent(in: view)
+                let shouldMaskText = content.hasText && config?.sessionReplayConfig.maskAllTextInputs == true
+                let shouldMaskGraphics = content.hasGraphic && config?.sessionReplayConfig.maskAllImages == true
+                if shouldMaskText || shouldMaskGraphics {
+                    // SVG nodes share a drawing surface, so mask the root when enabled content is present.
                     maskableWidgets.append(view.toAbsoluteRect(window))
                     return
                 }

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -136,6 +136,11 @@
 
         private let reactNativeTextView: AnyClass? = NSClassFromString("RCTTextView")
         private let reactNativeImageView: AnyClass? = NSClassFromString("RCTImageView")
+        // React Native New Architecture (Fabric) renders text and images with these component views
+        // instead of RCTTextView/RCTImageView; react-native-svg draws into RNSVGSvgView
+        private let reactNativeParagraphView: AnyClass? = NSClassFromString("RCTParagraphComponentView")
+        private let reactNativeImageComponentView: AnyClass? = NSClassFromString("RCTImageComponentView")
+        private let reactNativeSvgView: AnyClass? = NSClassFromString("RNSVGSvgView")
         // These are usually views that don't belong to the current process and are most likely sensitive
         private let systemSandboxedView: AnyClass? = NSClassFromString("_UIRemoteView")
 
@@ -857,6 +862,13 @@
                 }
             }
 
+            if let reactNativeParagraphView = reactNativeParagraphView {
+                if view.isKind(of: reactNativeParagraphView), config?.sessionReplayConfig.maskAllTextInputs == true {
+                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    return
+                }
+            }
+
             /// SwiftUI: Some control images like the ones in `Picker` view may land here
             if let image = view as? UIImageView {
                 if isImageViewSensitive(image) {
@@ -867,6 +879,20 @@
 
             if let reactNativeImageView = reactNativeImageView {
                 if view.isKind(of: reactNativeImageView), config?.sessionReplayConfig.maskAllImages == true {
+                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    return
+                }
+            }
+
+            if let reactNativeImageComponentView = reactNativeImageComponentView {
+                if view.isKind(of: reactNativeImageComponentView), config?.sessionReplayConfig.maskAllImages == true {
+                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    return
+                }
+            }
+
+            if let reactNativeSvgView = reactNativeSvgView {
+                if view.isKind(of: reactNativeSvgView), config?.sessionReplayConfig.maskAllImages == true {
                     maskableWidgets.append(view.toAbsoluteRect(window))
                     return
                 }

--- a/PostHogTests/PostHogReactNativeMaskingTest.swift
+++ b/PostHogTests/PostHogReactNativeMaskingTest.swift
@@ -20,6 +20,10 @@
     @objc(RCTParagraphComponentView) private final class FabricParagraphViewStub: UIView {}
     @objc(RCTImageComponentView) private final class FabricImageViewStub: UIView {}
     @objc(RNSVGSvgView) private final class SvgViewStub: UIView {}
+    @objc(RNSVGRenderable) private class SvgRenderableViewStub: UIView {}
+    @objc(RNSVGGroup) private class SvgGroupViewStub: SvgRenderableViewStub {}
+    @objc(RNSVGText) private final class SvgTextViewStub: SvgGroupViewStub {}
+    @objc(RNSVGImage) private final class SvgImageViewStub: SvgRenderableViewStub {}
 
     @Suite("Replay masking for React Native (Fabric) component views", .serialized)
     @MainActor
@@ -31,7 +35,7 @@
         /// skips them). Resets the static install flag a prior replay suite may have
         /// left set, so this install binds fresh instead of no-opping onto a stale one.
         private func makeSut(maskText: Bool, maskImages: Bool) -> Sut {
-            let config = PostHogConfig(apiKey: "phc_reactNativeMaskingTest")
+            let config = PostHogConfig(projectToken: "phc_reactNativeMaskingTest")
             config.disableReachabilityForTesting = true
             config.sessionReplayConfig.maskAllTextInputs = maskText
             config.sessionReplayConfig.maskAllImages = maskImages
@@ -78,12 +82,27 @@
             #expect(sut.integration.collectMaskableRects(in: window) == [CGRect(x: 40, y: 200, width: 160, height: 100)])
         }
 
-        @Test("react-native-svg root view is masked under maskAllImages")
-        func svgViewMasked() {
+        @Test("react-native-svg image content is masked under maskAllImages")
+        func svgImageMasked() {
             let sut = makeSut(maskText: false, maskImages: true)
             defer { teardown(sut) }
 
             let svg = SvgViewStub(frame: CGRect(x: 10, y: 300, width: 300, height: 180))
+            svg.addSubview(SvgImageViewStub())
+            let window = makeWindow(containing: svg)
+
+            #expect(sut.integration.collectMaskableRects(in: window) == [CGRect(x: 10, y: 300, width: 300, height: 180)])
+        }
+
+        @Test("react-native-svg text content is masked under maskAllTextInputs")
+        func svgTextMasked() {
+            let sut = makeSut(maskText: true, maskImages: false)
+            defer { teardown(sut) }
+
+            let svg = SvgViewStub(frame: CGRect(x: 10, y: 300, width: 300, height: 180))
+            let group = SvgGroupViewStub()
+            group.addSubview(SvgTextViewStub())
+            svg.addSubview(group)
             let window = makeWindow(containing: svg)
 
             #expect(sut.integration.collectMaskableRects(in: window) == [CGRect(x: 10, y: 300, width: 300, height: 180)])
@@ -94,33 +113,48 @@
             let sut = makeSut(maskText: false, maskImages: false)
             defer { teardown(sut) }
 
+            let svg = SvgViewStub(frame: CGRect(x: 10, y: 340, width: 300, height: 180))
+            svg.addSubview(SvgTextViewStub())
+            svg.addSubview(SvgImageViewStub())
             let window = makeWindow(
                 containing: FabricParagraphViewStub(frame: CGRect(x: 24, y: 120, width: 200, height: 32)),
                 FabricImageViewStub(frame: CGRect(x: 40, y: 200, width: 160, height: 100)),
-                SvgViewStub(frame: CGRect(x: 10, y: 340, width: 300, height: 180))
+                svg
             )
 
             #expect(sut.integration.collectMaskableRects(in: window) == [])
         }
 
-        @Test("each class is gated by its matching flag, not the other one")
-        func maskingGatedByMatchingFlag() {
-            // maskAllImages alone must not mask text views...
-            let imagesOnly = makeSut(maskText: false, maskImages: true)
-            let paragraphWindow = makeWindow(
-                containing: FabricParagraphViewStub(frame: CGRect(x: 24, y: 120, width: 200, height: 32))
-            )
-            #expect(imagesOnly.integration.collectMaskableRects(in: paragraphWindow) == [])
-            teardown(imagesOnly)
+        @Test("text-only React Native views are not masked under maskAllImages")
+        func textViewsNotMaskedByImageSetting() {
+            let sut = makeSut(maskText: false, maskImages: true)
+            defer { teardown(sut) }
 
-            // ...and maskAllTextInputs alone must not mask image or SVG views.
-            let textOnly = makeSut(maskText: true, maskImages: false)
-            let imageWindow = makeWindow(
-                containing: FabricImageViewStub(frame: CGRect(x: 40, y: 200, width: 160, height: 100)),
-                SvgViewStub(frame: CGRect(x: 10, y: 340, width: 300, height: 180))
+            let svg = SvgViewStub(frame: CGRect(x: 10, y: 340, width: 300, height: 180))
+            let group = SvgGroupViewStub()
+            group.addSubview(SvgTextViewStub())
+            svg.addSubview(group)
+            let window = makeWindow(
+                containing: FabricParagraphViewStub(frame: CGRect(x: 24, y: 120, width: 200, height: 32)),
+                svg
             )
-            #expect(textOnly.integration.collectMaskableRects(in: imageWindow) == [])
-            teardown(textOnly)
+
+            #expect(sut.integration.collectMaskableRects(in: window) == [])
+        }
+
+        @Test("image-only React Native views are not masked under maskAllTextInputs")
+        func imageViewsNotMaskedByTextSetting() {
+            let sut = makeSut(maskText: true, maskImages: false)
+            defer { teardown(sut) }
+
+            let svg = SvgViewStub(frame: CGRect(x: 10, y: 340, width: 300, height: 180))
+            svg.addSubview(SvgImageViewStub())
+            let window = makeWindow(
+                containing: FabricImageViewStub(frame: CGRect(x: 40, y: 200, width: 160, height: 100)),
+                svg
+            )
+
+            #expect(sut.integration.collectMaskableRects(in: window) == [])
         }
     }
 #endif

--- a/PostHogTests/PostHogReactNativeMaskingTest.swift
+++ b/PostHogTests/PostHogReactNativeMaskingTest.swift
@@ -1,0 +1,126 @@
+//
+//  Masking coverage for React Native component views. React Native's New
+//  Architecture (Fabric) renders text as RCTParagraphComponentView and images as
+//  RCTImageComponentView — not the legacy RCTTextView/RCTImageView — and
+//  react-native-svg draws into RNSVGSvgView. The integration resolves all of
+//  these classes by name (NSClassFromString) when it is created, so this suite
+//  registers plain UIView stubs under the real Objective-C runtime names and
+//  needs no React Native dependency: the stubs resolve exactly like the real
+//  classes do in a React Native host app.
+//
+
+#if os(iOS)
+    import Foundation
+    @testable import PostHog
+    import Testing
+    import UIKit
+
+    // Registered with the Objective-C runtime under the exact names React Native
+    // exports, so NSClassFromString finds them at integration init.
+    @objc(RCTParagraphComponentView) private final class FabricParagraphViewStub: UIView {}
+    @objc(RCTImageComponentView) private final class FabricImageViewStub: UIView {}
+    @objc(RNSVGSvgView) private final class SvgViewStub: UIView {}
+
+    @Suite("Replay masking for React Native (Fabric) component views", .serialized)
+    @MainActor
+    struct PostHogReactNativeMaskingTest {
+        private typealias Sut = (sdk: PostHogSDK, integration: PostHogReplayIntegration)
+
+        /// An integration with a bound config, so the maskAllTextInputs/maskAllImages
+        /// heuristics are live (a bare `PostHogReplayIntegration()` has no config and
+        /// skips them). Resets the static install flag a prior replay suite may have
+        /// left set, so this install binds fresh instead of no-opping onto a stale one.
+        private func makeSut(maskText: Bool, maskImages: Bool) -> Sut {
+            let config = PostHogConfig(apiKey: "phc_reactNativeMaskingTest")
+            config.disableReachabilityForTesting = true
+            config.sessionReplayConfig.maskAllTextInputs = maskText
+            config.sessionReplayConfig.maskAllImages = maskImages
+            PostHogReplayIntegration.clearInstalls()
+            let sdk = PostHogSDK.with(config)
+            let integration = PostHogReplayIntegration()
+            _ = integration.install(sdk)
+            return (sdk, integration)
+        }
+
+        private func teardown(_ sut: Sut) {
+            sut.integration.uninstall(sut.sdk)
+            sut.sdk.close()
+        }
+
+        private func makeWindow(containing views: UIView...) -> UIWindow {
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+            for view in views {
+                window.addSubview(view)
+            }
+            window.layoutIfNeeded()
+            return window
+        }
+
+        @Test("Fabric paragraph view is masked under maskAllTextInputs")
+        func fabricParagraphViewMasked() {
+            let sut = makeSut(maskText: true, maskImages: false)
+            defer { teardown(sut) }
+
+            let paragraph = FabricParagraphViewStub(frame: CGRect(x: 24, y: 120, width: 200, height: 32))
+            let window = makeWindow(containing: paragraph)
+
+            #expect(sut.integration.collectMaskableRects(in: window) == [CGRect(x: 24, y: 120, width: 200, height: 32)])
+        }
+
+        @Test("Fabric image component view is masked under maskAllImages")
+        func fabricImageComponentViewMasked() {
+            let sut = makeSut(maskText: false, maskImages: true)
+            defer { teardown(sut) }
+
+            let image = FabricImageViewStub(frame: CGRect(x: 40, y: 200, width: 160, height: 100))
+            let window = makeWindow(containing: image)
+
+            #expect(sut.integration.collectMaskableRects(in: window) == [CGRect(x: 40, y: 200, width: 160, height: 100)])
+        }
+
+        @Test("react-native-svg root view is masked under maskAllImages")
+        func svgViewMasked() {
+            let sut = makeSut(maskText: false, maskImages: true)
+            defer { teardown(sut) }
+
+            let svg = SvgViewStub(frame: CGRect(x: 10, y: 300, width: 300, height: 180))
+            let window = makeWindow(containing: svg)
+
+            #expect(sut.integration.collectMaskableRects(in: window) == [CGRect(x: 10, y: 300, width: 300, height: 180)])
+        }
+
+        @Test("nothing is masked with both flags off")
+        func nothingMaskedWithFlagsOff() {
+            let sut = makeSut(maskText: false, maskImages: false)
+            defer { teardown(sut) }
+
+            let window = makeWindow(
+                containing: FabricParagraphViewStub(frame: CGRect(x: 24, y: 120, width: 200, height: 32)),
+                FabricImageViewStub(frame: CGRect(x: 40, y: 200, width: 160, height: 100)),
+                SvgViewStub(frame: CGRect(x: 10, y: 340, width: 300, height: 180))
+            )
+
+            #expect(sut.integration.collectMaskableRects(in: window) == [])
+        }
+
+        @Test("each class is gated by its matching flag, not the other one")
+        func maskingGatedByMatchingFlag() {
+            // maskAllImages alone must not mask text views...
+            let imagesOnly = makeSut(maskText: false, maskImages: true)
+            let paragraphWindow = makeWindow(
+                containing: FabricParagraphViewStub(frame: CGRect(x: 24, y: 120, width: 200, height: 32))
+            )
+            #expect(imagesOnly.integration.collectMaskableRects(in: paragraphWindow) == [])
+            teardown(imagesOnly)
+
+            // ...and maskAllTextInputs alone must not mask image or SVG views.
+            let textOnly = makeSut(maskText: true, maskImages: false)
+            let imageWindow = makeWindow(
+                containing: FabricImageViewStub(frame: CGRect(x: 40, y: 200, width: 160, height: 100)),
+                SvgViewStub(frame: CGRect(x: 10, y: 340, width: 300, height: 180))
+            )
+            #expect(textOnly.integration.collectMaskableRects(in: imageWindow) == [])
+            teardown(textOnly)
+        }
+    }
+#endif


### PR DESCRIPTION
### :bulb: Motivation and Context

Session replay masking matches view classes, and for React Native it only knows the old architecture classes `RCTTextView` and `RCTImageView`. React Native 0.82+ removed the old architecture, and on the New Architecture (Fabric) text renders as `RCTParagraphComponentView` and images as `RCTImageComponentView`. Neither matches, so on any current React Native app:

- Nothing rendered as text is masked. Replays record every label, balance, and merchant name in the clear even with `maskAllTextInputs` enabled; only real UIKit text inputs stay redacted.
- Images mostly get masked only through a side door: the Fabric image view embeds a `UIImageView` subclass that the generic `UIImageView` branch happens to catch. This PR makes the image view match by its component class directly.
- react-native-svg content (`RNSVGSvgView`) is not matched by anything.

We hit this in production hardening of a React Native 0.85 finance app: with both mask flags on, replays showed the full net worth screen legible. We could not find an existing issue or PR covering the Fabric classes.

The change mirrors the existing pattern exactly: three more `NSClassFromString` lookups, with `RCTParagraphComponentView` gated on `maskAllTextInputs` (like the legacy `RCTTextView`) and `RCTImageComponentView` plus `RNSVGSvgView` gated on `maskAllImages` (like the legacy `RCTImageView`). Apps without React Native are unaffected since the classes simply do not resolve.

If you would prefer to treat react-native-svg as out of scope for the core RN fix, happy to split `RNSVGSvgView` into a separate PR.

(posthog-android is not affected: it masks any `TextView`, and React Native's `ReactTextView` is a `TextView` subclass.)

### :green_heart: How did you test it?

- Reproduced the leak on device: React Native 0.85 (Expo SDK 56) app with session replay enabled, `maskAllTextInputs` and `maskAllImages` on; all rendered text was legible in recorded replays.
- Applied this change on top of 3.58.1, pinned the patched pod into the app, and validated on device (internal staging build 78, 2026-08-23) that recorded replays mask text, images, and SVG content: the same net worth flow that previously recorded fully legible now records fully redacted.
- Added `PostHogTests/PostHogReactNativeMaskingTest.swift`. The integration resolves the RN classes by name, so the suite registers plain `UIView` stubs under the real Objective-C runtime names and asserts `collectMaskableRects(in:)` returns each stub's rect under its matching flag only (and nothing with both flags off). No React Native dependency needed.
- Honest limitation: this machine cannot run `make lint` / `make test` / `make buildSdk` locally (macOS 12, Xcode 14.2, below the required 16.1), so we are relying on CI for the full suite. The patch and test mirror the surrounding code style closely.

### :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed. (Happy to update the session replay privacy docs if you point me at the right page; the behavior change is "masking now also covers Fabric and react-native-svg views", which is what users already expect the flags to mean.)
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Changeset file added (`.changeset/fabric-replay-masking.md`, patch bump). Written by hand in the same format `pnpm changeset` generates, since this machine cannot run the toolchain.

### 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Directed by @ivdezine (assign as PR assignee / DRI). Built with Claude Code (Claude Fable 5) during device validation and hardening of our app's session replay rollout.
- Decisions along the way: gated `RCTParagraphComponentView` on `maskAllTextInputs` rather than introducing a new flag, to match the legacy `RCTTextView` handling; kept `RNSVGSvgView` in scope because SVG frequently carries sensitive user content in RN apps (charts, QR codes), while offering to split it out; wrote the test with ObjC-named stub classes instead of adding a React Native dev dependency to the test bundle.
- The commit is authored by the human driver; agent assistance is disclosed in this section rather than in commit trailers.

