### PR TITLE
chore(ci): update changed shared workflow pins

### DIFF
--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
     call-flags-project:
-        uses: PostHog/.github/.github/workflows/flags-project-board.yml@95c20087fda2dc10fbbbcc3f1ef32b7bae779339
+        uses: PostHog/.github/.github/workflows/flags-project-board.yml@5ba5d24966f2c416ca792654638e4ce6f19f545b
         with:
             pr_number: ${{ github.event.pull_request.number }}
             pr_node_id: ${{ github.event.pull_request.node_id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
     name: Notify Slack - Approval Needed
     needs: check-changesets
     if: needs.check-changesets.outputs.has-changesets == 'true'
-    uses: PostHog/.github/.github/workflows/notify-approval-needed.yml@5fc4680761e8ac29a61b212756230eba0e276d8c
+    uses: PostHog/.github/.github/workflows/notify-approval-needed.yml@5ba5d24966f2c416ca792654638e4ce6f19f545b
     with:
       slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
       slack_user_group_id: ${{ vars.GROUP_CLIENT_LIBRARIES_SLACK_GROUP_ID }}


### PR DESCRIPTION
## :bulb: Motivation and Context

The shared `flags-project-board.yml` and `notify-approval-needed.yml` workflows have changed since the commits pinned in this repository. The other shared workflow references still match their pinned content and do not need new SHAs.

This updates only the changed reusable workflows to `PostHog/.github@5ba5d24966f2c416ca792654638e4ce6f19f545b`.

## :green_heart: How did you test it?

- Compared the Git blob for each referenced workflow at its pinned commit with the same file at `5ba5d24966f2c416ca792654638e4ce6f19f545b`.
- Ran `git diff --check`.
- Ran `actionlint -shellcheck=` on the changed workflow files.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi's delegated worker agent made this repository-administration change. It compared workflow Git blobs and retained older SHA pins when the referenced file content was unchanged. No public agent session URL is available.
