### PR TITLE
fix(release): opt private package into changesets v3 versioning

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,6 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "privatePackages": { "version": true, "tag": false }
 }


### PR DESCRIPTION
## :bulb: Motivation and Context

The `@changesets/cli` 2.31.1 → 3.0.0 bump in #772 silently broke releases. `package.json` here is `"private": true` (it only exists to track the SDK version), and v3 no longer versions private packages unless you opt in, so `pnpm changeset version` became a no-op: it leaves the version untouched, leaves the changeset files in place, prints its usual success line and exits 0.

That cascades quietly through `release.yml`. `Apply changesets and update version` re-reads the unchanged `3.69.8`, `Sync version to Swift files` writes identical values, `Check for version bump changes` finds an empty `git status --porcelain` and sets `committed=false`, so `Commit version bump` is skipped and `create-github-release` never runs. The whole run reports success because every step genuinely succeeded, and no tag, GitHub release or CocoaPods publish comes out of it.

Two releases went out this way, [32369581097](https://github.com/PostHog/posthog-ios/actions/runs/32369581097) and [32374857791](https://github.com/PostHog/posthog-ios/actions/runs/32374857791), which is why three changesets are still sitting in `.changeset/` waiting to go out.

Sets `privatePackages: { version: true, tag: false }` in `.changeset/config.json` to restore the v2 behaviour. `tag: false` because the release workflow creates the git tag itself in `create-github-release`, not changesets.

## :green_heart: How did you test it?

Ran `changeset version` against a copy of this branch's `.changeset/` and `package.json` on both CLI versions:

| CLI | result |
| --- | --- |
| 2.31.1 (before #772) | bumps to `3.69.9`, consumes all 3 changesets, writes `CHANGELOG.md` |
| 3.0.0 without this fix | stays on `3.69.8`, changesets untouched, exits 0 |
| 3.0.0 with this fix | bumps to `3.69.9`, consumes all 3 changesets, writes `CHANGELOG.md` |

No changeset on this PR, it's a release-config fix with nothing user-facing to put in the changelog. The path filter on the release workflow is `.changeset/*.md`, so touching `config.json` won't kick off a release on merge.

The pending release run [32706203084](https://github.com/PostHog/posthog-ios/actions/runs/32706203084) is still waiting on the Release environment gate. `version-bump` checks out `main` at approval time, so once this lands that same run can be approved and will pick the fix up, releasing the three queued changesets as `3.69.9`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**DRI:** @ioannisj
**Autonomy:** Human-driven (agent-assisted)
