### PR TITLE
fix(replay): keep session replay masks aligned with the captured frame

### DIFF
--- a/.changeset/gentle-geese-argue.md
+++ b/.changeset/gentle-geese-argue.md
@@ -2,4 +2,4 @@
 "posthog-ios": patch
 ---
 
-Fix session replay masks drifting away from the content they cover while a screen scrolls or animates. During fast scrolling, frames are captured with a renderer that keeps masks aligned but draws blur, video and Metal content flat — use `postHogMask()` for anything that must never appear in a recording.
+Fix session replay masks drifting away from the content they cover while a screen scrolls or animates. During fast scrolling, frames are captured with a renderer that keeps masks aligned but draws blur, video and Metal content flat, and that also ignores `layer.mask`, `maskView` and CoreAnimation `filters` — content hidden by those alone is drawn in full in those frames. Use `postHogMask()` for anything that must never appear in a recording.

--- a/.changeset/gentle-geese-argue.md
+++ b/.changeset/gentle-geese-argue.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Fix session replay masks drifting away from the content they cover while a screen scrolls or animates. During fast scrolling, frames are captured with a renderer that keeps masks aligned but draws blur, video and Metal content flat — use `postHogMask()` for anything that must never appear in a recording.

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		69F518122BAC783300F52C14 /* CGColor+Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69F518112BAC783300F52C14 /* CGColor+Util.swift */; };
 		69F518142BAC7F4300F52C14 /* Date+Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69F518132BAC7F4300F52C14 /* Date+Util.swift */; };
 		69F518162BAC7F9200F52C14 /* UIView+Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69F518152BAC7F9200F52C14 /* UIView+Util.swift */; };
+		654EC5A16DFC454F974A30A0 /* PostHogMaskSettleAnalysis.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25D0AE93D314E7FBE8DA8C7 /* PostHogMaskSettleAnalysis.swift */; };
 		69F518182BAC80A300F52C14 /* String+Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69F518172BAC80A300F52C14 /* String+Util.swift */; };
 		69F5181A2BAC81FC00F52C14 /* UITextInputTraits+Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69F518192BAC81FC00F52C14 /* UITextInputTraits+Util.swift */; };
 		69F518382BB2BA0100F52C14 /* PostHogSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69F518372BB2BA0100F52C14 /* PostHogSwizzler.swift */; };
@@ -946,6 +947,7 @@
 		69F518112BAC783300F52C14 /* CGColor+Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGColor+Util.swift"; sourceTree = "<group>"; };
 		69F518132BAC7F4300F52C14 /* Date+Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Util.swift"; sourceTree = "<group>"; };
 		69F518152BAC7F9200F52C14 /* UIView+Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Util.swift"; sourceTree = "<group>"; };
+		E25D0AE93D314E7FBE8DA8C7 /* PostHogMaskSettleAnalysis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostHogMaskSettleAnalysis.swift"; sourceTree = "<group>"; };
 		69F518172BAC80A300F52C14 /* String+Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Util.swift"; sourceTree = "<group>"; };
 		69F518192BAC81FC00F52C14 /* UITextInputTraits+Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextInputTraits+Util.swift"; sourceTree = "<group>"; };
 		69F518372BB2BA0100F52C14 /* PostHogSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSwizzler.swift; sourceTree = "<group>"; };
@@ -1896,6 +1898,7 @@
 				69F518112BAC783300F52C14 /* CGColor+Util.swift */,
 				69F518132BAC7F4300F52C14 /* Date+Util.swift */,
 				69F518152BAC7F9200F52C14 /* UIView+Util.swift */,
+				E25D0AE93D314E7FBE8DA8C7 /* PostHogMaskSettleAnalysis.swift */,
 				69F518172BAC80A300F52C14 /* String+Util.swift */,
 				DA30AE682D3EFB4F00465A64 /* Optional+Util.swift */,
 				69F518192BAC81FC00F52C14 /* UITextInputTraits+Util.swift */,
@@ -3215,6 +3218,7 @@
 				D9CC0D1E00010000000000B2 /* BeforeSendChain.swift in Sources */,
 				C236F4F79DBF4F55B918D685 /* BoxedBeforeSend.swift in Sources */,
 				69F518162BAC7F9200F52C14 /* UIView+Util.swift in Sources */,
+				654EC5A16DFC454F974A30A0 /* PostHogMaskSettleAnalysis.swift in Sources */,
 				69261D192AD9673500232EC7 /* PostHogUploadInfo.swift in Sources */,
 				DAC699EC2CCA73E5000D1D6B /* ForwardingPickerViewDelegate.swift in Sources */,
 				DA26419C2CC0499300CB427B /* PostHogAutocaptureEventTracker.swift in Sources */,

--- a/PostHog/Replay/PostHogMaskSettleAnalysis.swift
+++ b/PostHog/Replay/PostHogMaskSettleAnalysis.swift
@@ -44,13 +44,13 @@
         /// Raise only to stop idle screens paying for inflation, and only a little: this much
         /// displacement then goes uncompensated, so it is the one knob that trades directly
         /// against coverage.
-        private static let settleTolerancePoints = 80 * CGFloat(settleWindowSeconds)
+        static let settleTolerancePoints = 80 * CGFloat(settleWindowSeconds)
 
         /// Above 2000pt/s, drop to the presentation-tree renderer, whose masks cannot disagree with
         /// its pixels but which flattens blur, video and Metal. Raise to keep more motion at full
         /// fidelity, paying for it in larger inflated masks; lower for tighter masks and more flat
         /// frames. Sits between animation and fling so ordinary movement never flattens.
-        private static let driftBudgetPoints = 2000 * CGFloat(settleWindowSeconds)
+        static let driftBudgetPoints = 2000 * CGFloat(settleWindowSeconds)
 
         /// Lead added past the newer sample, as a fraction of the measured displacement — the union
         /// of both samples does the real covering, this only pads the direction of travel. On device

--- a/PostHog/Replay/PostHogMaskSettleAnalysis.swift
+++ b/PostHog/Replay/PostHogMaskSettleAnalysis.swift
@@ -1,0 +1,179 @@
+/// Pure geometry analysis for deciding whether masks have settled between two samples.
+/// Every function here takes its inputs as parameters and touches no instance state.
+#if os(iOS)
+    import Foundation
+    import UIKit
+
+    extension PostHogReplayIntegration {
+        /// A maskable rect tagged with its view/layer identity, so two samples taken moments
+        /// apart pair by identity rather than array index — traversal order isn't stable across
+        /// cell recycling or z-order changes. `object` is retained because a deallocation would
+        /// otherwise let `owner`'s address be reused by an unrelated view.
+        struct MaskedRegion {
+            let owner: ObjectIdentifier
+            let object: AnyObject
+            let rect: CGRect
+
+            init(_ object: AnyObject, rect: CGRect) {
+                owner = ObjectIdentifier(object)
+                self.object = object
+                self.rect = rect
+            }
+
+            init(_ view: UIView, in window: UIWindow?) {
+                self.init(view, rect: view.toPresentationRect(window))
+            }
+
+            init(_ layer: CALayer, in window: UIWindow?) {
+                self.init(layer, rect: layer.toPresentationRect(window))
+            }
+        }
+
+        // Tuning surface for the settle check. Defaults are deliberately conservative: measured on
+        // device, a 25ms window sees ~1.5pt of slow drift, ~4pt of CA animation and 185pt+ of a
+        // scroll fling, so everything except a fling keeps the same renderer session replay has
+        // always used, and only a fling trades fidelity for exactly-aligned masks.
+
+        /// Gap between the two geometry samples. Raising it delays each capture by that much and
+        /// holds the render-in-flight slot longer; lowering it makes the velocity estimate noisier.
+        /// The band thresholds derive from it, so changing it rescales them rather than
+        /// invalidating them.
+        static let settleWindowSeconds: TimeInterval = 0.025
+
+        /// At or below 80pt/s, geometry counts as unmoved and rects are used exactly as sampled.
+        /// Raise only to stop idle screens paying for inflation, and only a little: this much
+        /// displacement then goes uncompensated, so it is the one knob that trades directly
+        /// against coverage.
+        private static let settleTolerancePoints = 80 * CGFloat(settleWindowSeconds)
+
+        /// Above 2000pt/s, drop to the presentation-tree renderer, whose masks cannot disagree with
+        /// its pixels but which flattens blur, video and Metal. Raise to keep more motion at full
+        /// fidelity, paying for it in larger inflated masks; lower for tighter masks and more flat
+        /// frames. Sits between animation and fling so ordinary movement never flattens.
+        private static let driftBudgetPoints = 2000 * CGFloat(settleWindowSeconds)
+
+        /// Lead added past the newer sample, as a fraction of the measured displacement — the union
+        /// of both samples does the real covering, this only pads the direction of travel. On device
+        /// every value from 1 down to 1/64 held without exposing content, so it stays small; raise
+        /// it only if content is ever seen escaping the leading edge, since it grows every mask.
+        private static let driftLeadFraction: CGFloat = 1.0 / 16.0
+
+        /// Displacement between the two rect samples estimates how far the displayed pixels
+        /// trail current geometry — the display pipeline is about one settle window deep.
+        enum SettleBand {
+            case still, drift, motion
+
+            /// Only motion needs the presentation-tree renderer, which is aligned by construction.
+            var usesFidelity: Bool { self != .motion }
+        }
+
+        /// Old rects in `after` order, or nil when the two samples can't be paired one-to-one:
+        /// a nil sample, a count mismatch, a duplicate owner in either, or an owner with no
+        /// counterpart. Index-pairing would fail open into `.still`, so pairing is by identity.
+        /// Rects keyed by owner, or nil on a repeated owner — one object can match two maskable
+        /// heuristics and be collected twice, and pairing is then ambiguous. Built by hand rather
+        /// than Dictionary(uniqueKeysWithValues:), which traps on a duplicate key, and an SDK must
+        /// not turn that into a host-app crash.
+        private static func rectsByOwner(_ regions: [MaskedRegion]) -> [ObjectIdentifier: CGRect]? {
+            var byOwner: [ObjectIdentifier: CGRect] = [:]
+            byOwner.reserveCapacity(regions.count)
+            for region in regions where byOwner.updateValue(region.rect, forKey: region.owner) != nil {
+                return nil
+            }
+            return byOwner
+        }
+
+        private static func pairedOldRects(before: [MaskedRegion]?, after: [MaskedRegion]?) -> [CGRect]? {
+            guard let before, let after, before.count == after.count,
+                  let beforeByOwner = rectsByOwner(before)
+            else {
+                return nil
+            }
+            // Ordered to match `after` one-for-one: the result substitutes positionally
+            // for the `after` sample downstream.
+            var oldRects: [CGRect] = []
+            oldRects.reserveCapacity(after.count)
+            var seenAfterOwners: Set<ObjectIdentifier> = []
+            seenAfterOwners.reserveCapacity(after.count)
+            for region in after {
+                // No counterpart in `before` — something appeared/disappeared, fail closed.
+                guard let oldRect = beforeByOwner[region.owner] else {
+                    return nil
+                }
+                // A duplicate here would silently pair two `after` entries with the same old
+                // rect, hiding whatever the repeated owner displaced — fail closed instead.
+                guard seenAfterOwners.insert(region.owner).inserted else {
+                    return nil
+                }
+                oldRects.append(oldRect)
+            }
+            return oldRects
+        }
+
+        /// Per-owner union of two samples taken either side of a render: covers wherever the
+        /// content sat while the render ran. An owner present in only one sample was still on
+        /// screen for part of that window, so its rect is emitted as collected rather than
+        /// discarding the frame — a scroll that recycles cells changes the owner set constantly,
+        /// and dropping every such frame freezes the recording across the whole interaction.
+        /// Unlike `pairedOldRects` the result is a mask list, not positionally tied to `after`.
+        /// nil only for a repeated owner within one sample, where the pairing is genuinely
+        /// ambiguous and there is no safe rect to emit.
+        static func sweptRects(before: [MaskedRegion]?, after: [MaskedRegion]?) -> [CGRect]? {
+            guard let before, let after, let beforeByOwner = rectsByOwner(before) else {
+                return nil
+            }
+
+            var rects: [CGRect] = []
+            rects.reserveCapacity(max(before.count, after.count))
+            var seenAfterOwners: Set<ObjectIdentifier> = []
+            seenAfterOwners.reserveCapacity(after.count)
+            for region in after {
+                guard seenAfterOwners.insert(region.owner).inserted else {
+                    return nil
+                }
+                // No counterpart means the owner appeared mid-render; cover where it landed.
+                rects.append(beforeByOwner[region.owner].map { $0.union(region.rect) } ?? region.rect)
+            }
+            // Owners that went away mid-render were still displayed for part of it.
+            for region in before where !seenAfterOwners.contains(region.owner) {
+                rects.append(region.rect)
+            }
+            return rects
+        }
+
+        /// Banded by measured drift:
+        /// - still (≤ tolerance): rects as collected.
+        /// - drift (≤ budget): each mask inflated to the swept region (both sampled positions
+        ///   plus `driftLeadFraction` of it as lead).
+        /// - motion (anything else, or unreadable geometry): fail-closed default.
+        static func settleVerdict(
+            before: [MaskedRegion]?, after: [MaskedRegion]?
+        ) -> (band: SettleBand, inflatedRects: [CGRect]?) {
+            guard let after, let oldRects = pairedOldRects(before: before, after: after) else {
+                return (.motion, nil)
+            }
+            let maxDisplacement = zip(oldRects, after).map { old, new in
+                max(abs(old.minX - new.rect.minX), abs(old.minY - new.rect.minY),
+                    abs(old.width - new.rect.width), abs(old.height - new.rect.height))
+            }.max() ?? 0
+            if maxDisplacement <= settleTolerancePoints {
+                return (.still, nil)
+            }
+            if maxDisplacement <= driftBudgetPoints {
+                let inflated = zip(oldRects, after).map { old, region -> CGRect in
+                    let new = region.rect
+                    let deltaX = new.midX - old.midX
+                    let deltaY = new.midY - old.midY
+                    return old.union(new)
+                        .union(new.offsetBy(dx: deltaX * driftLeadFraction, dy: deltaY * driftLeadFraction))
+                        // Full displacement, not a fraction like the lead: this covers a position
+                        // that was never sampled, since a render pipeline deeper than one settle
+                        // window leaves the displayed pixels behind `before`.
+                        .union(old.offsetBy(dx: -deltaX, dy: -deltaY))
+                }
+                return (.drift, inflated)
+            }
+            return (.motion, nil)
+        }
+    }
+#endif

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -1108,11 +1108,10 @@
             return wireframe
         }
 
-        /// A maskable rect tagged with the identity of the view/layer it came from, so two
-        /// samples taken moments apart can be paired by identity instead of by array index —
-        /// traversal order isn't stable across cell recycling or z-order changes. Retains the
-        /// object so the identity stays valid for the sample's lifetime, otherwise a
-        /// deallocation could hand the same address to an unrelated view.
+        /// A maskable rect tagged with its view/layer identity, so two samples taken moments
+        /// apart pair by identity rather than array index — traversal order isn't stable across
+        /// cell recycling or z-order changes. `object` is retained because a deallocation would
+        /// otherwise let `owner`'s address be reused by an unrelated view.
         struct MaskedRegion {
             let owner: ObjectIdentifier
             let object: AnyObject
@@ -1133,14 +1132,12 @@
             }
         }
 
-        /// All regions to redact in `window`: heuristic widgets from the hierarchy walk
-        /// plus the live regions of `postHogMask()` reporters. Returns nil when a
-        /// reporter hasn't been laid out yet — the caller must skip the frame rather
-        /// than capture it under-masked.
-        ///
-        /// Pre-existing limitation with `screenshotModeBackgroundCapture` (off by
-        /// default): pixels render after this collection, so any rect source can go
-        /// stale for content committed in between.
+        /// All regions to redact in `window`: heuristic widgets from the hierarchy walk plus the
+        /// live regions of `postHogMask()` reporters. Returns nil when a reporter hasn't laid out
+        /// yet — the caller must skip the frame rather than capture it under-masked.
+        /// Pre-existing limitation with `screenshotModeBackgroundCapture` (off by default): pixels
+        /// render after this collection, so any rect source can go stale for content committed in
+        /// between.
         private func collectMaskedRegions(in window: UIWindow) -> [MaskedRegion]? {
             // The cheap registry read can veto the frame; keep it before the walk.
             let masked = PostHogSessionReplayMaskRegistry.shared.maskedRects(in: window)
@@ -1571,12 +1568,6 @@
         /// it only if content is ever seen escaping the leading edge, since it grows every mask.
         private static let driftLeadFraction: CGFloat = 1.0 / 16.0
 
-        /// Trail added behind the older sample, as a fraction of the measured displacement. Unlike
-        /// the lead, which pads past a position that WAS sampled, this covers a position that was
-        /// never sampled — if the render pipeline is deeper than one settle window, the displayed
-        /// pixels can sit behind `before` — so it gets a full settle window rather than a fraction.
-        private static let driftTrailFraction: CGFloat = 1.0
-
         /// Displacement between the two rect samples estimates how far the displayed pixels
         /// trail current geometry — the display pipeline is about one settle window deep.
         enum SettleBand {
@@ -1586,11 +1577,9 @@
             var usesFidelity: Bool { self != .motion }
         }
 
-        /// Old rects in `after` order, or nil when the two samples can't be paired one-to-one
-        /// (nil sample, count mismatch, a duplicate owner in either, or an owner with no counterpart).
-        /// Pairs by view identity, not array index — traversal order isn't stable across cell
-        /// recycling or z-order changes, so index-pairing could compare unrelated rects and
-        /// fail open into `.still`.
+        /// Old rects in `after` order, or nil when the two samples can't be paired one-to-one:
+        /// a nil sample, a count mismatch, a duplicate owner in either, or an owner with no
+        /// counterpart. Index-pairing would fail open into `.still`, so pairing is by identity.
         private static func pairedOldRects(before: [MaskedRegion]?, after: [MaskedRegion]?) -> [CGRect]? {
             guard let before, let after, before.count == after.count else {
                 return nil
@@ -1660,20 +1649,21 @@
                     let deltaY = new.midY - old.midY
                     return old.union(new)
                         .union(new.offsetBy(dx: deltaX * driftLeadFraction, dy: deltaY * driftLeadFraction))
-                        .union(old.offsetBy(dx: -deltaX * driftTrailFraction, dy: -deltaY * driftTrailFraction))
+                        // Full displacement, not a fraction like the lead: this covers a position
+                        // that was never sampled, since a render pipeline deeper than one settle
+                        // window leaves the displayed pixels behind `before`.
+                        .union(old.offsetBy(dx: -deltaX, dy: -deltaY))
                 }
                 return (.drift, inflated)
             }
             return (.motion, nil)
         }
 
-        /// Background capture's render sits between two mask samples instead of one: geometry is
-        /// measured, pixels render off-main, geometry is measured again, and the per-owner union of
-        /// both samples is what gets masked — provably covering wherever the content sat while the
-        /// render ran, no threshold needed since the interval is the render itself rather than a
-        /// guess. Always renders with `drawHierarchy` (never the presentation-tree renderer): that
-        /// renderer reads `layer.presentation()`, which is only safe from main, and every other read
-        /// on this path already sits inside `main.sync`.
+        /// The render sits between two mask samples instead of one: measure geometry, render
+        /// off-main, measure again, mask the per-owner union — provably covering wherever the
+        /// content sat while the render ran, so no threshold is needed. Always uses
+        /// `drawHierarchy`, never the presentation-tree renderer: that reads `layer.presentation()`,
+        /// which is main-only, and this path's other reads already sit inside `main.sync`.
         @discardableResult
         private func performBracketedBackgroundCapture(window: UIWindow, screenName: String?, postHog: PostHogSDK) -> Bool {
             defer { finishScreenshotRender() }

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -1586,19 +1586,14 @@
             var usesFidelity: Bool { self != .motion }
         }
 
-        /// Banded by measured drift:
-        /// - still (≤ tolerance): rects as collected.
-        /// - drift (≤ budget): each mask inflated to the swept region (both sampled positions
-        ///   plus `driftLeadFraction` of it as lead).
-        /// - motion (anything else, or unreadable geometry): fail-closed default.
+        /// Old rects in `after` order, or nil when the two samples can't be paired one-to-one
+        /// (nil sample, count mismatch, a duplicate owner in either, or an owner with no counterpart).
         /// Pairs by view identity, not array index — traversal order isn't stable across cell
         /// recycling or z-order changes, so index-pairing could compare unrelated rects and
         /// fail open into `.still`.
-        static func settleVerdict(
-            before: [MaskedRegion]?, after: [MaskedRegion]?
-        ) -> (band: SettleBand, inflatedRects: [CGRect]?) {
+        private static func pairedOldRects(before: [MaskedRegion]?, after: [MaskedRegion]?) -> [CGRect]? {
             guard let before, let after, before.count == after.count else {
-                return (.motion, nil)
+                return nil
             }
             // Built by hand rather than Dictionary(uniqueKeysWithValues:), which traps on a
             // duplicate owner — one object can match two maskable heuristics and be collected
@@ -1607,9 +1602,9 @@
             var beforeByOwner: [ObjectIdentifier: CGRect] = [:]
             beforeByOwner.reserveCapacity(before.count)
             for region in before where beforeByOwner.updateValue(region.rect, forKey: region.owner) != nil {
-                return (.motion, nil)
+                return nil
             }
-            // Ordered to match `after` one-for-one: inflatedRects substitutes positionally
+            // Ordered to match `after` one-for-one: the result substitutes positionally
             // for the `after` sample downstream.
             var oldRects: [CGRect] = []
             oldRects.reserveCapacity(after.count)
@@ -1618,14 +1613,38 @@
             for region in after {
                 // No counterpart in `before` — something appeared/disappeared, fail closed.
                 guard let oldRect = beforeByOwner[region.owner] else {
-                    return (.motion, nil)
+                    return nil
                 }
                 // A duplicate here would silently pair two `after` entries with the same old
                 // rect, hiding whatever the repeated owner displaced — fail closed instead.
                 guard seenAfterOwners.insert(region.owner).inserted else {
-                    return (.motion, nil)
+                    return nil
                 }
                 oldRects.append(oldRect)
+            }
+            return oldRects
+        }
+
+        /// Per-owner union of two samples taken either side of a render, in `after` order:
+        /// covers wherever the content sat while the render ran. nil when the samples can't be
+        /// paired, so the caller skips the frame rather than masking the wrong places.
+        static func sweptRects(before: [MaskedRegion]?, after: [MaskedRegion]?) -> [CGRect]? {
+            guard let oldRects = pairedOldRects(before: before, after: after), let after else {
+                return nil
+            }
+            return zip(oldRects, after).map { $0.union($1.rect) }
+        }
+
+        /// Banded by measured drift:
+        /// - still (≤ tolerance): rects as collected.
+        /// - drift (≤ budget): each mask inflated to the swept region (both sampled positions
+        ///   plus `driftLeadFraction` of it as lead).
+        /// - motion (anything else, or unreadable geometry): fail-closed default.
+        static func settleVerdict(
+            before: [MaskedRegion]?, after: [MaskedRegion]?
+        ) -> (band: SettleBand, inflatedRects: [CGRect]?) {
+            guard let after, let oldRects = pairedOldRects(before: before, after: after) else {
+                return (.motion, nil)
             }
             let maxDisplacement = zip(oldRects, after).map { old, new in
                 max(abs(old.minX - new.rect.minX), abs(old.minY - new.rect.minY),
@@ -1646,6 +1665,46 @@
                 return (.drift, inflated)
             }
             return (.motion, nil)
+        }
+
+        /// Background capture's render sits between two mask samples instead of one: geometry is
+        /// measured, pixels render off-main, geometry is measured again, and the per-owner union of
+        /// both samples is what gets masked — provably covering wherever the content sat while the
+        /// render ran, no threshold needed since the interval is the render itself rather than a
+        /// guess. Always renders with `drawHierarchy` (never the presentation-tree renderer): that
+        /// renderer reads `layer.presentation()`, which is only safe from main, and every other read
+        /// on this path already sits inside `main.sync`.
+        @discardableResult
+        private func performBracketedBackgroundCapture(window: UIWindow, screenName: String?, postHog: PostHogSDK) -> Bool {
+            defer { finishScreenshotRender() }
+
+            let before = DispatchQueue.main.sync { self.collectMaskedRegions(in: window) }
+            // Off-main on purpose, and the reason this mode exists: drawHierarchy on main was too
+            // slow to keep up. UIKit documents it as main-thread-only, so it stays experimental
+            // behind `screenshotModeBackgroundCapture` — the bracketing above is what keeps masks
+            // aligned with pixels despite the render happening on this thread.
+            let image = window.toImage(preferFidelityRenderer: true)
+            let capture = DispatchQueue.main.sync { () -> ScreenshotCapture? in
+                let after = self.collectMaskedRegions(in: window)
+                guard let rects = Self.sweptRects(before: before, after: after) else {
+                    return nil
+                }
+                return self.collectScreenshotMetadata(window, preferFidelityRenderer: true, overrideMaskRects: rects, renderImage: false)
+            }
+
+            guard let capture, let image, postHog.isSessionReplayActive() else {
+                return false
+            }
+
+            return renderAndEnqueueScreenshot(
+                capture.wireframe,
+                window: window,
+                windowSize: capture.windowSize,
+                screenName: screenName,
+                postHog: postHog,
+                timestampDate: capture.timestampDate,
+                image: image
+            )
         }
 
         /// Settle-then-shoot: after one display-pipeline depth, unchanged mask geometry proves the
@@ -1699,7 +1758,7 @@
 
                 if postHog.config.sessionReplayConfig.screenshotModeBackgroundCapture {
                     PostHogReplayIntegration.dispatchQueue.async { [weak self] in
-                        self?.performScreenshotCapture(window: window, screenName: screenName, postHog: postHog)
+                        self?.performBracketedBackgroundCapture(window: window, screenName: screenName, postHog: postHog)
                     }
                 } else {
                     scheduleSettledCapture(window: window, screenName: screenName, postHog: postHog)

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -13,7 +13,7 @@
     import UIKit
     import WebKit
 
-    class PostHogReplayIntegration: PostHogIntegration { // swiftlint:disable:this type_body_length
+    class PostHogReplayIntegration: PostHogIntegration {
         var requiresSwizzling: Bool { true }
 
         private static let integrationInstallState = PostHogIntegrationInstallState()
@@ -1108,30 +1108,6 @@
             return wireframe
         }
 
-        /// A maskable rect tagged with its view/layer identity, so two samples taken moments
-        /// apart pair by identity rather than array index — traversal order isn't stable across
-        /// cell recycling or z-order changes. `object` is retained because a deallocation would
-        /// otherwise let `owner`'s address be reused by an unrelated view.
-        struct MaskedRegion {
-            let owner: ObjectIdentifier
-            let object: AnyObject
-            let rect: CGRect
-
-            init(_ object: AnyObject, rect: CGRect) {
-                owner = ObjectIdentifier(object)
-                self.object = object
-                self.rect = rect
-            }
-
-            init(_ view: UIView, in window: UIWindow?) {
-                self.init(view, rect: view.toPresentationRect(window))
-            }
-
-            init(_ layer: CALayer, in window: UIWindow?) {
-                self.init(layer, rect: layer.toPresentationRect(window))
-            }
-        }
-
         /// All regions to redact in `window`: heuristic widgets from the hierarchy walk plus the
         /// live regions of `postHogMask()` reporters. Returns nil when a reporter hasn't laid out
         /// yet — the caller must skip the frame rather than capture it under-masked.
@@ -1226,9 +1202,16 @@
         ) -> Bool {
             defer { finishScreenshotRender() }
 
-            // Off-main callers (`screenshotModeBackgroundCapture`) render on their own thread, and the
-            // bridge's first frame needs its own `afterScreenUpdates: true` pass — bouncing either
-            // render onto main here would undo the point of that path.
+            // Ahead of the render, not just after it: collect() now renders the image, so a session
+            // that stopped between the snapshot trigger and here would otherwise pay for a
+            // full-window render and throw it away.
+            guard postHog.isSessionReplayActive() else {
+                return false
+            }
+
+            // The bridge's first frame needs its own `afterScreenUpdates: true` pass, so it renders
+            // later in renderAndEnqueueScreenshot rather than in this tick. Both callers arrive on
+            // main already; the sync below is defensive.
             let rendersInMeasuringTick = Thread.isMainThread && !episodeFirstFrame
             func collect() -> ScreenshotCapture? {
                 collectScreenshotMetadata(
@@ -1539,126 +1522,6 @@
             )
         }
 
-        // Tuning surface for the settle check. Defaults are deliberately conservative: measured on
-        // device, a 25ms window sees ~1.5pt of slow drift, ~4pt of CA animation and 185pt+ of a
-        // scroll fling, so everything except a fling keeps the same renderer session replay has
-        // always used, and only a fling trades fidelity for exactly-aligned masks.
-
-        /// Gap between the two geometry samples, and the unit every threshold below is measured in.
-        /// Raising it delays each capture by that much and holds the render-in-flight slot longer;
-        /// lowering it makes the velocity estimate noisier. Change this and the two point
-        /// thresholds stop meaning what they say — rescale them by the same factor.
-        private static let settleWindowSeconds: TimeInterval = 0.025
-
-        /// At or below this, geometry counts as unmoved and rects are used exactly as sampled.
-        /// Raise only to stop idle screens paying for inflation, and only a little: this much
-        /// displacement then goes uncompensated, so it is the one knob that trades directly
-        /// against coverage.
-        private static let settleTolerancePoints: CGFloat = 2.0
-
-        /// Above this, drop to the presentation-tree renderer, whose masks cannot disagree with its
-        /// pixels but which flattens blur, video and Metal. Raise to keep more motion at full
-        /// fidelity, paying for it in larger inflated masks; lower for tighter masks and more flat
-        /// frames. Sits between animation and fling so ordinary movement never flattens.
-        private static let driftBudgetPoints: CGFloat = 100.0
-
-        /// Lead added past the newer sample, as a fraction of the measured displacement — the union
-        /// of both samples does the real covering, this only pads the direction of travel. On device
-        /// every value from 1 down to 1/64 held without exposing content, so it stays small; raise
-        /// it only if content is ever seen escaping the leading edge, since it grows every mask.
-        private static let driftLeadFraction: CGFloat = 1.0 / 16.0
-
-        /// Displacement between the two rect samples estimates how far the displayed pixels
-        /// trail current geometry — the display pipeline is about one settle window deep.
-        enum SettleBand {
-            case still, drift, motion
-
-            /// Only motion needs the presentation-tree renderer, which is aligned by construction.
-            var usesFidelity: Bool { self != .motion }
-        }
-
-        /// Old rects in `after` order, or nil when the two samples can't be paired one-to-one:
-        /// a nil sample, a count mismatch, a duplicate owner in either, or an owner with no
-        /// counterpart. Index-pairing would fail open into `.still`, so pairing is by identity.
-        private static func pairedOldRects(before: [MaskedRegion]?, after: [MaskedRegion]?) -> [CGRect]? {
-            guard let before, let after, before.count == after.count else {
-                return nil
-            }
-            // Built by hand rather than Dictionary(uniqueKeysWithValues:), which traps on a
-            // duplicate owner — one object can match two maskable heuristics and be collected
-            // twice, and an SDK must not turn that into a host-app crash. Ambiguous pairing
-            // fails closed instead.
-            var beforeByOwner: [ObjectIdentifier: CGRect] = [:]
-            beforeByOwner.reserveCapacity(before.count)
-            for region in before where beforeByOwner.updateValue(region.rect, forKey: region.owner) != nil {
-                return nil
-            }
-            // Ordered to match `after` one-for-one: the result substitutes positionally
-            // for the `after` sample downstream.
-            var oldRects: [CGRect] = []
-            oldRects.reserveCapacity(after.count)
-            var seenAfterOwners: Set<ObjectIdentifier> = []
-            seenAfterOwners.reserveCapacity(after.count)
-            for region in after {
-                // No counterpart in `before` — something appeared/disappeared, fail closed.
-                guard let oldRect = beforeByOwner[region.owner] else {
-                    return nil
-                }
-                // A duplicate here would silently pair two `after` entries with the same old
-                // rect, hiding whatever the repeated owner displaced — fail closed instead.
-                guard seenAfterOwners.insert(region.owner).inserted else {
-                    return nil
-                }
-                oldRects.append(oldRect)
-            }
-            return oldRects
-        }
-
-        /// Per-owner union of two samples taken either side of a render, in `after` order:
-        /// covers wherever the content sat while the render ran. nil when the samples can't be
-        /// paired, so the caller skips the frame rather than masking the wrong places.
-        static func sweptRects(before: [MaskedRegion]?, after: [MaskedRegion]?) -> [CGRect]? {
-            guard let oldRects = pairedOldRects(before: before, after: after), let after else {
-                return nil
-            }
-            return zip(oldRects, after).map { $0.union($1.rect) }
-        }
-
-        /// Banded by measured drift:
-        /// - still (≤ tolerance): rects as collected.
-        /// - drift (≤ budget): each mask inflated to the swept region (both sampled positions
-        ///   plus `driftLeadFraction` of it as lead).
-        /// - motion (anything else, or unreadable geometry): fail-closed default.
-        static func settleVerdict(
-            before: [MaskedRegion]?, after: [MaskedRegion]?
-        ) -> (band: SettleBand, inflatedRects: [CGRect]?) {
-            guard let after, let oldRects = pairedOldRects(before: before, after: after) else {
-                return (.motion, nil)
-            }
-            let maxDisplacement = zip(oldRects, after).map { old, new in
-                max(abs(old.minX - new.rect.minX), abs(old.minY - new.rect.minY),
-                    abs(old.width - new.rect.width), abs(old.height - new.rect.height))
-            }.max() ?? 0
-            if maxDisplacement <= settleTolerancePoints {
-                return (.still, nil)
-            }
-            if maxDisplacement <= driftBudgetPoints {
-                let inflated = zip(oldRects, after).map { old, region -> CGRect in
-                    let new = region.rect
-                    let deltaX = new.midX - old.midX
-                    let deltaY = new.midY - old.midY
-                    return old.union(new)
-                        .union(new.offsetBy(dx: deltaX * driftLeadFraction, dy: deltaY * driftLeadFraction))
-                        // Full displacement, not a fraction like the lead: this covers a position
-                        // that was never sampled, since a render pipeline deeper than one settle
-                        // window leaves the displayed pixels behind `before`.
-                        .union(old.offsetBy(dx: -deltaX, dy: -deltaY))
-                }
-                return (.drift, inflated)
-            }
-            return (.motion, nil)
-        }
-
         /// The render sits between two mask samples instead of one: measure geometry, render
         /// off-main, measure again, mask the per-owner union — provably covering wherever the
         /// content sat while the render ran, so no threshold is needed. Always uses
@@ -1677,9 +1540,12 @@
             let capture = DispatchQueue.main.sync { () -> ScreenshotCapture? in
                 let after = self.collectMaskedRegions(in: window)
                 guard let rects = Self.sweptRects(before: before, after: after) else {
+                    hedgeLog("[Session Replay] Skipping snapshot: mask samples could not be paired")
                     return nil
                 }
-                return self.collectScreenshotMetadata(window, preferFidelityRenderer: true, overrideMaskRects: rects, renderImage: false)
+                // No renderer preference: `renderImage: false` means this call never renders — the
+                // image was already taken off-main above.
+                return self.collectScreenshotMetadata(window, overrideMaskRects: rects, renderImage: false)
             }
 
             guard let capture, let image, postHog.isSessionReplayActive() else {
@@ -1702,6 +1568,14 @@
         /// (blur/video/Metal intact); drift within budget keeps drawHierarchy with masks swept to
         /// cover it, only motion or an unpairable sample drops to render(in:) for alignment.
         private func scheduleSettledCapture(window: UIWindow, screenName: String?, postHog: PostHogSDK) {
+            // Same bails prepareScreenshotWireframe applies, hoisted ahead of the two sampling
+            // walks: without this a view controller transition pays for both traversals and then
+            // discards them, where before it walked the hierarchy zero times.
+            guard window.isVisible(), !isAnimatingTransition(window) else {
+                finishScreenshotRender()
+                return
+            }
+
             let sentinelRegions = collectMaskedRegions(in: window)
             DispatchQueue.main.asyncAfter(deadline: .now() + Self.settleWindowSeconds) { [weak self] in
                 guard let self else { return }

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -862,7 +862,7 @@
             return (hasText, hasGraphic)
         }
 
-        private func findMaskableWidgets(_ view: UIView, _ window: UIWindow, _ maskableWidgets: inout [CGRect], _ maskChildren: inout Bool) {
+        private func findMaskableWidgets(_ view: UIView, _ window: UIWindow, _ maskableWidgets: inout [MaskedRegion], _ maskChildren: inout Bool) {
             // User explicitly marked this view (and its subviews) as non-maskable through `.postHogNoMask()` view modifier
             if view.postHogNoMask {
                 return
@@ -870,7 +870,7 @@
 
             if let textView = view as? UITextView { // TextEditor, SwiftUI.TextEditorTextView, SwiftUI.UIKitTextView
                 if isTextViewSensitive(textView) {
-                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    maskableWidgets.append(.init(view, in: window))
                     return
                 }
             }
@@ -878,21 +878,21 @@
             /// SwiftUI: `TextField`, `SecureField` will land here
             if let textField = view as? UITextField {
                 if isTextFieldSensitive(textField) {
-                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    maskableWidgets.append(.init(view, in: window))
                     return
                 }
             }
 
             if let reactNativeTextView = reactNativeTextView {
                 if view.isKind(of: reactNativeTextView), config?.sessionReplayConfig.maskAllTextInputs == true {
-                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    maskableWidgets.append(.init(view, in: window))
                     return
                 }
             }
 
             if let reactNativeParagraphView = reactNativeParagraphView {
                 if view.isKind(of: reactNativeParagraphView), config?.sessionReplayConfig.maskAllTextInputs == true {
-                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    maskableWidgets.append(.init(view, in: window))
                     return
                 }
             }
@@ -900,21 +900,21 @@
             /// SwiftUI: Some control images like the ones in `Picker` view may land here
             if let image = view as? UIImageView {
                 if isImageViewSensitive(image) {
-                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    maskableWidgets.append(.init(view, in: window))
                     return
                 }
             }
 
             if let reactNativeImageView = reactNativeImageView {
                 if view.isKind(of: reactNativeImageView), config?.sessionReplayConfig.maskAllImages == true {
-                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    maskableWidgets.append(.init(view, in: window))
                     return
                 }
             }
 
             if let reactNativeImageComponentView = reactNativeImageComponentView {
                 if view.isKind(of: reactNativeImageComponentView), config?.sessionReplayConfig.maskAllImages == true {
-                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    maskableWidgets.append(.init(view, in: window))
                     return
                 }
             }
@@ -925,14 +925,14 @@
                 let shouldMaskGraphics = content.hasGraphic && config?.sessionReplayConfig.maskAllImages == true
                 if shouldMaskText || shouldMaskGraphics {
                     // SVG nodes share a drawing surface, so mask the root when enabled content is present.
-                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    maskableWidgets.append(.init(view, in: window))
                     return
                 }
             }
 
             if let label = view as? UILabel { // Text, this code might never be reachable in SwiftUI, see swiftUIImageTypes instead
                 if isLabelSensitive(label) {
-                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    maskableWidgets.append(.init(view, in: window))
                     return
                 }
             }
@@ -941,7 +941,7 @@
                 // since we cannot mask the webview content, if masking texts or images are enabled
                 // we mask the whole webview as well
                 if isAnyInputSensitive(webView) {
-                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    maskableWidgets.append(.init(view, in: window))
                     return
                 }
             }
@@ -949,7 +949,7 @@
             /// SwiftUI: `SwiftUI.UIKitIconPreferringButton` and other subclasses will land here
             if let button = view as? UIButton {
                 if isButtonSensitive(button) {
-                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    maskableWidgets.append(.init(view, in: window))
                     return
                 }
             }
@@ -957,7 +957,7 @@
             /// SwiftUI: `Toggle` (no text, labels are just rendered to Text (swiftUIImageTypes))
             if let theSwitch = view as? UISwitch {
                 if isSwitchSensitive(theSwitch) {
-                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    maskableWidgets.append(.init(view, in: window))
                     return
                 }
             }
@@ -967,7 +967,7 @@
                let systemSandboxedView,
                view.isKind(of: systemSandboxedView)
             {
-                maskableWidgets.append(view.toAbsoluteRect(window))
+                maskableWidgets.append(.init(view, in: window))
                 return
             }
 
@@ -977,7 +977,7 @@
             /// SwiftUI: `Picker` with .pickerStyle(.wheel) will land here
             if let picker = view as? UIPickerView {
                 if isTextInputSensitive(picker), !hasSubViews {
-                    maskableWidgets.append(picker.toAbsoluteRect(window))
+                    maskableWidgets.append(.init(picker, in: window))
                     return
                 }
             }
@@ -985,7 +985,7 @@
             /// SwiftUI: Text based views like `Text`, `Button`, `TextEditor`
             if swiftUITextBasedViewTypes.contains(where: view.isKind(of:)) {
                 if isTextInputSensitive(view), !hasSubViews {
-                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    maskableWidgets.append(.init(view, in: window))
                     return
                 }
             }
@@ -993,7 +993,7 @@
             /// SwiftUI: Image based views like `Image`, `AsyncImage`. (Note: We check the layer type here)
             if swiftUIImageLayerTypes.contains(where: view.layer.isKind(of:)) {
                 if isSwiftUIImageSensitive(view), !hasSubViews {
-                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    maskableWidgets.append(.init(view, in: window))
                     return
                 }
             }
@@ -1014,7 +1014,7 @@
             // this can be anything, so better to be conservative
             if swiftUIGenericTypes.contains(where: { view.isKind(of: $0) }), !isSwiftUILayerSafe(view.layer) {
                 if isTextInputSensitive(view), !hasSubViews {
-                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    maskableWidgets.append(.init(view, in: window))
                     return
                 }
             }
@@ -1027,7 +1027,7 @@
 
                 // Check if the rectangles do not match
                 if !viewRect.equalTo(windowRect) {
-                    maskableWidgets.append(view.toAbsoluteRect(window))
+                    maskableWidgets.append(.init(view, in: window))
                 } else {
                     maskChildren = true
                 }
@@ -1052,7 +1052,7 @@
         /// heuristics below inspect layers as well. (`.postHogMask()` regions are collected
         /// separately via the mask-reporter registry.)
         @available(iOS 26.0, *)
-        private func findMaskableLayers(_ layer: CALayer, _ view: UIView, _ window: UIWindow, _ maskableWidgets: inout [CGRect]) {
+        private func findMaskableLayers(_ layer: CALayer, _ view: UIView, _ window: UIWindow, _ maskableWidgets: inout [MaskedRegion]) {
             for sublayer in layer.sublayers ?? [] {
                 // Skip layers tagged with .postHogNoMask()
                 if sublayer.postHogNoMask {
@@ -1069,14 +1069,14 @@
                 // Text-based layers
                 if swiftUITextBasedViewTypes.contains(where: sublayer.isKind(of:)) {
                     if isTextInputSensitive(view) {
-                        maskableWidgets.append(sublayer.toAbsoluteRect(window))
+                        maskableWidgets.append(.init(sublayer, in: window))
                     }
                 }
 
                 // Image layers
                 if swiftUIImageLayerTypes.contains(where: sublayer.isKind(of:)) {
                     if isSwiftUIImageSensitive(view) {
-                        maskableWidgets.append(sublayer.toAbsoluteRect(window))
+                        maskableWidgets.append(.init(sublayer, in: window))
                     }
                 }
 
@@ -1087,7 +1087,7 @@
             }
         }
 
-        private func prepareScreenshotWireframe(_ window: UIWindow) -> RRWireframe? {
+        private func prepareScreenshotWireframe(_ window: UIWindow, overrideMaskRects: [CGRect]? = nil) -> RRWireframe? {
             // this will bail on view controller animations (interactive or not)
             if !window.isVisible() || isAnimatingTransition(window) {
                 return nil
@@ -1095,7 +1095,9 @@
 
             // nil = a mask reporter has no geometry yet; capturing now could show that
             // content unmasked. Skip the tick (fail closed), like the transition bail.
-            guard let maskableWidgets = collectMaskableRects(in: window) else {
+            // overrideMaskRects: the settle check's drift band passes swept-region rects
+            // measured moments ago, so masks cover the travel path instead of one instant.
+            guard let maskableWidgets = overrideMaskRects ?? collectMaskableRects(in: window) else {
                 hedgeLog("[Session Replay] Skipping snapshot: a masked view hasn't been laid out yet")
                 return nil
             }
@@ -1106,37 +1108,81 @@
             return wireframe
         }
 
-        /// All rects to redact in `window`: heuristic widgets from the hierarchy walk
-        /// plus the live rects of `postHogMask()` reporters. Returns nil when a
+        /// A maskable rect tagged with the identity of the view/layer it came from, so two
+        /// samples taken moments apart can be paired by identity instead of by array index —
+        /// traversal order isn't stable across cell recycling or z-order changes. Retains the
+        /// object so the identity stays valid for the sample's lifetime, otherwise a
+        /// deallocation could hand the same address to an unrelated view.
+        struct MaskedRegion {
+            let owner: ObjectIdentifier
+            let object: AnyObject
+            let rect: CGRect
+
+            init(_ object: AnyObject, rect: CGRect) {
+                owner = ObjectIdentifier(object)
+                self.object = object
+                self.rect = rect
+            }
+
+            init(_ view: UIView, in window: UIWindow?) {
+                self.init(view, rect: view.toPresentationRect(window))
+            }
+
+            init(_ layer: CALayer, in window: UIWindow?) {
+                self.init(layer, rect: layer.toPresentationRect(window))
+            }
+        }
+
+        /// All regions to redact in `window`: heuristic widgets from the hierarchy walk
+        /// plus the live regions of `postHogMask()` reporters. Returns nil when a
         /// reporter hasn't been laid out yet — the caller must skip the frame rather
         /// than capture it under-masked.
         ///
         /// Pre-existing limitation with `screenshotModeBackgroundCapture` (off by
         /// default): pixels render after this collection, so any rect source can go
         /// stale for content committed in between.
-        func collectMaskableRects(in window: UIWindow) -> [CGRect]? {
+        private func collectMaskedRegions(in window: UIWindow) -> [MaskedRegion]? {
             // The cheap registry read can veto the frame; keep it before the walk.
             let masked = PostHogSessionReplayMaskRegistry.shared.maskedRects(in: window)
             guard !masked.hasUnsettledReporters else {
                 return nil
             }
 
-            var maskableWidgets: [CGRect] = []
+            var maskableWidgets: [MaskedRegion] = []
             var maskChildren = false
             findMaskableWidgets(window, window, &maskableWidgets, &maskChildren)
-            maskableWidgets.append(contentsOf: masked.rects)
+            maskableWidgets.append(contentsOf: masked.regions)
             return maskableWidgets
+        }
+
+        func collectMaskableRects(in window: UIWindow) -> [CGRect]? {
+            collectMaskedRegions(in: window)?.map(\.rect)
+        }
+
+        private struct ScreenshotCapture {
+            let wireframe: RRWireframe
+            let windowSize: CGSize
+            let timestampDate: Date
+            let image: UIImage?
         }
 
         // To be called from main thread
         private func collectScreenshotMetadata(
-            _ window: UIWindow
-        ) -> (wireframe: RRWireframe, windowSize: CGSize, timestampDate: Date)? {
-            guard let wireframe = autoreleasepool(invoking: { prepareScreenshotWireframe(window) }) else {
+            _ window: UIWindow,
+            preferFidelityRenderer: Bool = true,
+            overrideMaskRects: [CGRect]? = nil,
+            renderImage: Bool = true
+        ) -> ScreenshotCapture? {
+            guard let wireframe = autoreleasepool(invoking: { prepareScreenshotWireframe(window, overrideMaskRects: overrideMaskRects) }) else {
                 return nil
             }
 
-            return (wireframe, window.bounds.size, Date())
+            // The settled path renders here so the pixels come from the same main-thread tick that
+            // measured the mask rects — any later and the presentation tree has moved on. Callers
+            // that render themselves (background capture, the bridge's first frame) pass false.
+            let image = renderImage ? window.toImage(preferFidelityRenderer: preferFidelityRenderer) : nil
+
+            return ScreenshotCapture(wireframe: wireframe, windowSize: window.bounds.size, timestampDate: Date(), image: image)
         }
 
         @discardableResult
@@ -1147,12 +1193,15 @@
             screenName: String?,
             postHog: PostHogSDK,
             timestampDate: Date,
+            image collectedImage: UIImage?,
             episodeFirstFrame: Bool = false
         ) -> Bool {
             autoreleasepool {
-                guard let image = window.toImage(afterScreenUpdates: episodeFirstFrame),
-                      image.size.hasSize()
-                else {
+                // Only the settle-checked path picks a renderer by band; every other path keeps
+                // drawHierarchy. The bridge's first frame needs afterScreenUpdates: true on top —
+                // a freshly-presented native VC renders black otherwise.
+                let image = collectedImage ?? window.toImage(afterScreenUpdates: episodeFirstFrame, preferFidelityRenderer: true)
+                guard let image, image.size.hasSize() else {
                     return false
                 }
                 wireframe.image = image
@@ -1174,16 +1223,25 @@
             window: UIWindow,
             screenName: String?,
             postHog: PostHogSDK,
-            episodeFirstFrame: Bool = false
+            episodeFirstFrame: Bool = false,
+            preferFidelityRenderer: Bool = true,
+            overrideMaskRects: [CGRect]? = nil
         ) -> Bool {
             defer { finishScreenshotRender() }
 
-            let screenshotCapture: (wireframe: RRWireframe, windowSize: CGSize, timestampDate: Date)?
-            if Thread.isMainThread {
-                screenshotCapture = collectScreenshotMetadata(window)
-            } else {
-                screenshotCapture = DispatchQueue.main.sync { collectScreenshotMetadata(window) }
+            // Off-main callers (`screenshotModeBackgroundCapture`) render on their own thread, and the
+            // bridge's first frame needs its own `afterScreenUpdates: true` pass — bouncing either
+            // render onto main here would undo the point of that path.
+            let rendersInMeasuringTick = Thread.isMainThread && !episodeFirstFrame
+            func collect() -> ScreenshotCapture? {
+                collectScreenshotMetadata(
+                    window,
+                    preferFidelityRenderer: preferFidelityRenderer,
+                    overrideMaskRects: overrideMaskRects,
+                    renderImage: rendersInMeasuringTick
+                )
             }
+            let screenshotCapture = Thread.isMainThread ? collect() : DispatchQueue.main.sync(execute: collect)
 
             guard let screenshotCapture, postHog.isSessionReplayActive() else {
                 return false
@@ -1196,6 +1254,7 @@
                 screenName: screenName,
                 postHog: postHog,
                 timestampDate: screenshotCapture.timestampDate,
+                image: screenshotCapture.image,
                 episodeFirstFrame: episodeFirstFrame
             )
         }
@@ -1483,6 +1542,134 @@
             )
         }
 
+        // Tuning surface for the settle check. Defaults are deliberately conservative: measured on
+        // device, a 25ms window sees ~1.5pt of slow drift, ~4pt of CA animation and 185pt+ of a
+        // scroll fling, so everything except a fling keeps the same renderer session replay has
+        // always used, and only a fling trades fidelity for exactly-aligned masks.
+
+        /// Gap between the two geometry samples, and the unit every threshold below is measured in.
+        /// Raising it delays each capture by that much and holds the render-in-flight slot longer;
+        /// lowering it makes the velocity estimate noisier. Change this and the two point
+        /// thresholds stop meaning what they say — rescale them by the same factor.
+        private static let settleWindowSeconds: TimeInterval = 0.025
+
+        /// At or below this, geometry counts as unmoved and rects are used exactly as sampled.
+        /// Raise only to stop idle screens paying for inflation, and only a little: this much
+        /// displacement then goes uncompensated, so it is the one knob that trades directly
+        /// against coverage.
+        private static let settleTolerancePoints: CGFloat = 2.0
+
+        /// Above this, drop to the presentation-tree renderer, whose masks cannot disagree with its
+        /// pixels but which flattens blur, video and Metal. Raise to keep more motion at full
+        /// fidelity, paying for it in larger inflated masks; lower for tighter masks and more flat
+        /// frames. Sits between animation and fling so ordinary movement never flattens.
+        private static let driftBudgetPoints: CGFloat = 100.0
+
+        /// Lead added past the newer sample, as a fraction of the measured displacement — the union
+        /// of both samples does the real covering, this only pads the direction of travel. On device
+        /// every value from 1 down to 1/64 held without exposing content, so it stays small; raise
+        /// it only if content is ever seen escaping the leading edge, since it grows every mask.
+        private static let driftLeadFraction: CGFloat = 1.0 / 16.0
+
+        /// Trail added behind the older sample, as a fraction of the measured displacement. Unlike
+        /// the lead, which pads past a position that WAS sampled, this covers a position that was
+        /// never sampled — if the render pipeline is deeper than one settle window, the displayed
+        /// pixels can sit behind `before` — so it gets a full settle window rather than a fraction.
+        private static let driftTrailFraction: CGFloat = 1.0
+
+        /// Displacement between the two rect samples estimates how far the displayed pixels
+        /// trail current geometry — the display pipeline is about one settle window deep.
+        enum SettleBand {
+            case still, drift, motion
+
+            /// Only motion needs the presentation-tree renderer, which is aligned by construction.
+            var usesFidelity: Bool { self != .motion }
+        }
+
+        /// Banded by measured drift:
+        /// - still (≤ tolerance): rects as collected.
+        /// - drift (≤ budget): each mask inflated to the swept region (both sampled positions
+        ///   plus `driftLeadFraction` of it as lead).
+        /// - motion (anything else, or unreadable geometry): fail-closed default.
+        /// Pairs by view identity, not array index — traversal order isn't stable across cell
+        /// recycling or z-order changes, so index-pairing could compare unrelated rects and
+        /// fail open into `.still`.
+        static func settleVerdict(
+            before: [MaskedRegion]?, after: [MaskedRegion]?
+        ) -> (band: SettleBand, inflatedRects: [CGRect]?) {
+            guard let before, let after, before.count == after.count else {
+                return (.motion, nil)
+            }
+            // Built by hand rather than Dictionary(uniqueKeysWithValues:), which traps on a
+            // duplicate owner — one object can match two maskable heuristics and be collected
+            // twice, and an SDK must not turn that into a host-app crash. Ambiguous pairing
+            // fails closed instead.
+            var beforeByOwner: [ObjectIdentifier: CGRect] = [:]
+            beforeByOwner.reserveCapacity(before.count)
+            for region in before where beforeByOwner.updateValue(region.rect, forKey: region.owner) != nil {
+                return (.motion, nil)
+            }
+            // Ordered to match `after` one-for-one: inflatedRects substitutes positionally
+            // for the `after` sample downstream.
+            var oldRects: [CGRect] = []
+            oldRects.reserveCapacity(after.count)
+            var seenAfterOwners: Set<ObjectIdentifier> = []
+            seenAfterOwners.reserveCapacity(after.count)
+            for region in after {
+                // No counterpart in `before` — something appeared/disappeared, fail closed.
+                guard let oldRect = beforeByOwner[region.owner] else {
+                    return (.motion, nil)
+                }
+                // A duplicate here would silently pair two `after` entries with the same old
+                // rect, hiding whatever the repeated owner displaced — fail closed instead.
+                guard seenAfterOwners.insert(region.owner).inserted else {
+                    return (.motion, nil)
+                }
+                oldRects.append(oldRect)
+            }
+            let maxDisplacement = zip(oldRects, after).map { old, new in
+                max(abs(old.minX - new.rect.minX), abs(old.minY - new.rect.minY),
+                    abs(old.width - new.rect.width), abs(old.height - new.rect.height))
+            }.max() ?? 0
+            if maxDisplacement <= settleTolerancePoints {
+                return (.still, nil)
+            }
+            if maxDisplacement <= driftBudgetPoints {
+                let inflated = zip(oldRects, after).map { old, region -> CGRect in
+                    let new = region.rect
+                    let deltaX = new.midX - old.midX
+                    let deltaY = new.midY - old.midY
+                    return old.union(new)
+                        .union(new.offsetBy(dx: deltaX * driftLeadFraction, dy: deltaY * driftLeadFraction))
+                        .union(old.offsetBy(dx: -deltaX * driftTrailFraction, dy: -deltaY * driftTrailFraction))
+                }
+                return (.drift, inflated)
+            }
+            return (.motion, nil)
+        }
+
+        /// Settle-then-shoot: after one display-pipeline depth, unchanged mask geometry proves the
+        /// displayed frame identical to the current tree, so full-fidelity drawHierarchy is safe
+        /// (blur/video/Metal intact); drift within budget keeps drawHierarchy with masks swept to
+        /// cover it, only motion or an unpairable sample drops to render(in:) for alignment.
+        private func scheduleSettledCapture(window: UIWindow, screenName: String?, postHog: PostHogSDK) {
+            let sentinelRegions = collectMaskedRegions(in: window)
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.settleWindowSeconds) { [weak self] in
+                guard let self else { return }
+                let regionsNow = self.collectMaskedRegions(in: window)
+                // Banded on mask geometry alone, not on layout-event counts: layout events arrive in
+                // bursts, so a count false-positives on the very burst that triggered the capture.
+                let verdict = Self.settleVerdict(before: sentinelRegions, after: regionsNow)
+                self.performScreenshotCapture(
+                    window: window,
+                    screenName: screenName,
+                    postHog: postHog,
+                    preferFidelityRenderer: verdict.band.usesFidelity,
+                    overrideMaskRects: verdict.inflatedRects ?? regionsNow?.map(\.rect)
+                )
+            }
+        }
+
         @objc private func snapshot() {
             guard let postHog, postHog.isSessionReplayActive() else {
                 return
@@ -1515,7 +1702,7 @@
                         self?.performScreenshotCapture(window: window, screenName: screenName, postHog: postHog)
                     }
                 } else {
-                    performScreenshotCapture(window: window, screenName: screenName, postHog: postHog)
+                    scheduleSettledCapture(window: window, screenName: screenName, postHog: postHog)
                 }
                 return
             }

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -13,7 +13,7 @@
     import UIKit
     import WebKit
 
-    class PostHogReplayIntegration: PostHogIntegration {
+    class PostHogReplayIntegration: PostHogIntegration { // swiftlint:disable:this type_body_length
         var requiresSwizzling: Bool { true }
 
         private static let integrationInstallState = PostHogIntegrationInstallState()

--- a/PostHog/Replay/UIView+Util.swift
+++ b/PostHog/Replay/UIView+Util.swift
@@ -76,7 +76,7 @@
                     } else {
                         // drawHierarchy lags the render server, so mask rects could sit ahead of
                         // the pixels during scroll or animation; the presentation tree is the same
-                        // source toAbsoluteRect measures, at the same instant, so the two agree.
+                        // source toPresentationRect measures, at the same instant, so the two agree.
                         // Trade-off: blur, video and Metal render flat, and render(in:) also skips
                         // filters and layer.mask — content that must stay hidden needs postHogMask().
                         (layer.presentation() ?? layer).render(in: context)

--- a/PostHog/Replay/UIView+Util.swift
+++ b/PostHog/Replay/UIView+Util.swift
@@ -50,7 +50,7 @@
             setPostHogFlag(&AssociatedKeys.phNoRageClick, enabled: enabled, owner: owner)
         }
 
-        func toImage(afterScreenUpdates: Bool = false) -> UIImage? {
+        func toImage(afterScreenUpdates: Bool = false, preferFidelityRenderer: Bool = true) -> UIImage? {
             let bounds = self.bounds
             let size = bounds.size
 
@@ -64,11 +64,28 @@
             let renderer = PostHogGraphicsImageRenderer(size: size, scale: nativeScale)
 
             return autoreleasepool {
-                renderer.image { _ in
-                    /// Note: Default `false` for `afterScreenUpdates` since this will cause the screen to flicker when a sensitive text field is visible on screen
-                    /// This can potentially affect capturing a snapshot during a screen transition but we want the lesser of the two evils here
-                    /// The bridge capture passes `true`: a freshly-presented native VC renders black otherwise.
-                    drawHierarchy(in: bounds, afterScreenUpdates: afterScreenUpdates)
+                renderer.image { context in
+                    if afterScreenUpdates {
+                        /// The bridge capture passes `true`: a freshly-presented native VC renders black otherwise.
+                        drawHierarchy(in: bounds, afterScreenUpdates: true)
+                    } else if preferFidelityRenderer {
+                        // Chosen when the settle check measured little enough movement that the
+                        // displayed frame still matches the current tree, so drawHierarchy's
+                        // full fidelity (blur, video, Metal) is worth lagging the render server.
+                        drawHierarchy(in: bounds, afterScreenUpdates: false)
+                    } else {
+                        // drawHierarchy lags the render server's displayed frame, so mask rects would
+                        // sit ahead of the pixels during scroll or animation. The presentation tree is
+                        // the same source toAbsoluteRect measures, at the same instant — masks and
+                        // pixels can't disagree. Trade-off: blur/video/Metal render flat or empty.
+                        //
+                        // Known limitation: render(in:) skips filters, backgroundFilters and
+                        // layer.mask, so anything relying on a blur or a layer mask to hide content
+                        // draws unhidden here. Whether a blur is redaction or decoration isn't
+                        // knowable from the view, so this isn't detected — content that must never
+                        // appear needs postHogMask().
+                        (layer.presentation() ?? layer).render(in: context)
+                    }
                 }
             }
         }
@@ -77,11 +94,26 @@
         func toAbsoluteRect(_ window: UIWindow?) -> CGRect {
             convert(bounds, to: window)
         }
+
+        /// Mask geometry only. During a CA animation the model layer parks at the destination
+        /// while the presentation layer holds the in-flight position the screenshot renders, so
+        /// mask rects have to come from the presentation tree. Wireframe geometry is a separate
+        /// consumer with no pixels to agree with and stays on `toAbsoluteRect`.
+        func toPresentationRect(_ window: UIWindow?) -> CGRect {
+            guard layer.presentation() != nil else {
+                // UIView's own convert, not the layer's: it resolves a nil window to the view's.
+                return convert(bounds, to: window)
+            }
+            return layer.toPresentationRect(window)
+        }
     }
 
     extension CALayer {
-        func toAbsoluteRect(_ window: UIWindow?) -> CGRect {
-            convert(bounds, to: window?.layer)
+        func toPresentationRect(_ window: UIWindow?) -> CGRect {
+            guard let presentationLayer = presentation() else {
+                return convert(bounds, to: window?.layer)
+            }
+            return presentationLayer.convert(presentationLayer.bounds, to: window?.layer.presentation() ?? window?.layer)
         }
 
         /// Backing flag for the SwiftUI `.postHogNoRageClick()` modifier on layer-backed

--- a/PostHog/Replay/UIView+Util.swift
+++ b/PostHog/Replay/UIView+Util.swift
@@ -74,16 +74,11 @@
                         // full fidelity (blur, video, Metal) is worth lagging the render server.
                         drawHierarchy(in: bounds, afterScreenUpdates: false)
                     } else {
-                        // drawHierarchy lags the render server's displayed frame, so mask rects would
-                        // sit ahead of the pixels during scroll or animation. The presentation tree is
-                        // the same source toAbsoluteRect measures, at the same instant — masks and
-                        // pixels can't disagree. Trade-off: blur/video/Metal render flat or empty.
-                        //
-                        // Known limitation: render(in:) skips filters, backgroundFilters and
-                        // layer.mask, so anything relying on a blur or a layer mask to hide content
-                        // draws unhidden here. Whether a blur is redaction or decoration isn't
-                        // knowable from the view, so this isn't detected — content that must never
-                        // appear needs postHogMask().
+                        // drawHierarchy lags the render server, so mask rects could sit ahead of
+                        // the pixels during scroll or animation; the presentation tree is the same
+                        // source toAbsoluteRect measures, at the same instant, so the two agree.
+                        // Trade-off: blur, video and Metal render flat, and render(in:) also skips
+                        // filters and layer.mask — content that must stay hidden needs postHogMask().
                         (layer.presentation() ?? layer).render(in: context)
                     }
                 }

--- a/PostHog/SwiftUI/PostHogMaskViewModifier.swift
+++ b/PostHog/SwiftUI/PostHogMaskViewModifier.swift
@@ -64,10 +64,12 @@
         private var reporters: [ObjectIdentifier: Weak<PostHogMaskReporterUIView>] = [:]
 
         struct MaskedRects {
-            let rects: [CGRect]
+            let regions: [PostHogReplayIntegration.MaskedRegion]
             /// A reporter in this window hasn't been laid out yet, so its region can't
             /// be reported. Callers must skip the frame instead of masking nothing.
             let hasUnsettledReporters: Bool
+
+            var rects: [CGRect] { regions.map(\.rect) }
         }
 
         func register(_ reporter: PostHogMaskReporterUIView) {
@@ -91,7 +93,7 @@
                 return reporters.values.compactMap(\.value)
             }
 
-            var rects: [CGRect] = []
+            var regions: [PostHogReplayIntegration.MaskedRegion] = []
             var hasUnsettledReporters = false
             for reporter in liveReporters {
                 guard reporter.window === window, !reporter.isHidden, reporter.alpha > 0 else { continue }
@@ -99,12 +101,12 @@
                     hasUnsettledReporters = true
                     continue
                 }
-                let rect = reporter.toAbsoluteRect(window)
+                let rect = reporter.toPresentationRect(window)
                 if !rect.isEmpty {
-                    rects.append(rect)
+                    regions.append(.init(reporter, rect: rect))
                 }
             }
-            return MaskedRects(rects: rects, hasUnsettledReporters: hasUnsettledReporters)
+            return MaskedRects(regions: regions, hasUnsettledReporters: hasUnsettledReporters)
         }
 
         #if TESTING

--- a/PostHogTests/PostHogMaskScenarioTest.swift
+++ b/PostHogTests/PostHogMaskScenarioTest.swift
@@ -496,5 +496,104 @@
             #expect(inflated[0].minY <= 95)
             #expect(inflated[0].maxY >= 125.31)
         }
+
+        @Test("swept union covers both sample positions, in after order")
+        func sweptRectsCoversBothSamplesInAfterOrder() throws {
+            let a = NSObject()
+            let b = NSObject()
+            let before = [
+                region(a, CGRect(x: 0, y: 0, width: 100, height: 20)),
+                region(b, CGRect(x: 0, y: 100, width: 100, height: 20)),
+            ]
+            // b moves; a is stationary. after is in swapped order vs before, so
+            // ordering must be recovered from `owner`, not index.
+            let after = [
+                region(b, CGRect(x: 0, y: 130, width: 100, height: 20)),
+                region(a, CGRect(x: 0, y: 0, width: 100, height: 20)),
+            ]
+            let swept = try #require(PostHogReplayIntegration.sweptRects(before: before, after: after))
+            #expect(swept.count == 2)
+
+            // swept[0] pairs with after[0] (b): union of y=100..120 and y=130..150.
+            #expect(swept[0] == CGRect(x: 0, y: 100, width: 100, height: 50))
+
+            // swept[1] pairs with after[1] (a): stationary, so it collapses to a's rect.
+            #expect(swept[1] == CGRect(x: 0, y: 0, width: 100, height: 20))
+        }
+
+        @Test("nil before makes sweptRects nil")
+        func sweptRectsNilBefore() {
+            let a = NSObject()
+            let after = [region(a, CGRect(x: 0, y: 0, width: 100, height: 20))]
+            #expect(PostHogReplayIntegration.sweptRects(before: nil, after: after) == nil)
+        }
+
+        @Test("nil after makes sweptRects nil")
+        func sweptRectsNilAfter() {
+            let a = NSObject()
+            let before = [region(a, CGRect(x: 0, y: 0, width: 100, height: 20))]
+            #expect(PostHogReplayIntegration.sweptRects(before: before, after: nil) == nil)
+        }
+
+        @Test("count mismatch makes sweptRects nil")
+        func sweptRectsCountMismatch() {
+            let a = NSObject()
+            let b = NSObject()
+            let before = [region(a, CGRect(x: 0, y: 0, width: 100, height: 20))]
+            let after = [
+                region(a, CGRect(x: 0, y: 0, width: 100, height: 20)),
+                region(b, CGRect(x: 0, y: 100, width: 100, height: 20)),
+            ]
+            #expect(PostHogReplayIntegration.sweptRects(before: before, after: after) == nil)
+        }
+
+        @Test("duplicate owner in before makes sweptRects nil")
+        func sweptRectsDuplicateOwnerInBefore() {
+            let a = NSObject()
+            let b = NSObject()
+            let before = [
+                region(a, CGRect(x: 0, y: 0, width: 100, height: 20)),
+                region(a, CGRect(x: 0, y: 0, width: 100, height: 20)),
+            ]
+            let after = [
+                region(a, CGRect(x: 0, y: 0, width: 100, height: 20)),
+                region(b, CGRect(x: 0, y: 100, width: 100, height: 20)),
+            ]
+            #expect(PostHogReplayIntegration.sweptRects(before: before, after: after) == nil)
+        }
+
+        @Test("duplicate owner in after makes sweptRects nil")
+        func sweptRectsDuplicateOwnerInAfter() {
+            let a = NSObject()
+            let b = NSObject()
+            let before = [
+                region(a, CGRect(x: 0, y: 0, width: 100, height: 20)),
+                region(b, CGRect(x: 0, y: 100, width: 100, height: 20)),
+            ]
+            let after = [
+                region(a, CGRect(x: 0, y: 0, width: 100, height: 20)),
+                region(a, CGRect(x: 0, y: 0, width: 100, height: 20)),
+            ]
+            #expect(PostHogReplayIntegration.sweptRects(before: before, after: after) == nil)
+        }
+
+        @Test("disjoint owner set makes sweptRects nil")
+        func sweptRectsDisjointOwnerSet() {
+            let a = NSObject()
+            let b = NSObject()
+            let before = [region(a, CGRect(x: 0, y: 0, width: 100, height: 20))]
+            let after = [region(b, CGRect(x: 0, y: 0, width: 100, height: 20))]
+            #expect(PostHogReplayIntegration.sweptRects(before: before, after: after) == nil)
+        }
+
+        @Test("a stationary owner's swept rect equals its rect unchanged")
+        func sweptRectsStationaryOwnerUnchanged() throws {
+            let a = NSObject()
+            let rect = CGRect(x: 10, y: 20, width: 100, height: 20)
+            let before = [region(a, rect)]
+            let after = [region(a, rect)]
+            let swept = try #require(PostHogReplayIntegration.sweptRects(before: before, after: after))
+            #expect(swept == [rect])
+        }
     }
 #endif

--- a/PostHogTests/PostHogMaskScenarioTest.swift
+++ b/PostHogTests/PostHogMaskScenarioTest.swift
@@ -532,8 +532,8 @@
             #expect(PostHogReplayIntegration.sweptRects(before: before, after: nil) == nil)
         }
 
-        @Test("count mismatch makes sweptRects nil")
-        func sweptRectsCountMismatch() {
+        @Test("an owner that appears mid-render is covered, not dropped")
+        func sweptRectsCountMismatch() throws {
             let a = NSObject()
             let b = NSObject()
             let before = [region(a, CGRect(x: 0, y: 0, width: 100, height: 20))]
@@ -541,7 +541,13 @@
                 region(a, CGRect(x: 0, y: 0, width: 100, height: 20)),
                 region(b, CGRect(x: 0, y: 100, width: 100, height: 20)),
             ]
-            #expect(PostHogReplayIntegration.sweptRects(before: before, after: after) == nil)
+            // b appeared mid-render, so it was displayed for part of the window and is covered
+            // rather than costing the whole frame.
+            let swept = try #require(PostHogReplayIntegration.sweptRects(before: before, after: after))
+            #expect(swept == [
+                CGRect(x: 0, y: 0, width: 100, height: 20),
+                CGRect(x: 0, y: 100, width: 100, height: 20),
+            ])
         }
 
         @Test("duplicate owner in before makes sweptRects nil")
@@ -574,13 +580,19 @@
             #expect(PostHogReplayIntegration.sweptRects(before: before, after: after) == nil)
         }
 
-        @Test("disjoint owner set makes sweptRects nil")
-        func sweptRectsDisjointOwnerSet() {
+        @Test("a fully recycled owner set covers both samples, not nil")
+        func sweptRectsDisjointOwnerSet() throws {
             let a = NSObject()
             let b = NSObject()
             let before = [region(a, CGRect(x: 0, y: 0, width: 100, height: 20))]
-            let after = [region(b, CGRect(x: 0, y: 0, width: 100, height: 20))]
-            #expect(PostHogReplayIntegration.sweptRects(before: before, after: after) == nil)
+            let after = [region(b, CGRect(x: 0, y: 200, width: 100, height: 20))]
+            // Neither owner can be paired, but both were on screen during the render window:
+            // `after` entries come first, then the ones that went away.
+            let swept = try #require(PostHogReplayIntegration.sweptRects(before: before, after: after))
+            #expect(swept == [
+                CGRect(x: 0, y: 200, width: 100, height: 20),
+                CGRect(x: 0, y: 0, width: 100, height: 20),
+            ])
         }
 
         @Test("a stationary owner's swept rect equals its rect unchanged")

--- a/PostHogTests/PostHogMaskScenarioTest.swift
+++ b/PostHogTests/PostHogMaskScenarioTest.swift
@@ -300,7 +300,7 @@
         func exactlyAtTolerance() {
             let a = NSObject()
             let before = [region(a, CGRect(x: 0, y: 0, width: 100, height: 20))]
-            let after = [region(a, CGRect(x: 2, y: 0, width: 100, height: 20))]
+            let after = [region(a, CGRect(x: PostHogReplayIntegration.settleTolerancePoints, y: 0, width: 100, height: 20))]
             let verdict = PostHogReplayIntegration.settleVerdict(before: before, after: after)
             #expect(verdict.band == .still)
             #expect(verdict.inflatedRects == nil)
@@ -310,7 +310,7 @@
         func justOverTolerance() {
             let a = NSObject()
             let before = [region(a, CGRect(x: 0, y: 0, width: 100, height: 20))]
-            let after = [region(a, CGRect(x: 2.1, y: 0, width: 100, height: 20))]
+            let after = [region(a, CGRect(x: PostHogReplayIntegration.settleTolerancePoints + 0.1, y: 0, width: 100, height: 20))]
             let verdict = PostHogReplayIntegration.settleVerdict(before: before, after: after)
             #expect(verdict.band == .drift)
         }
@@ -319,7 +319,7 @@
         func exactlyAtDriftBudget() {
             let a = NSObject()
             let before = [region(a, CGRect(x: 0, y: 0, width: 100, height: 20))]
-            let after = [region(a, CGRect(x: 100, y: 0, width: 100, height: 20))]
+            let after = [region(a, CGRect(x: PostHogReplayIntegration.driftBudgetPoints, y: 0, width: 100, height: 20))]
             let verdict = PostHogReplayIntegration.settleVerdict(before: before, after: after)
             #expect(verdict.band == .drift)
         }
@@ -328,7 +328,7 @@
         func justOverDriftBudget() {
             let a = NSObject()
             let before = [region(a, CGRect(x: 0, y: 0, width: 100, height: 20))]
-            let after = [region(a, CGRect(x: 100.1, y: 0, width: 100, height: 20))]
+            let after = [region(a, CGRect(x: PostHogReplayIntegration.driftBudgetPoints + 0.1, y: 0, width: 100, height: 20))]
             let verdict = PostHogReplayIntegration.settleVerdict(before: before, after: after)
             #expect(verdict.band == .motion)
             #expect(verdict.inflatedRects == nil)
@@ -431,7 +431,7 @@
         func thresholdsAreOrdered() {
             let a = NSObject()
             let before = [region(a, CGRect(x: 0, y: 0, width: 100, height: 20))]
-            let justOverTolerance = [region(a, CGRect(x: 3, y: 0, width: 100, height: 20))]
+            let justOverTolerance = [region(a, CGRect(x: PostHogReplayIntegration.settleTolerancePoints + 0.1, y: 0, width: 100, height: 20))]
             #expect(PostHogReplayIntegration.settleVerdict(before: before, after: justOverTolerance).band == .drift)
         }
 

--- a/PostHogTests/PostHogMaskScenarioTest.swift
+++ b/PostHogTests/PostHogMaskScenarioTest.swift
@@ -287,4 +287,214 @@
             }
         }
     }
+
+    // Guards the identity pairing in `settleVerdict`: cell recycling and z-order changes
+    // permute traversal order at a fixed count, so pairing rect samples by array index
+    // would compare unrelated rects and settle `.still` fail-open.
+    @Suite("settleVerdict identity pairing")
+    struct PostHogSettleVerdictTest {
+        private typealias MaskedRegion = PostHogReplayIntegration.MaskedRegion
+
+        private func region(_ owner: AnyObject, _ rect: CGRect) -> MaskedRegion {
+            MaskedRegion(owner, rect: rect)
+        }
+
+        @Test("displacement exactly at tolerance settles")
+        func exactlyAtTolerance() {
+            let a = NSObject()
+            let before = [region(a, CGRect(x: 0, y: 0, width: 100, height: 20))]
+            let after = [region(a, CGRect(x: 2, y: 0, width: 100, height: 20))]
+            let verdict = PostHogReplayIntegration.settleVerdict(before: before, after: after)
+            #expect(verdict.band == .still)
+            #expect(verdict.inflatedRects == nil)
+        }
+
+        @Test("just over tolerance drifts")
+        func justOverTolerance() {
+            let a = NSObject()
+            let before = [region(a, CGRect(x: 0, y: 0, width: 100, height: 20))]
+            let after = [region(a, CGRect(x: 2.1, y: 0, width: 100, height: 20))]
+            let verdict = PostHogReplayIntegration.settleVerdict(before: before, after: after)
+            #expect(verdict.band == .drift)
+        }
+
+        @Test("displacement exactly at drift budget drifts")
+        func exactlyAtDriftBudget() {
+            let a = NSObject()
+            let before = [region(a, CGRect(x: 0, y: 0, width: 100, height: 20))]
+            let after = [region(a, CGRect(x: 100, y: 0, width: 100, height: 20))]
+            let verdict = PostHogReplayIntegration.settleVerdict(before: before, after: after)
+            #expect(verdict.band == .drift)
+        }
+
+        @Test("just over drift budget is motion")
+        func justOverDriftBudget() {
+            let a = NSObject()
+            let before = [region(a, CGRect(x: 0, y: 0, width: 100, height: 20))]
+            let after = [region(a, CGRect(x: 100.1, y: 0, width: 100, height: 20))]
+            let verdict = PostHogReplayIntegration.settleVerdict(before: before, after: after)
+            #expect(verdict.band == .motion)
+            #expect(verdict.inflatedRects == nil)
+        }
+
+        @Test("nil before is motion")
+        func nilBefore() {
+            let a = NSObject()
+            let after = [region(a, CGRect(x: 0, y: 0, width: 100, height: 20))]
+            let verdict = PostHogReplayIntegration.settleVerdict(before: nil, after: after)
+            #expect(verdict.band == .motion)
+        }
+
+        @Test("nil after is motion")
+        func nilAfter() {
+            let a = NSObject()
+            let before = [region(a, CGRect(x: 0, y: 0, width: 100, height: 20))]
+            let verdict = PostHogReplayIntegration.settleVerdict(before: before, after: nil)
+            #expect(verdict.band == .motion)
+        }
+
+        @Test("count mismatch is motion")
+        func countMismatch() {
+            let a = NSObject()
+            let b = NSObject()
+            let before = [region(a, CGRect(x: 0, y: 0, width: 100, height: 20))]
+            let after = [
+                region(a, CGRect(x: 0, y: 0, width: 100, height: 20)),
+                region(b, CGRect(x: 0, y: 100, width: 100, height: 20)),
+            ]
+            let verdict = PostHogReplayIntegration.settleVerdict(before: before, after: after)
+            #expect(verdict.band == .motion)
+        }
+
+        @Test("same count but a different owner set is motion (index-pairing regression)")
+        func differentOwnerSet() {
+            let a = NSObject()
+            let b = NSObject()
+            let before = [region(a, CGRect(x: 0, y: 0, width: 100, height: 20))]
+            let after = [region(b, CGRect(x: 0, y: 0, width: 100, height: 20))]
+            let verdict = PostHogReplayIntegration.settleVerdict(before: before, after: after)
+            #expect(verdict.band == .motion)
+        }
+
+        @Test("permuted order with identical per-owner geometry settles")
+        func permutedOrderIdenticalGeometry() {
+            let a = NSObject()
+            let b = NSObject()
+            let before = [
+                region(a, CGRect(x: 0, y: 0, width: 100, height: 20)),
+                region(b, CGRect(x: 0, y: 100, width: 100, height: 20)),
+            ]
+            // Same owners, same rects, but traversal order swapped (e.g. cell recycling).
+            let after = [
+                region(b, CGRect(x: 0, y: 100, width: 100, height: 20)),
+                region(a, CGRect(x: 0, y: 0, width: 100, height: 20)),
+            ]
+            let verdict = PostHogReplayIntegration.settleVerdict(before: before, after: after)
+            #expect(verdict.band == .still)
+        }
+
+        @Test("duplicate owner in a sample is motion, not a trap")
+        func duplicateOwnerFailsClosed() {
+            let a = NSObject()
+            let b = NSObject()
+            // One object can match two maskable heuristics and be collected twice.
+            let before = [
+                region(a, CGRect(x: 0, y: 0, width: 100, height: 20)),
+                region(a, CGRect(x: 0, y: 0, width: 100, height: 20)),
+            ]
+            let after = [
+                region(a, CGRect(x: 0, y: 0, width: 100, height: 20)),
+                region(b, CGRect(x: 0, y: 100, width: 100, height: 20)),
+            ]
+            let verdict = PostHogReplayIntegration.settleVerdict(before: before, after: after)
+            #expect(verdict.band == .motion)
+        }
+
+        @Test("duplicate owner in the after sample is motion, not a trap")
+        func duplicateOwnerInAfterFailsClosed() {
+            let a = NSObject()
+            let b = NSObject()
+            // Counts match and every `after` entry resolves to a known owner, but `a`
+            // appears twice — b's disappearance would go unnoticed if this weren't caught.
+            let before = [
+                region(a, CGRect(x: 0, y: 0, width: 100, height: 20)),
+                region(b, CGRect(x: 0, y: 100, width: 100, height: 20)),
+            ]
+            let after = [
+                region(a, CGRect(x: 0, y: 0, width: 100, height: 20)),
+                region(a, CGRect(x: 0, y: 0, width: 100, height: 20)),
+            ]
+            let verdict = PostHogReplayIntegration.settleVerdict(before: before, after: after)
+            #expect(verdict.band == .motion)
+        }
+
+        /// Ordering the two thresholds wrong makes `.drift` unreachable, which silently drops the
+        /// swept-region inflation with nothing else failing.
+        @Test("the still tolerance stays below the drift budget")
+        func thresholdsAreOrdered() {
+            let a = NSObject()
+            let before = [region(a, CGRect(x: 0, y: 0, width: 100, height: 20))]
+            let justOverTolerance = [region(a, CGRect(x: 3, y: 0, width: 100, height: 20))]
+            #expect(PostHogReplayIntegration.settleVerdict(before: before, after: justOverTolerance).band == .drift)
+        }
+
+        @Test("only motion drops to the presentation-tree renderer")
+        func bandsPickRenderer() {
+            #expect(PostHogReplayIntegration.SettleBand.still.usesFidelity)
+            #expect(PostHogReplayIntegration.SettleBand.drift.usesFidelity)
+            #expect(!PostHogReplayIntegration.SettleBand.motion.usesFidelity)
+        }
+
+        @Test("empty arrays settle as still")
+        func emptyArraysStill() {
+            let verdict = PostHogReplayIntegration.settleVerdict(before: [], after: [])
+            #expect(verdict.band == .still)
+            #expect(verdict.inflatedRects == nil)
+        }
+
+        @Test("drift inflation covers the swept region and is ordered like after")
+        func driftInflationCoversSweepInAfterOrder() throws {
+            let a = NSObject()
+            let b = NSObject()
+            let before = [
+                region(a, CGRect(x: 0, y: 0, width: 100, height: 20)),
+                region(b, CGRect(x: 0, y: 100, width: 100, height: 20)),
+            ]
+            // b drifts by 5pt; a is stationary. after is in swapped order vs before, so
+            // ordering must be recovered from `owner`, not index.
+            let after = [
+                region(b, CGRect(x: 0, y: 105, width: 100, height: 20)),
+                region(a, CGRect(x: 0, y: 0, width: 100, height: 20)),
+            ]
+            let verdict = PostHogReplayIntegration.settleVerdict(before: before, after: after)
+            #expect(verdict.band == .drift)
+            let inflated = try #require(verdict.inflatedRects)
+            #expect(inflated.count == 2)
+
+            // inflated[0] pairs with after[0] (b): swept from y=100 through y=105, plus a
+            // sixteenth of the 5pt displacement as lead.
+            let bInflated = inflated[0]
+            #expect(bInflated.minY <= 100)
+            #expect(bInflated.maxY >= 125.31)
+
+            // inflated[1] pairs with after[1] (a): stationary, so it collapses to a's rect.
+            #expect(inflated[1] == CGRect(x: 0, y: 0, width: 100, height: 20))
+        }
+
+        @Test("drift inflation also covers a full settle window behind the older sample")
+        func driftInflationCoversTrailBehindBefore() throws {
+            let a = NSObject()
+            let before = [region(a, CGRect(x: 0, y: 100, width: 100, height: 20))]
+            // a drifts by 5pt.
+            let after = [region(a, CGRect(x: 0, y: 105, width: 100, height: 20))]
+            let verdict = PostHogReplayIntegration.settleVerdict(before: before, after: after)
+            #expect(verdict.band == .drift)
+            let inflated = try #require(verdict.inflatedRects)
+
+            // The displayed pixels can lag `before` by a full settle window if the render
+            // pipeline is deeper than one window — the trail pads a position never sampled.
+            #expect(inflated[0].minY <= 95)
+            #expect(inflated[0].maxY >= 125.31)
+        }
+    }
 #endif

--- a/PostHogTests/PostHogMaskScenarioTest.swift
+++ b/PostHogTests/PostHogMaskScenarioTest.swift
@@ -288,9 +288,6 @@
         }
     }
 
-    // Guards the identity pairing in `settleVerdict`: cell recycling and z-order changes
-    // permute traversal order at a fixed count, so pairing rect samples by array index
-    // would compare unrelated rects and settle `.still` fail-open.
     @Suite("settleVerdict identity pairing")
     struct PostHogSettleVerdictTest {
         private typealias MaskedRegion = PostHogReplayIntegration.MaskedRegion


### PR DESCRIPTION
## :bulb: Motivation and Context

Session replay masks drift off the content they cover while a screen scrolls or animates. The mask rects get measured at one instant and the pixels get rendered at another, so on a fast scroll the redaction lands behind the text it's meant to hide.

Two things cause it:

- Mask geometry came from the model layer (`toAbsoluteRect`). During a Core Animation animation the model layer sits at its destination while the screenshot renders the presentation layer's in-flight position.
- `drawHierarchy` lags the render server, so even correct rects can sit ahead of the pixels that actually ship.

The base fix is `toPresentationRect`: mask geometry now reads the presentation tree, the same source the screenshot renders from. Wireframe geometry stays on `toAbsoluteRect`, it has no pixels to agree with.

On top of that there are two mechanisms, both driven by the same measurement. Before each capture `scheduleSettledCapture` samples mask geometry, waits 25ms (roughly one display-pipeline depth), samples again, and bands the result by the largest per-mask displacement. All of it lives in `PostHog/Replay/PostHogMaskSettleAnalysis.swift`.

### 1. Drop to the presentation-tree renderer on fast scrolling

The band picks the renderer:

- Still, at or under 80pt/s (2pt across the window): rects used as collected, full `drawHierarchy`.
- Drift, at or under 2000pt/s (50pt): still `drawHierarchy`, with the masks inflated as described below.
- Motion, anything faster: `render(in:)` against the presentation tree, whose masks can't disagree with its own pixels.

Unreadable geometry fails closed into motion, so an owner that appeared or disappeared between the samples, a duplicate owner, a count mismatch, or a nil sample all take the aligned renderer rather than guessing. Pairing is by owner identity (`MaskedRegion`), not by index, because index pairing would compare unrelated rects and report a false settle whenever the set changed shape.

The cost of the motion band is real and it's in the changeset: `render(in:)` draws blur, video and Metal flat, and it ignores `layer.mask`, `maskView` and Core Animation `filters`. Anything that must never appear in a recording needs `postHogMask()`.

### 2. Inflate masks across the two samples

In the drift band the frame keeps full fidelity and the masks absorb the movement instead. Each mask becomes the union of four rects: where it was, where it is, a lead of 1/16 of the measured displacement past the newer sample, and the older sample pushed back by the full displacement. That last one covers a position that was never sampled, since the display pipeline is deeper than a single settle window and the pixels on screen trail the older sample.

`screenshotModeBackgroundCapture` uses the same idea without a threshold. `performBracketedBackgroundCapture` puts the off-main render between two samples and masks the per-owner union, so the mask provably covers wherever the content sat while the render ran. An owner present in only one of those samples emits its rect as collected rather than dropping the frame, because a scroll that recycles cells changes the owner set constantly and dropping those frames would freeze the recording for the whole interaction.

### Defaults are deliberately conservative

The thresholds are set so that in practice only a fling changes anything. Measured on device across a 25ms window: slow drift moves about 1.5pt, a Core Animation animation about 4pt, a scroll fling 185pt or more. So ordinary movement stays on the renderer session replay has always used, and the flattened frames are limited to the part of a fling nobody is reading anyway. Every constant is tunable in one place with the reasoning next to it, so these are easy to move once feedback lands.

## :green_heart: How did you test it?

33 tests in `PostHogTests/PostHogMaskScenarioTest.swift`, in two groups:

- Scenario coverage: per-row and whole-row masks tracking new positions after scrolling, leaf masks hugging their labels, fail-closed nesting of `postHogMask()` and `postHogNoMask()`.
- Settle bands: both boundaries exactly and just past, a nil or unpairable sample falling to motion, a duplicate owner not trapping, permuted sample order still settling, and the inflated rects covering the swept region.
- Manual tests on simulator and physical device on local mock server inspecting the snapshots as they come through 


https://github.com/user-attachments/assets/70aa0f79-f9f3-49d3-8ff7-7157f5a70ba1




If you have a repro or a sample project that showed masks sliding off during a scroll, please run this branch against it and check the playback, particularly whether the flattened frames during a fling are an acceptable trade for aligned masks. That judgement is the part I'd most like a second opinion on.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**DRI:** @ioannisj
**Autonomy:** Human-driven (agent-assisted)
