### PR TITLE
fix: use posthog-cli Info.plist support for symbol uploads

### DIFF
--- a/.changeset/calm-symbols-upload.md
+++ b/.changeset/calm-symbols-upload.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': patch
+---
+
+Use posthog-cli 0.15.1 and newer to read release metadata directly from the app Info.plist when uploading debug symbols.

--- a/build-tools/upload-symbols.sh
+++ b/build-tools/upload-symbols.sh
@@ -159,9 +159,29 @@ if [ "$LOWEST" != "$MIN_POSTHOG_CLI_VERSION" ]; then
     exit 1
 fi
 
+INFO_PLIST_MIN_POSTHOG_CLI_VERSION="0.15.1"
+LOWEST=$(printf '%s\n%s\n' "$INFO_PLIST_MIN_POSTHOG_CLI_VERSION" "$PH_CLI_VERSION" | sort -t. -k1,1n -k2,2n -k3,3n | head -n1)
+POSTHOG_CLI_SUPPORTS_INFO_PLIST=0
+if [ "$LOWEST" = "$INFO_PLIST_MIN_POSTHOG_CLI_VERSION" ]; then
+    POSTHOG_CLI_SUPPORTS_INFO_PLIST=1
+fi
+
+POSTHOG_INFO_PLIST_PATH=""
+# Bare C preprocessor macros cannot be expanded safely, and the product plist may belong to a
+# previous build. Preserve the Xcode-setting fallback for preprocessed plists.
+if [ "${INFOPLIST_PREPROCESS:-}" != "YES" ] && [ -n "${INFOPLIST_FILE:-}" ]; then
+    if [[ "$INFOPLIST_FILE" = /* ]]; then
+        POSTHOG_INFO_PLIST_PATH="$INFOPLIST_FILE"
+    elif [ -n "${SRCROOT:-}" ]; then
+        POSTHOG_INFO_PLIST_PATH="${SRCROOT}/${INFOPLIST_FILE}"
+    fi
+    if [ ! -f "$POSTHOG_INFO_PLIST_PATH" ]; then
+        POSTHOG_INFO_PLIST_PATH=""
+    fi
+fi
+
 resolve_source_plist_value() {
     local key="$1"
-    local plist_path="${INFOPLIST_FILE:-}"
     local value
     local token
     local name
@@ -169,22 +189,8 @@ resolve_source_plist_value() {
     local prefix
     local suffix
 
-    # Bare C preprocessor macros cannot be expanded safely here, and the product plist may belong to
-    # a previous build. Preserve the existing Xcode-setting fallback for preprocessed plists.
-    if [ "${INFOPLIST_PREPROCESS:-}" = "YES" ] || [ -z "$plist_path" ]; then
-        return
-    fi
-    if [[ "$plist_path" != /* ]]; then
-        if [ -z "${SRCROOT:-}" ]; then
-            return
-        fi
-        plist_path="${SRCROOT}/${plist_path}"
-    fi
-    if [ ! -f "$plist_path" ]; then
-        return
-    fi
-
-    value=$(/usr/libexec/PlistBuddy -c "Print :${key}" "$plist_path" 2>/dev/null) || return
+    [ -n "$POSTHOG_INFO_PLIST_PATH" ] || return
+    value=$(/usr/libexec/PlistBuddy -c "Print :${key}" "$POSTHOG_INFO_PLIST_PATH" 2>/dev/null) || return
     while [[ "$value" =~ (\$\(([A-Za-z_][A-Za-z0-9_]*)\)|\$\{([A-Za-z_][A-Za-z0-9_]*)\}) ]]; do
         token=${BASH_REMATCH[1]}
         name=${BASH_REMATCH[2]:-${BASH_REMATCH[3]}}
@@ -199,8 +205,12 @@ resolve_source_plist_value() {
     printf '%s' "$value"
 }
 
-POSTHOG_RELEASE_VERSION=$(resolve_source_plist_value "CFBundleShortVersionString")
-POSTHOG_BUILD_VERSION=$(resolve_source_plist_value "CFBundleVersion")
+POSTHOG_RELEASE_VERSION=""
+POSTHOG_BUILD_VERSION=""
+if [ "$POSTHOG_CLI_SUPPORTS_INFO_PLIST" -ne 1 ]; then
+    POSTHOG_RELEASE_VERSION=$(resolve_source_plist_value "CFBundleShortVersionString")
+    POSTHOG_BUILD_VERSION=$(resolve_source_plist_value "CFBundleVersion")
+fi
 
 # Build CLI arguments as an array so paths with spaces are preserved.
 CLI_ARGS=(--directory "${DWARF_DSYM_FOLDER_PATH}")
@@ -210,20 +220,25 @@ if [ -n "${DWARF_DSYM_FILE_NAME}" ]; then
     CLI_ARGS+=(--main-dsym "${DWARF_DSYM_FILE_NAME}")
 fi
 
-# Prefer literal values from the source Info.plist. EAS remote versioning can update these values
-# without changing MARKETING_VERSION or CURRENT_PROJECT_VERSION.
-if [ -n "${PRODUCT_BUNDLE_IDENTIFIER}" ]; then
-    CLI_ARGS+=(--release-name "${PRODUCT_BUNDLE_IDENTIFIER}")
-fi
-if [ -n "$POSTHOG_RELEASE_VERSION" ]; then
-    CLI_ARGS+=(--release-version "$POSTHOG_RELEASE_VERSION")
-elif [ -n "${MARKETING_VERSION}" ]; then
-    CLI_ARGS+=(--release-version "${MARKETING_VERSION}")
-fi
-if [ -n "$POSTHOG_BUILD_VERSION" ]; then
-    CLI_ARGS+=(--build "$POSTHOG_BUILD_VERSION")
-elif [ -n "${CURRENT_PROJECT_VERSION}" ]; then
-    CLI_ARGS+=(--build "${CURRENT_PROJECT_VERSION}")
+# Prefer values from the source Info.plist. EAS remote versioning can update these values without
+# changing MARKETING_VERSION or CURRENT_PROJECT_VERSION. Newer CLIs resolve the plist and its Xcode
+# build-setting references directly; older CLIs retain the script's legacy resolution.
+if [ "$POSTHOG_CLI_SUPPORTS_INFO_PLIST" -eq 1 ] && [ -n "$POSTHOG_INFO_PLIST_PATH" ]; then
+    CLI_ARGS+=(--info-plist "$POSTHOG_INFO_PLIST_PATH")
+else
+    if [ -n "${PRODUCT_BUNDLE_IDENTIFIER}" ]; then
+        CLI_ARGS+=(--release-name "${PRODUCT_BUNDLE_IDENTIFIER}")
+    fi
+    if [ -n "$POSTHOG_RELEASE_VERSION" ]; then
+        CLI_ARGS+=(--release-version "$POSTHOG_RELEASE_VERSION")
+    elif [ -n "${MARKETING_VERSION}" ]; then
+        CLI_ARGS+=(--release-version "${MARKETING_VERSION}")
+    fi
+    if [ -n "$POSTHOG_BUILD_VERSION" ]; then
+        CLI_ARGS+=(--build "$POSTHOG_BUILD_VERSION")
+    elif [ -n "${CURRENT_PROJECT_VERSION}" ]; then
+        CLI_ARGS+=(--build "${CURRENT_PROJECT_VERSION}")
+    fi
 fi
 # Include source if requested via env var
 if [ "${POSTHOG_INCLUDE_SOURCE}" = "1" ]; then

--- a/build-tools/upload-symbols.sh
+++ b/build-tools/upload-symbols.sh
@@ -159,6 +159,7 @@ if [ "$LOWEST" != "$MIN_POSTHOG_CLI_VERSION" ]; then
     exit 1
 fi
 
+# --info-plist landed in 0.15.0, but unresolved plist fields were fatal until 0.15.1.
 INFO_PLIST_MIN_POSTHOG_CLI_VERSION="0.15.1"
 LOWEST=$(printf '%s\n%s\n' "$INFO_PLIST_MIN_POSTHOG_CLI_VERSION" "$PH_CLI_VERSION" | sort -t. -k1,1n -k2,2n -k3,3n | head -n1)
 POSTHOG_CLI_SUPPORTS_INFO_PLIST=0
@@ -175,7 +176,7 @@ if [ "${INFOPLIST_PREPROCESS:-}" != "YES" ] && [ -n "${INFOPLIST_FILE:-}" ]; the
     elif [ -n "${SRCROOT:-}" ]; then
         POSTHOG_INFO_PLIST_PATH="${SRCROOT}/${INFOPLIST_FILE}"
     fi
-    if [ ! -f "$POSTHOG_INFO_PLIST_PATH" ]; then
+    if [ ! -f "$POSTHOG_INFO_PLIST_PATH" ] || ! /usr/libexec/PlistBuddy -c "Print" "$POSTHOG_INFO_PLIST_PATH" >/dev/null 2>&1; then
         POSTHOG_INFO_PLIST_PATH=""
     fi
 fi
@@ -205,12 +206,8 @@ resolve_source_plist_value() {
     printf '%s' "$value"
 }
 
-POSTHOG_RELEASE_VERSION=""
-POSTHOG_BUILD_VERSION=""
-if [ "$POSTHOG_CLI_SUPPORTS_INFO_PLIST" -ne 1 ]; then
-    POSTHOG_RELEASE_VERSION=$(resolve_source_plist_value "CFBundleShortVersionString")
-    POSTHOG_BUILD_VERSION=$(resolve_source_plist_value "CFBundleVersion")
-fi
+POSTHOG_RELEASE_VERSION=$(resolve_source_plist_value "CFBundleShortVersionString")
+POSTHOG_BUILD_VERSION=$(resolve_source_plist_value "CFBundleVersion")
 
 # Build CLI arguments as an array so paths with spaces are preserved.
 CLI_ARGS=(--directory "${DWARF_DSYM_FOLDER_PATH}")
@@ -221,24 +218,24 @@ if [ -n "${DWARF_DSYM_FILE_NAME}" ]; then
 fi
 
 # Prefer values from the source Info.plist. EAS remote versioning can update these values without
-# changing MARKETING_VERSION or CURRENT_PROJECT_VERSION. Newer CLIs resolve the plist and its Xcode
-# build-setting references directly; older CLIs retain the script's legacy resolution.
+# changing MARKETING_VERSION or CURRENT_PROJECT_VERSION. Explicit values preserve compound Xcode
+# build-setting resolution and the configured bundle identifier; the CLI fills any gaps from the
+# plist when supported.
 if [ "$POSTHOG_CLI_SUPPORTS_INFO_PLIST" -eq 1 ] && [ -n "$POSTHOG_INFO_PLIST_PATH" ]; then
     CLI_ARGS+=(--info-plist "$POSTHOG_INFO_PLIST_PATH")
-else
-    if [ -n "${PRODUCT_BUNDLE_IDENTIFIER}" ]; then
-        CLI_ARGS+=(--release-name "${PRODUCT_BUNDLE_IDENTIFIER}")
-    fi
-    if [ -n "$POSTHOG_RELEASE_VERSION" ]; then
-        CLI_ARGS+=(--release-version "$POSTHOG_RELEASE_VERSION")
-    elif [ -n "${MARKETING_VERSION}" ]; then
-        CLI_ARGS+=(--release-version "${MARKETING_VERSION}")
-    fi
-    if [ -n "$POSTHOG_BUILD_VERSION" ]; then
-        CLI_ARGS+=(--build "$POSTHOG_BUILD_VERSION")
-    elif [ -n "${CURRENT_PROJECT_VERSION}" ]; then
-        CLI_ARGS+=(--build "${CURRENT_PROJECT_VERSION}")
-    fi
+fi
+if [ -n "${PRODUCT_BUNDLE_IDENTIFIER}" ]; then
+    CLI_ARGS+=(--release-name "${PRODUCT_BUNDLE_IDENTIFIER}")
+fi
+if [ -n "$POSTHOG_RELEASE_VERSION" ]; then
+    CLI_ARGS+=(--release-version "$POSTHOG_RELEASE_VERSION")
+elif [ -n "${MARKETING_VERSION}" ]; then
+    CLI_ARGS+=(--release-version "${MARKETING_VERSION}")
+fi
+if [ -n "$POSTHOG_BUILD_VERSION" ]; then
+    CLI_ARGS+=(--build "$POSTHOG_BUILD_VERSION")
+elif [ -n "${CURRENT_PROJECT_VERSION}" ]; then
+    CLI_ARGS+=(--build "${CURRENT_PROJECT_VERSION}")
 fi
 # Include source if requested via env var
 if [ "${POSTHOG_INCLUDE_SOURCE}" = "1" ]; then

--- a/build-tools/upload-symbols.test.sh
+++ b/build-tools/upload-symbols.test.sh
@@ -189,9 +189,12 @@ test_uses_info_plist_with_supported_cli_versions() {
         [ "$STATUS" -eq 0 ] || fail "Expected upload with posthog-cli $version to succeed: $OUTPUT"
         assert_file_contains_line "$CLI_ARGS_FILE" "--info-plist"
         assert_file_contains_line "$CLI_ARGS_FILE" "$SRC_ROOT/Config/Info.plist"
-        assert_file_does_not_contain_line "$CLI_ARGS_FILE" "--release-name"
-        assert_file_does_not_contain_line "$CLI_ARGS_FILE" "--release-version"
-        assert_file_does_not_contain_line "$CLI_ARGS_FILE" "--build"
+        assert_file_contains_line "$CLI_ARGS_FILE" "--release-name"
+        assert_file_contains_line "$CLI_ARGS_FILE" "com.example.app"
+        assert_file_contains_line "$CLI_ARGS_FILE" "--release-version"
+        assert_file_contains_line "$CLI_ARGS_FILE" "2.10.0"
+        assert_file_contains_line "$CLI_ARGS_FILE" "--build"
+        assert_file_contains_line "$CLI_ARGS_FILE" "154"
     done
 }
 
@@ -269,46 +272,59 @@ EOF
 }
 
 test_resolves_custom_build_setting_references() {
-    create_fixture "custom-build-settings"
-    write_plist "$SRC_ROOT/Config/Info.plist" "\$(APP_VERSION)" "\${BUILD_NUMBER}"
-    TEST_INFOPLIST_FILE="$SRC_ROOT/Config/Info.plist"
-    TEST_APP_VERSION="9.9.9"
-    TEST_BUILD_NUMBER="321"
+    local version
+    for version in "0.10.0" "0.15.1"; do
+        create_fixture "custom-build-settings-${version}"
+        write_plist "$SRC_ROOT/Config/Info.plist" "\$(APP_VERSION)" "\${BUILD_NUMBER}"
+        TEST_INFOPLIST_FILE="$SRC_ROOT/Config/Info.plist"
+        TEST_APP_VERSION="9.9.9"
+        TEST_BUILD_NUMBER="321"
+        TEST_CLI_VERSION="$version"
 
-    run_upload
+        run_upload
 
-    [ "$STATUS" -eq 0 ] || fail "Expected custom build-setting versions to resolve: $OUTPUT"
-    assert_file_contains_line "$CLI_ARGS_FILE" "9.9.9"
-    assert_file_contains_line "$CLI_ARGS_FILE" "321"
+        [ "$STATUS" -eq 0 ] || fail "Expected custom build-setting versions to resolve with posthog-cli $version: $OUTPUT"
+        assert_file_contains_line "$CLI_ARGS_FILE" "9.9.9"
+        assert_file_contains_line "$CLI_ARGS_FILE" "321"
+    done
 }
 
 test_falls_back_for_preprocessed_plist_values() {
-    create_fixture "preprocessed"
-    write_plist "$SRC_ROOT/Config/Info.plist" "APP_VERSION" "APP_BUILD"
-    TEST_INFOPLIST_FILE="$SRC_ROOT/Config/Info.plist"
-    TEST_INFOPLIST_PREPROCESS="YES"
+    local version
+    for version in "0.10.0" "0.15.1"; do
+        create_fixture "preprocessed-${version}"
+        write_plist "$SRC_ROOT/Config/Info.plist" "APP_VERSION" "APP_BUILD"
+        TEST_INFOPLIST_FILE="$SRC_ROOT/Config/Info.plist"
+        TEST_INFOPLIST_PREPROCESS="YES"
+        TEST_CLI_VERSION="$version"
 
-    run_upload
+        run_upload
 
-    [ "$STATUS" -eq 0 ] || fail "Expected preprocessed plist values to use Xcode fallbacks: $OUTPUT"
-    assert_file_contains_line "$CLI_ARGS_FILE" "1.0"
-    assert_file_contains_line "$CLI_ARGS_FILE" "1"
+        [ "$STATUS" -eq 0 ] || fail "Expected preprocessed plist values to use Xcode fallbacks with posthog-cli $version: $OUTPUT"
+        assert_file_contains_line "$CLI_ARGS_FILE" "1.0"
+        assert_file_contains_line "$CLI_ARGS_FILE" "1"
+        assert_file_does_not_contain_line "$CLI_ARGS_FILE" "--info-plist"
+    done
 }
 
 test_resolves_compound_build_settings() {
-    create_fixture "compound-build-settings"
-    write_plist "$SRC_ROOT/Config/Info.plist" "\$(VERSION_MAJOR).\$(VERSION_MINOR)" "\$(BUILD_PREFIX)\$(BUILD_NUMBER)"
-    TEST_INFOPLIST_FILE="$SRC_ROOT/Config/Info.plist"
-    TEST_VERSION_MAJOR="2"
-    TEST_VERSION_MINOR="10.0"
-    TEST_BUILD_PREFIX="1"
-    TEST_BUILD_NUMBER="54"
+    local version
+    for version in "0.10.0" "0.15.1"; do
+        create_fixture "compound-build-settings-${version}"
+        write_plist "$SRC_ROOT/Config/Info.plist" "\$(VERSION_MAJOR).\$(VERSION_MINOR)" "\$(BUILD_PREFIX)\$(BUILD_NUMBER)"
+        TEST_INFOPLIST_FILE="$SRC_ROOT/Config/Info.plist"
+        TEST_VERSION_MAJOR="2"
+        TEST_VERSION_MINOR="10.0"
+        TEST_BUILD_PREFIX="1"
+        TEST_BUILD_NUMBER="54"
+        TEST_CLI_VERSION="$version"
 
-    run_upload
+        run_upload
 
-    [ "$STATUS" -eq 0 ] || fail "Expected compound build settings to resolve: $OUTPUT"
-    assert_file_contains_line "$CLI_ARGS_FILE" "2.10.0"
-    assert_file_contains_line "$CLI_ARGS_FILE" "154"
+        [ "$STATUS" -eq 0 ] || fail "Expected compound build settings to resolve with posthog-cli $version: $OUTPUT"
+        assert_file_contains_line "$CLI_ARGS_FILE" "2.10.0"
+        assert_file_contains_line "$CLI_ARGS_FILE" "154"
+    done
 }
 
 test_skips_cli_lookup_when_build_does_not_emit_dsyms() {
@@ -325,13 +341,33 @@ test_skips_cli_lookup_when_build_does_not_emit_dsyms() {
 }
 
 test_falls_back_for_unresolved_source_plist_versions() {
-    create_fixture "fallback"
-    write_plist "$SRC_ROOT/Config/Info.plist" "\$(MISSING_VERSION)" "\$(A)-\$(B)"
-    TEST_INFOPLIST_FILE="$SRC_ROOT/Config/Info.plist"
+    local version
+    for version in "0.10.0" "0.15.1"; do
+        create_fixture "fallback-${version}"
+        write_plist "$SRC_ROOT/Config/Info.plist" "\$(MISSING_VERSION)" "\$(A)-\$(B)"
+        TEST_INFOPLIST_FILE="$SRC_ROOT/Config/Info.plist"
+        TEST_CLI_VERSION="$version"
+
+        run_upload
+
+        [ "$STATUS" -eq 0 ] || fail "Expected upload with fallback versions and posthog-cli $version to succeed: $OUTPUT"
+        assert_file_contains_line "$CLI_ARGS_FILE" "--release-version"
+        assert_file_contains_line "$CLI_ARGS_FILE" "1.0"
+        assert_file_contains_line "$CLI_ARGS_FILE" "--build"
+        assert_file_contains_line "$CLI_ARGS_FILE" "1"
+    done
+}
+
+test_falls_back_for_malformed_source_plist() {
+    create_fixture "malformed"
+    printf 'not a plist' > "$SRC_ROOT/Config/Info.plist"
+    TEST_INFOPLIST_FILE="Config/Info.plist"
+    TEST_CLI_VERSION="0.15.1"
 
     run_upload
 
-    [ "$STATUS" -eq 0 ] || fail "Expected upload with fallback versions to succeed: $OUTPUT"
+    [ "$STATUS" -eq 0 ] || fail "Expected a malformed plist to use Xcode fallbacks: $OUTPUT"
+    assert_file_does_not_contain_line "$CLI_ARGS_FILE" "--info-plist"
     assert_file_contains_line "$CLI_ARGS_FILE" "--release-version"
     assert_file_contains_line "$CLI_ARGS_FILE" "1.0"
     assert_file_contains_line "$CLI_ARGS_FILE" "--build"
@@ -349,5 +385,6 @@ test_falls_back_for_preprocessed_plist_values
 test_resolves_compound_build_settings
 test_skips_cli_lookup_when_build_does_not_emit_dsyms
 test_falls_back_for_unresolved_source_plist_versions
+test_falls_back_for_malformed_source_plist
 
 echo "upload-symbols tests passed"

--- a/build-tools/upload-symbols.test.sh
+++ b/build-tools/upload-symbols.test.sh
@@ -18,6 +18,14 @@ assert_file_contains_line() {
     grep -Fxq -- "$expected" "$file" || fail "Expected '$expected' in $file"
 }
 
+assert_file_does_not_contain_line() {
+    local file="$1"
+    local unexpected="$2"
+    if grep -Fxq -- "$unexpected" "$file"; then
+        fail "Did not expect '$unexpected' in $file"
+    fi
+}
+
 create_fixture() {
     local name="$1"
     FIXTURE_DIR="${TEMP_DIR}/${name}"
@@ -45,6 +53,7 @@ create_fixture() {
     TEST_BUILD_PREFIX=""
     TEST_INFOPLIST_PREPROCESS="NO"
     TEST_INFOPLIST_PATH=""
+    TEST_CLI_VERSION="0.10.0"
 
     mkdir -p "$HOME_DIR/.posthog" "$FAKE_BIN" "$SRC_ROOT/Config" "$(dirname "$MAIN_DWARF")" "$(dirname "$APP_EXECUTABLE")"
     printf 'dwarf' > "$MAIN_DWARF"
@@ -53,7 +62,7 @@ create_fixture() {
     cat > "$HOME_DIR/.posthog/posthog-cli" <<'EOF'
 #!/bin/sh
 if [ "$1" = "--version" ]; then
-    echo "posthog-cli 0.10.0"
+    echo "posthog-cli $TEST_CLI_VERSION"
     exit 0
 fi
 printf '%s\n' "$@" > "$TEST_CLI_ARGS_FILE"
@@ -127,6 +136,7 @@ run_upload() {
         TEST_DWARFDUMP_ATTEMPTS="$DWARFDUMP_ATTEMPTS" \
         TEST_LSOF_ATTEMPTS="$LSOF_ATTEMPTS" \
         TEST_XCRUN_MARKER="$XCRUN_MARKER" \
+        TEST_CLI_VERSION="$TEST_CLI_VERSION" \
         bash "$UPLOAD_SCRIPT" 2>&1)
     STATUS=$?
     set -e
@@ -164,6 +174,25 @@ EOF
     assert_file_contains_line "$CLI_ARGS_FILE" "2.10.0"
     assert_file_contains_line "$CLI_ARGS_FILE" "--build"
     assert_file_contains_line "$CLI_ARGS_FILE" "154"
+}
+
+test_uses_info_plist_with_supported_cli_versions() {
+    local version
+    for version in "0.15.1" "0.16.0"; do
+        create_fixture "info-plist-${version}"
+        write_plist "$SRC_ROOT/Config/Info.plist" "2.10.0" "154"
+        TEST_INFOPLIST_FILE="Config/Info.plist"
+        TEST_CLI_VERSION="$version"
+
+        run_upload
+
+        [ "$STATUS" -eq 0 ] || fail "Expected upload with posthog-cli $version to succeed: $OUTPUT"
+        assert_file_contains_line "$CLI_ARGS_FILE" "--info-plist"
+        assert_file_contains_line "$CLI_ARGS_FILE" "$SRC_ROOT/Config/Info.plist"
+        assert_file_does_not_contain_line "$CLI_ARGS_FILE" "--release-name"
+        assert_file_does_not_contain_line "$CLI_ARGS_FILE" "--release-version"
+        assert_file_does_not_contain_line "$CLI_ARGS_FILE" "--build"
+    done
 }
 
 test_waits_until_matching_dsym_is_closed_for_writing() {
@@ -311,6 +340,7 @@ test_falls_back_for_unresolved_source_plist_versions() {
 
 bash -n "$UPLOAD_SCRIPT"
 test_waits_for_current_dsym_and_uses_source_plist_versions
+test_uses_info_plist_with_supported_cli_versions
 test_waits_until_matching_dsym_is_closed_for_writing
 test_fails_when_dsym_never_matches
 test_checks_for_cli_before_waiting_for_dsym


### PR DESCRIPTION
## :bulb: Motivation and Context

`upload-symbols.sh` resolves release metadata from the source Info.plist, including compound Xcode build-setting references that posthog-cli does not resolve itself. posthog-cli 0.15.1 added safe `--info-plist` fallback support, so it can fill metadata that the script cannot resolve.

Starting with 0.15.1, the script passes a valid source Info.plist alongside its explicit release arguments. Explicit values preserve compound build-setting resolution and `PRODUCT_BUNDLE_IDENTIFIER` behavior. Older CLI versions keep the existing arguments, and malformed or preprocessed plists fall back without failing the Release build.

## :green_heart: How did you test it?

- Ran `make testUploadSymbols`.
- Ran `make lint`.
- Ran Bash syntax checks and ShellCheck.
- Built the example app in Release mode and ran the upload script with real posthog-cli versions 0.14.1, 0.15.0, and 0.15.1 in dry-run mode.
- Verified compound build settings and malformed plist fallback with the real posthog-cli 0.15.1 binary.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent. XcodeBuildMCP was used for the Release example builds. The version cutoff, explicit metadata precedence, and fallback behavior were verified with locally installed posthog-cli binaries.
