### PR TITLE
fix(replay): prevent fatal SIGPIPE when tearing down console log capture

### DIFF
--- a/.changeset/console-logs-sigpipe.md
+++ b/.changeset/console-logs-sigpipe.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Fix a fatal SIGPIPE when session replay console log capture is torn down, for example when the app backgrounds with `sessionReplayConfig.captureLogs` enabled. Teardown closed the descriptors the pipe readers were still writing to, which could kill the process.

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -299,6 +299,7 @@
 		DA52CACB2F24027500305F3D /* PostHogMulticastCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA52CACA2F24027500305F3D /* PostHogMulticastCallback.swift */; };
 		DA52CAD32F2402E000305F3D /* PostHogMulticastCallbackTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA52CAD22F2402E000305F3D /* PostHogMulticastCallbackTest.swift */; };
 		DA52CAEF2F24319800305F3D /* PostHogSessionReplayPluginTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA52CAEE2F24319800305F3D /* PostHogSessionReplayPluginTest.swift */; };
+		DA52CAEF2F2431980030AA01 /* PostHogConsoleLogInterceptorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA52CAEE2F2431980030AA01 /* PostHogConsoleLogInterceptorTest.swift */; };
 		DA53DE762D3E29A900C38DCA /* fixture_remote_config.json in Resources */ = {isa = PBXBuildFile; fileRef = DA53DE702D3E299F00C38DCA /* fixture_remote_config.json */; };
 		DA53DE7E2D3E66AA00C38DCA /* PostHogRemoteConfigTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA53DE7D2D3E66A300C38DCA /* PostHogRemoteConfigTest.swift */; };
 		DA578E982D6768BC00B3A56C /* PostHogScreenViewIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA578E972D6768B400B3A56C /* PostHogScreenViewIntegration.swift */; };
@@ -1078,6 +1079,7 @@
 		DA52CACA2F24027500305F3D /* PostHogMulticastCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogMulticastCallback.swift; sourceTree = "<group>"; };
 		DA52CAD22F2402E000305F3D /* PostHogMulticastCallbackTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogMulticastCallbackTest.swift; sourceTree = "<group>"; };
 		DA52CAEE2F24319800305F3D /* PostHogSessionReplayPluginTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSessionReplayPluginTest.swift; sourceTree = "<group>"; };
+		DA52CAEE2F2431980030AA01 /* PostHogConsoleLogInterceptorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogConsoleLogInterceptorTest.swift; sourceTree = "<group>"; };
 		DA53DE702D3E299F00C38DCA /* fixture_remote_config.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = fixture_remote_config.json; sourceTree = "<group>"; };
 		DA53DE7D2D3E66A300C38DCA /* PostHogRemoteConfigTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogRemoteConfigTest.swift; sourceTree = "<group>"; };
 		DA578E972D6768B400B3A56C /* PostHogScreenViewIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogScreenViewIntegration.swift; sourceTree = "<group>"; };
@@ -1749,6 +1751,7 @@
 				69ED1AB52C90711D00FE7A91 /* PostHogSDKPersonProfilesTest.swift */,
 				DA52CAD22F2402E000305F3D /* PostHogMulticastCallbackTest.swift */,
 				DA52CAEE2F24319800305F3D /* PostHogSessionReplayPluginTest.swift */,
+				DA52CAEE2F2431980030AA01 /* PostHogConsoleLogInterceptorTest.swift */,
 				DA6A2A5D2F39BE9300BD1B4C /* PostHogPropertiesSerializationTest.swift */,
 				DA697CAA2EF935490019640F /* PostHogCrashReportProcessorTest.swift */,
 				DA697CAB2EF935490019640F /* PostHogDebugImageProviderTest.swift */,
@@ -3516,6 +3519,7 @@
 				DA4FFB192DA93C78006BAEEA /* PostHogReplayScreenshotDedupTest.swift in Sources */,
 				DADE7DFE2F7EA90D00C4650C /* PostHogDeepLinkIntegrationTests.swift in Sources */,
 				DA52CAEF2F24319800305F3D /* PostHogSessionReplayPluginTest.swift in Sources */,
+				DA52CAEF2F2431980030AA01 /* PostHogConsoleLogInterceptorTest.swift in Sources */,
 				690FF0DF2AEFBC5700A0B06B /* PostHogLegacyQueueTest.swift in Sources */,
 				DA6F24822D4A6CA100CA2777 /* PostHogApiTest.swift in Sources */,
 				AE3C6A5B6DAB01EF554A0270 /* PostHogPushNotificationTest.swift in Sources */,

--- a/PostHog/Replay/Plugins/Console Logs/PostHogConsoleLogInterceptor.swift
+++ b/PostHog/Replay/Plugins/Console Logs/PostHogConsoleLogInterceptor.swift
@@ -17,9 +17,17 @@
             let level: PostHogLogLevel
         }
 
+        private enum Stream {
+            case stdout
+            case stderr
+        }
+
         static let shared = PostHogConsoleLogInterceptor()
 
         // Pipe redirection properties
+        // Guarded by `fdLock`, which the readability handlers also take, so that a handler
+        // can never be mid-write against a file descriptor that teardown is closing
+        private let fdLock = NSLock()
         private var stdoutPipe: Pipe?
         private var stderrPipe: Pipe?
         private var originalStdout: Int32 = -1
@@ -39,40 +47,94 @@
             setvbuf(stdout, nil, _IONBF, 0)
             setvbuf(stderr, nil, _IONBF, 0)
 
+            let stdoutPipe = Pipe()
+            let stderrPipe = Pipe()
+
+            fdLock.lock()
+
             // Save original file descriptors
             originalStdout = dup(STDOUT_FILENO)
             originalStderr = dup(STDERR_FILENO)
 
-            stdoutPipe = Pipe()
-            stderrPipe = Pipe()
-
-            guard let stdoutPipe = stdoutPipe, let stderrPipe = stderrPipe else { return }
+            // A broken pipe on a descriptor we own must surface as EPIPE, not as a fatal
+            // SIGPIPE that the host app cannot catch. NOSIGPIPE is a property of the open
+            // file description, so the copies dup2'd onto STDOUT/STDERR inherit it too.
+            setNoSigPipe(originalStdout)
+            setNoSigPipe(originalStderr)
+            setNoSigPipe(stdoutPipe.fileHandleForWriting.fileDescriptor)
+            setNoSigPipe(stderrPipe.fileHandleForWriting.fileDescriptor)
 
             // Redirect stdout and stderr to our pipes
             dup2(stdoutPipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
             dup2(stderrPipe.fileHandleForWriting.fileDescriptor, STDERR_FILENO)
 
+            self.stdoutPipe = stdoutPipe
+            self.stderrPipe = stderrPipe
+
+            fdLock.unlock()
+
             // Setup and handle pipe output
-            setupPipeSource(for: originalStdout, fileHandle: stdoutPipe.fileHandleForReading, config: config, callback: callback)
-            setupPipeSource(for: originalStderr, fileHandle: stderrPipe.fileHandleForReading, config: config, callback: callback)
+            setupPipeSource(for: .stdout, fileHandle: stdoutPipe.fileHandleForReading, config: config, callback: callback)
+            setupPipeSource(for: .stderr, fileHandle: stderrPipe.fileHandleForReading, config: config, callback: callback)
         }
 
-        private func setupPipeSource(for originalFd: Int32, fileHandle: FileHandle, config: PostHogConfig, callback: @escaping (ConsoleOutput) -> Void) {
-            fileHandle.readabilityHandler = { [weak self] handle in
-                let data = handle.availableData
-                guard !data.isEmpty,
-                      let output = String(data: data, encoding: .utf8),
-                      let self = self else { return }
+        private func setNoSigPipe(_ descriptor: Int32) {
+            guard descriptor != -1 else { return }
+            _ = fcntl(descriptor, F_SETNOSIGPIPE, 1)
+        }
 
-                // Write to original file descriptor, so logs appear normally
-                if originalFd != -1 {
-                    if let data = output.data(using: .utf8) {
-                        _ = data.withUnsafeBytes { ptr in
-                            write(originalFd, ptr.baseAddress, ptr.count)
-                        }
-                    }
+        private func setupPipeSource(for stream: Stream, fileHandle: FileHandle, config: PostHogConfig, callback: @escaping (ConsoleOutput) -> Void) {
+            fileHandle.readabilityHandler = { [weak self] handle in
+                guard let self = self else { return }
+
+                // Hold the lock for the read and the echo: `stopCapturing` takes the same lock
+                // before closing these descriptors, so it cannot close one out from under us
+                self.fdLock.lock()
+
+                // Identity, not a sentinel: `stopCapturing` nils the pipes under this same lock, so
+                // this is false exactly when the session that installed this handler is over. A
+                // `-1` descriptor check would instead conflate that with "dup(STDOUT_FILENO)
+                // failed" and skip the read, leaving the pipe to fill until every `print` blocks
+                let pipe = stream == .stdout ? self.stdoutPipe : self.stderrPipe
+                guard pipe?.fileHandleForReading === handle else {
+                    self.fdLock.unlock()
+                    return
                 }
 
+                // The read has to stay inside the lock: `stopCapturing` closes this handle while
+                // holding it, so an unlocked read could hit an already closed descriptor and
+                // raise `NSFileHandleOperationException` on EBADF
+                let data = handle.availableData
+                guard !data.isEmpty else {
+                    self.fdLock.unlock()
+                    return
+                }
+
+                // Duplicate the echo target rather than writing under the lock: the app's real
+                // stdout is not ours, and if its reader has stalled the `write` blocks — holding
+                // `fdLock` through that would hang `stopCapturing` on the main thread as the app
+                // backgrounds. `dup` never blocks, and the copy keeps the open file description
+                // (and its NOSIGPIPE flag) alive even if teardown closes the original
+                let originalFd = stream == .stdout ? self.originalStdout : self.originalStderr
+                let echoFd = originalFd != -1 ? dup(originalFd) : -1
+
+                self.fdLock.unlock()
+
+                // Echo before decoding, so a chunk that is not valid UTF-8 (a multi-byte sequence
+                // split across a pipe buffer boundary) still reaches the console
+                if echoFd != -1 {
+                    _ = data.withUnsafeBytes { ptr in
+                        write(echoFd, ptr.baseAddress, ptr.count)
+                    }
+                    close(echoFd)
+                }
+
+                guard let output = String(data: data, encoding: .utf8) else { return }
+
+                // Deliberately outside the lock: `callback` re-enters SDK code (`handleConsoleLog`
+                // -> `postHog.capture`) that can reach back into the replay lifecycle and take
+                // `fdLock` again. It is non-recursive, so folding the unlock into a `defer`
+                // would deadlock
                 self.processOutput(output, config: config, callback: callback)
             }
         }
@@ -111,6 +173,22 @@
         }
 
         func stopCapturing() {
+            // Snapshot under the lock, because `setupPipeRedirection` writes these properties
+            // under it. Reading a var that holds a strong class reference while another thread
+            // writes it is a data race in Swift, and the failure mode is an over-release, not
+            // just a stale value
+            fdLock.lock()
+            let stdoutReading = stdoutPipe?.fileHandleForReading
+            let stderrReading = stderrPipe?.fileHandleForReading
+            fdLock.unlock()
+
+            // Detach the readability handlers first, and outside the lock, so that a handler
+            // that is already running can finish and release the lock instead of deadlocking
+            stdoutReading?.readabilityHandler = nil
+            stderrReading?.readabilityHandler = nil
+
+            fdLock.lock()
+
             // Restore original file descriptors
             if originalStdout != -1 {
                 dup2(originalStdout, STDOUT_FILENO)
@@ -125,12 +203,12 @@
             }
 
             // remove pipes
-            stdoutPipe?.fileHandleForReading.readabilityHandler = nil
-            stderrPipe?.fileHandleForReading.readabilityHandler = nil
-            stdoutPipe?.fileHandleForReading.closeFile()
-            stderrPipe?.fileHandleForReading.closeFile()
+            stdoutReading?.closeFile()
+            stderrReading?.closeFile()
             stdoutPipe = nil
             stderrPipe = nil
+
+            fdLock.unlock()
         }
     }
 #endif

--- a/PostHogTests/PostHogConsoleLogInterceptorTest.swift
+++ b/PostHogTests/PostHogConsoleLogInterceptorTest.swift
@@ -1,0 +1,206 @@
+//
+//  PostHogConsoleLogInterceptorTest.swift
+//  PostHogTests
+//
+//  Regression coverage for https://github.com/PostHog/posthog-ios/issues/780
+//
+
+#if os(iOS)
+    import Foundation
+    @testable import PostHog
+    import Testing
+
+    @Suite("Console Log Interceptor Tests", .serialized)
+    class PostHogConsoleLogInterceptorTest {
+        private func getConfig() -> PostHogConfig {
+            PostHogConfig(apiKey: "test-api-key")
+        }
+
+        /// A broken pipe on a descriptor the SDK owns has to surface as `EPIPE`, not as a
+        /// fatal `SIGPIPE` that the host app has no way to catch.
+        @Test("stdout and stderr are marked NOSIGPIPE while capturing")
+        func stdioIsMarkedNoSigPipeWhileCapturing() {
+            let interceptor = PostHogConsoleLogInterceptor.shared
+            interceptor.startCapturing(config: getConfig()) { _ in }
+            defer { interceptor.stopCapturing() }
+
+            #expect(fcntl(STDOUT_FILENO, F_GETNOSIGPIPE) == 1)
+            #expect(fcntl(STDERR_FILENO, F_GETNOSIGPIPE) == 1)
+        }
+
+        /// `stopCapturing` has to hand the real console back, otherwise every later `print`
+        /// disappears into a pipe nobody is reading.
+        @Test("stopCapturing restores the original stdout and stderr")
+        func stopCapturingRestoresOriginalDescriptors() throws {
+            let marker = "posthog-interceptor-test-\(UUID().uuidString)\n"
+            let path = NSTemporaryDirectory() + "posthog-stdout-\(UUID().uuidString).txt"
+            FileManager.default.createFile(atPath: path, contents: nil)
+            defer { try? FileManager.default.removeItem(atPath: path) }
+
+            let file = try #require(FileHandle(forWritingAtPath: path))
+            defer { file.closeFile() }
+
+            // Stand in for the real console so we can read back what landed on fd 1
+            let savedStdout = dup(STDOUT_FILENO)
+            dup2(file.fileDescriptor, STDOUT_FILENO)
+            defer {
+                dup2(savedStdout, STDOUT_FILENO)
+                close(savedStdout)
+            }
+
+            let interceptor = PostHogConsoleLogInterceptor.shared
+            interceptor.startCapturing(config: getConfig()) { _ in }
+            interceptor.stopCapturing()
+
+            _ = Array(marker.utf8).withUnsafeBytes { ptr in
+                write(STDOUT_FILENO, ptr.baseAddress, ptr.count)
+            }
+
+            let written = try #require(try? String(contentsOfFile: path, encoding: .utf8))
+            #expect(written.contains(marker.trimmingCharacters(in: .newlines)))
+        }
+
+        /// The rest of the suite passes `{ _ in }`, so nothing else proves the interceptor
+        /// delivers anything at all. This is what makes the handler's
+        /// `fileHandleForReading === handle` identity check falsifiable: if that assumption were
+        /// wrong, console capture would be silently dead and every other test would still pass.
+        @Test("captured stdout reaches the callback")
+        func capturedStdoutReachesTheCallback() throws {
+            // Plain hex and dashes, so the default sanitizer classifies it as `.info`, and it
+            // cannot be mistaken for one of the SDK's own logs
+            let marker = "posthog-interceptor-capture-\(UUID().uuidString)"
+            try #require(!marker.contains("[PostHog]"))
+
+            let watcher = MarkerWatcher(marker: marker)
+
+            let config = getConfig()
+            // Defaults to `.error`, which would drop the marker
+            config.sessionReplayConfig.captureLogsConfig.minLogLevel = .info
+
+            let interceptor = PostHogConsoleLogInterceptor.shared
+            interceptor.startCapturing(config: config) { output in
+                watcher.record(output.text)
+            }
+            defer { interceptor.stopCapturing() }
+
+            print(marker)
+
+            #expect(watcher.waitForMarker(timeout: 10))
+            #expect(watcher.capturedText.contains { $0.contains(marker) })
+        }
+
+        /// The crash in #780: teardown used to close the descriptors the readability handlers
+        /// write to while those handlers were still in flight, so a handler could write into a
+        /// descriptor number the process had already recycled. Churning start/stop against a
+        /// thread that never stops logging is what surfaced it.
+        @Test("concurrent start/stop while logging does not crash")
+        func concurrentStartStopWhileLoggingIsSafe() throws {
+            // Point fd 1 at a temp file for the duration. The churn prints on a tight loop and
+            // the interceptor echoes every line, which would otherwise dump megabytes into the
+            // CI log
+            let path = NSTemporaryDirectory() + "posthog-churn-\(UUID().uuidString).txt"
+            FileManager.default.createFile(atPath: path, contents: nil)
+            defer { try? FileManager.default.removeItem(atPath: path) }
+
+            let file = try #require(FileHandle(forWritingAtPath: path))
+            defer { file.closeFile() }
+
+            let savedStdout = dup(STDOUT_FILENO)
+            dup2(file.fileDescriptor, STDOUT_FILENO)
+            defer {
+                dup2(savedStdout, STDOUT_FILENO)
+                close(savedStdout)
+            }
+
+            // Identity of the descriptor the churn has to hand back untouched
+            var beforeChurn = stat()
+            #expect(fstat(STDOUT_FILENO, &beforeChurn) == 0)
+
+            let interceptor = PostHogConsoleLogInterceptor.shared
+            let config = getConfig()
+
+            let keepLogging = TestFlag()
+            let loggerFinished = DispatchSemaphore(value: 0)
+            let logger = Thread {
+                while keepLogging.isSet {
+                    print("posthog interceptor test chatter")
+                }
+                loggerFinished.signal()
+            }
+            logger.stackSize = 512 * 1024
+            logger.start()
+
+            for _ in 0 ..< 200 {
+                interceptor.startCapturing(config: config) { _ in }
+                // Stress knob, not synchronization: it widens the window in which a readability
+                // handler is in flight against teardown, which is what reproduces #780
+                usleep(200)
+                interceptor.stopCapturing()
+            }
+
+            keepLogging.clear()
+            // Join the logging thread rather than sleeping, so it cannot still be printing into
+            // whatever fd 1 has become once the suite moves on
+            #expect(loggerFinished.wait(timeout: .now() + 30) == .success)
+
+            // `fcntl(F_GETFD)` would only prove fd 1 is open, which it always is. Comparing the
+            // device/inode pins that the *original* stdout came back, rather than a leftover
+            // pipe end from a mixed-up start/stop pair
+            var afterChurn = stat()
+            #expect(fstat(STDOUT_FILENO, &afterChurn) == 0)
+            #expect(beforeChurn.st_dev == afterChurn.st_dev)
+            #expect(beforeChurn.st_ino == afterChurn.st_ino)
+        }
+    }
+
+    /// Collects interceptor output off the reader queue and lets a test wait for a specific
+    /// marker without polling on a fixed sleep.
+    private final class MarkerWatcher {
+        private let marker: String
+        private let lock = NSLock()
+        private let signalled = DispatchSemaphore(value: 0)
+        private var captured: [String] = []
+
+        init(marker: String) {
+            self.marker = marker
+        }
+
+        var capturedText: [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return captured
+        }
+
+        func record(_ text: String) {
+            lock.lock()
+            captured.append(text)
+            lock.unlock()
+
+            if text.contains(marker) {
+                signalled.signal()
+            }
+        }
+
+        func waitForMarker(timeout: TimeInterval) -> Bool {
+            signalled.wait(timeout: .now() + timeout) == .success
+        }
+    }
+
+    /// Minimal flag so the logging thread can be stopped without pulling in a dependency.
+    private final class TestFlag {
+        private let lock = NSLock()
+        private var value = true
+
+        var isSet: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return value
+        }
+
+        func clear() {
+            lock.lock()
+            value = false
+            lock.unlock()
+        }
+    }
+#endif


### PR DESCRIPTION
## :bulb: Motivation and Context

Fixes #780.

With `sessionReplayConfig.captureLogs` enabled, backgrounding the app could kill the process with a fatal `SIGPIPE`. The host app cannot catch it, so it lands in crash reporters as a hard crash inside the SDK's own teardown.

`stopCapturing()` closed `originalStdout` / `originalStderr` **before** detaching the `readabilityHandler`s that write to them, and those handlers captured the descriptor **by value**. So a handler still in flight on its dispatch queue could `write()` to a descriptor the main thread had just closed. A backgrounding app immediately recycles that descriptor number into a `URLSession` socket whose peer is gone — and that write raises `SIGPIPE`.

The reported top frame is `dup2` at `PostHogConsoleLogInterceptor.swift:122`, which is the main thread's *next* line; the signal comes from the reader queue.

**The fix suggested in the issue is not sufficient.** Measured on a standalone stress harness (verbatim copy of the interceptor's pipe machinery, driven by a logging thread plus socket churn):

| Variant | Runs that died with `SIGPIPE` |
| --- | --- |
| Unpatched | 10 / 10 |
| `F_SETNOSIGPIPE` only (the issue's preferred option) | 4 / 6 |
| Reorder teardown only | 6 / 6 |
| Shared lock (this PR) | 0 / 15 |

`F_SETNOSIGPIPE` can't help because the signal comes from the *recycled* descriptor, which isn't ours to flag. Reordering can't help because `readabilityHandler = nil` doesn't wait for a handler already running. The lock is the load-bearing part.

## :green_heart: How did you test it?

- **New regression tests** in `PostHogConsoleLogInterceptorTest.swift`. Against the unpatched interceptor, the concurrency test **crashes the test runner** and the `NOSIGPIPE` test fails; both pass with the fix. I re-ran that negative control after the tests were reworked, to confirm the repro still fires.
- **Full iOS simulator suite:** 836 tests / 130 suites pass.
- **`make test`:** 763 tests pass.
- **`make lint`:** clean, no new violations.

These tests are `#if os(iOS)`, so `make test` (swift test on macOS) compiles them away — they run only in the `test-ios-simulator` job. That makes the `project.pbxproj` registration load-bearing rather than cosmetic.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## Notes for reviewers

**Three invariants in this file are load-bearing** — a plausible-looking tidy-up breaks them, so they're commented in place:

1. `handle.availableData` must stay **inside** `fdLock` — it's what stops `closeFile()` racing an in-flight read (`EBADF` → uncatchable `NSFileHandleOperationException`).
2. `readabilityHandler = nil` must stay **outside** `fdLock` — folding it in deadlocks teardown against a running handler.
3. `unlock()` must stay **before** `processOutput` — the callback re-enters `postHog.capture`, and `fdLock` is a non-recursive `NSLock`.

**One accepted process-global side effect.** `F_SETNOSIGPIPE` is set on the file description shared with the app's real stdout/stderr and is never cleared, so after the first `startCapturing` any write to stdout/stderr that previously raised `SIGPIPE` returns `EPIPE` instead. Strictly safer (an uncatchable fatal signal becomes a checkable errno), no API change, `patch` bump still correct. Reverting it on teardown is deliberately **not** done: clearing the flag on a description an in-flight echo write may still be using is a path straight back to the crash class this PR closes.

**Known gaps, filed as follow-ups rather than widened into this PR:**

- `startCapturing` is not atomic — it releases the lock between `stopCapturing()` and `setupPipeRedirection()`. Two concurrent starts can permanently leak the process's only handle on the real console. Fixing it inside the interceptor alone would buy false safety, because `PostHogSessionReplayConsoleLogsPlugin.isActive` and `PostHogReplayIntegration.isEnabled` on the same path are unsynchronized too.
- `F_SETNOSIGPIPE` is never restored on teardown (see above).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5). Reproduced the crash first with a standalone stress harness rather than reasoning from the stack trace alone, which is what surfaced that the issue's own preferred fix (`F_SETNOSIGPIPE`) doesn't actually work — the ablation table above is measured, not argued.

The change then went through an automated review loop (independent review → skeptical triage → implementation → verification). That loop caught a real regression in the first draft of this fix: the handler had started returning *before* `handle.availableData` when the descriptor sentinel was `-1`, so if `dup(STDOUT_FILENO)` ever failed, nothing would drain the pipe and every `print()` in the app would eventually block forever. Replacing the `-1` sentinel with a `fileHandleForReading === handle` identity check fixed that and closed a stale-handler hazard at the same time. The loop also added the positive-capture test, without which a wrong identity check would have silently disabled console capture with a fully green suite.

Deliberately rejected during triage: adding a `lifecycleLock` (only half-covers the problem, adds a new main-thread block during backgrounding) and reverting `F_SETNOSIGPIPE` on teardown (reintroduces the crash class). Both are written up as follow-ups above.
