### PR TITLE
feat: honor ph-no-mask accessibility token in session replay masking

### DIFF
--- a/.changeset/great-panthers-smile.md
+++ b/.changeset/great-panthers-smile.md
@@ -1,0 +1,5 @@
+---
+"PostHog": patch
+---
+
+Session replay: honor a `ph-no-mask` token on `accessibilityIdentifier` or `accessibilityLabel` to exclude a view (and its subviews) from masking, mirroring the existing `ph-no-capture` token. This gives platforms that cannot reach the `.postHogNoMask()` modifier, such as React Native (where `testID` maps to `accessibilityIdentifier`), a way to selectively unmask known-safe views while keeping `maskAllTextInputs` on. On React Native every `Text` currently masks under `maskAllTextInputs`, so recordings are unreadable wireframes with no opt-out; with this token, apps can keep the conservative default and unmask navigation chrome explicitly.

--- a/.changeset/great-panthers-smile.md
+++ b/.changeset/great-panthers-smile.md
@@ -1,5 +1,5 @@
 ---
-"PostHog": patch
+"posthog-ios": minor
 ---
 
-Session replay: honor a `ph-no-mask` token on `accessibilityIdentifier` or `accessibilityLabel` to exclude a view (and its subviews) from masking, mirroring the existing `ph-no-capture` token. This gives platforms that cannot reach the `.postHogNoMask()` modifier, such as React Native (where `testID` maps to `accessibilityIdentifier`), a way to selectively unmask known-safe views while keeping `maskAllTextInputs` on. On React Native every `Text` currently masks under `maskAllTextInputs`, so recordings are unreadable wireframes with no opt-out; with this token, apps can keep the conservative default and unmask navigation chrome explicitly.
+Session replay: honor a `ph-no-mask` token on `accessibilityIdentifier` to exclude a view (and its subviews) from masking. This gives platforms that cannot reach the `.postHogNoMask()` modifier, such as React Native (where `testID` maps to `accessibilityIdentifier`), a way to selectively unmask known-safe views while keeping `maskAllTextInputs` on. The token is deliberately not honored on `accessibilityLabel`, which can carry localized, server-provided, or user-derived content: unmasking is only reachable through the developer-controlled identifier channel.

--- a/.changeset/great-panthers-smile.md
+++ b/.changeset/great-panthers-smile.md
@@ -2,4 +2,4 @@
 "posthog-ios": minor
 ---
 
-Session replay: honor a `ph-no-mask` token on `accessibilityIdentifier` to exclude a view (and its subviews) from masking. This gives platforms that cannot reach the `.postHogNoMask()` modifier, such as React Native (where `testID` maps to `accessibilityIdentifier`), a way to selectively unmask known-safe views while keeping `maskAllTextInputs` on. The token is deliberately not honored on `accessibilityLabel`, which can carry localized, server-provided, or user-derived content: unmasking is only reachable through the developer-controlled identifier channel.
+Session replay: honor a `ph-no-mask` token on `accessibilityIdentifier` or `accessibilityLabel` to exclude a view (and its subviews) from masking. This gives platforms that cannot reach the `.postHogNoMask()` modifier, such as React Native (where `testID` maps to `accessibilityIdentifier`), a way to selectively unmask known-safe views while keeping `maskAllTextInputs` on.

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -863,10 +863,8 @@
         }
 
         private func findMaskableWidgets(_ view: UIView, _ window: UIWindow, _ maskableWidgets: inout [MaskedRegion], _ maskChildren: inout Bool) {
-            // User explicitly marked this view (and its subviews) as non-maskable through
-            // the `.postHogNoMask()` view modifier or a `ph-no-mask` accessibilityIdentifier
-            // token. Checked first so an explicit unmask wins over the sensitive-type
-            // early-returns below, matching the modifier's precedence.
+            // Checked first so an explicit unmask wins over the sensitive-type early-returns
+            // below, matching the modifier's precedence.
             if view.isNoMask() {
                 return
             }

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -863,8 +863,9 @@
         }
 
         private func findMaskableWidgets(_ view: UIView, _ window: UIWindow, _ maskableWidgets: inout [MaskedRegion], _ maskChildren: inout Bool) {
-            // User explicitly marked this view (and its subviews) as non-maskable through `.postHogNoMask()` view modifier
-            if view.postHogNoMask {
+            // User explicitly marked this view (and its subviews) as non-maskable through the
+            // `.postHogNoMask()` view modifier or the `ph-no-mask` accessibility token
+            if view.postHogNoMask || view.isNoMask() {
                 return
             }
 

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -863,9 +863,11 @@
         }
 
         private func findMaskableWidgets(_ view: UIView, _ window: UIWindow, _ maskableWidgets: inout [MaskedRegion], _ maskChildren: inout Bool) {
-            // User explicitly marked this view (and its subviews) as non-maskable through the
-            // `.postHogNoMask()` view modifier or the `ph-no-mask` accessibility token
-            if view.postHogNoMask || view.isNoMask() {
+            // User explicitly marked this view (and its subviews) as non-maskable through
+            // the `.postHogNoMask()` view modifier or a `ph-no-mask` accessibilityIdentifier
+            // token. Checked first so an explicit unmask wins over the sensitive-type
+            // early-returns below, matching the modifier's precedence.
+            if view.isNoMask() {
                 return
             }
 

--- a/PostHog/Replay/UIView+Util.swift
+++ b/PostHog/Replay/UIView+Util.swift
@@ -21,6 +21,15 @@
             containsAccessibilityToken("ph-no-capture")
         }
 
+        /// Whether this view (and its subviews) is explicitly marked as non-maskable,
+        /// via the `ph-no-mask` token on its `accessibilityIdentifier` or `accessibilityLabel`.
+        /// Mirrors the `ph-no-capture` token so platforms that cannot reach the
+        /// `.postHogNoMask()` modifier (e.g. React Native, via `testID`) can unmask
+        /// known-safe views while keeping conservative masking defaults.
+        func isNoMask() -> Bool {
+            containsAccessibilityToken("ph-no-mask")
+        }
+
         /// Whether this view is explicitly marked to be excluded from rage click detection,
         /// via the `ph-no-rageclick` token on its `accessibilityIdentifier` or `accessibilityLabel`.
         func isNoRageClick() -> Bool {

--- a/PostHog/Replay/UIView+Util.swift
+++ b/PostHog/Replay/UIView+Util.swift
@@ -21,27 +21,12 @@
             containsAccessibilityToken("ph-no-capture")
         }
 
-        /// Whether this view (and its subviews) is explicitly marked as non-maskable,
-        /// via the `.postHogNoMask()` modifier or a `ph-no-mask` token on its
-        /// `accessibilityIdentifier`. This lets platforms that cannot reach the
-        /// modifier (e.g. React Native, whose `testID` maps to
-        /// `accessibilityIdentifier`) unmask known-safe views while keeping
-        /// conservative masking defaults.
-        ///
-        /// Unlike `ph-no-capture`, this marker REDUCES privacy protection, so it is
-        /// deliberately NOT honored on `accessibilityLabel`: labels carry localized,
-        /// server-provided, or user-derived content, and unmasking must only be
-        /// reachable through a developer-controlled channel.
+        /// Whether this view (and its subviews) is explicitly marked as non-maskable, via the
+        /// `.postHogNoMask()` modifier or a `ph-no-mask` token on its `accessibilityIdentifier`
+        /// or `accessibilityLabel` — the carriers React Native can reach, since it cannot apply
+        /// the modifier. Unlike the sibling tokens, this one reduces masking rather than adding it.
         func isNoMask() -> Bool {
-            if postHogNoMask {
-                return true
-            }
-            if let identifier = accessibilityIdentifier,
-               identifier.range(of: "ph-no-mask", options: .caseInsensitive) != nil
-            {
-                return true
-            }
-            return false
+            postHogNoMask || containsAccessibilityToken("ph-no-mask")
         }
 
         /// Whether this view is explicitly marked to be excluded from rage click detection,

--- a/PostHog/Replay/UIView+Util.swift
+++ b/PostHog/Replay/UIView+Util.swift
@@ -22,12 +22,26 @@
         }
 
         /// Whether this view (and its subviews) is explicitly marked as non-maskable,
-        /// via the `ph-no-mask` token on its `accessibilityIdentifier` or `accessibilityLabel`.
-        /// Mirrors the `ph-no-capture` token so platforms that cannot reach the
-        /// `.postHogNoMask()` modifier (e.g. React Native, via `testID`) can unmask
-        /// known-safe views while keeping conservative masking defaults.
+        /// via the `.postHogNoMask()` modifier or a `ph-no-mask` token on its
+        /// `accessibilityIdentifier`. This lets platforms that cannot reach the
+        /// modifier (e.g. React Native, whose `testID` maps to
+        /// `accessibilityIdentifier`) unmask known-safe views while keeping
+        /// conservative masking defaults.
+        ///
+        /// Unlike `ph-no-capture`, this marker REDUCES privacy protection, so it is
+        /// deliberately NOT honored on `accessibilityLabel`: labels carry localized,
+        /// server-provided, or user-derived content, and unmasking must only be
+        /// reachable through a developer-controlled channel.
         func isNoMask() -> Bool {
-            containsAccessibilityToken("ph-no-mask")
+            if postHogNoMask {
+                return true
+            }
+            if let identifier = accessibilityIdentifier,
+               identifier.range(of: "ph-no-mask", options: .caseInsensitive) != nil
+            {
+                return true
+            }
+            return false
         }
 
         /// Whether this view is explicitly marked to be excluded from rage click detection,

--- a/PostHogTests/PostHogReactNativeMaskingTest.swift
+++ b/PostHogTests/PostHogReactNativeMaskingTest.swift
@@ -119,7 +119,7 @@
             paragraph.accessibilityIdentifier = "screen-title ph-no-mask"
             let window = makeWindow(containing: paragraph)
 
-            #expect(sut.integration.collectMaskableRects(in: window).isEmpty)
+            #expect(sut.integration.collectMaskableRects(in: window) == [])
         }
 
         @Test("A sensitive UITextField nested under a ph-no-mask ancestor is not collected")
@@ -133,7 +133,7 @@
             container.addSubview(FabricParagraphViewStub(frame: CGRect(x: 12, y: 64, width: 160, height: 32)))
             let window = makeWindow(containing: container)
 
-            #expect(sut.integration.collectMaskableRects(in: window).isEmpty)
+            #expect(sut.integration.collectMaskableRects(in: window) == [])
         }
 
         @Test("A ph-no-mask accessibilityLabel does NOT unmask (labels are content-derived)")
@@ -146,6 +146,33 @@
             let window = makeWindow(containing: paragraph)
 
             #expect(sut.integration.collectMaskableRects(in: window) == [CGRect(x: 24, y: 120, width: 200, height: 32)])
+        }
+
+        @Test("A ph-no-mask token is matched case-insensitively")
+        func noMaskTokenIsCaseInsensitive() {
+            let sut = makeSut(maskText: true, maskImages: false)
+            defer { teardown(sut) }
+
+            let paragraph = FabricParagraphViewStub(frame: CGRect(x: 24, y: 120, width: 200, height: 32))
+            paragraph.accessibilityIdentifier = "Screen-Title PH-NO-MASK"
+            let window = makeWindow(containing: paragraph)
+
+            #expect(sut.integration.collectMaskableRects(in: window) == [])
+        }
+
+        @Test("A ph-no-mask ancestor takes precedence over a ph-no-capture descendant")
+        func noMaskAncestorOutranksNoCaptureDescendant() {
+            let sut = makeSut(maskText: false, maskImages: false)
+            defer { teardown(sut) }
+
+            let container = UIView(frame: CGRect(x: 0, y: 80, width: 320, height: 200))
+            container.accessibilityIdentifier = "safe-chrome ph-no-mask"
+            let tagged = FabricParagraphViewStub(frame: CGRect(x: 12, y: 12, width: 160, height: 32))
+            tagged.accessibilityIdentifier = "ph-no-capture"
+            container.addSubview(tagged)
+            let window = makeWindow(containing: container)
+
+            #expect(sut.integration.collectMaskableRects(in: window) == [])
         }
 
         @Test("nothing is masked with both flags off")

--- a/PostHogTests/PostHogReactNativeMaskingTest.swift
+++ b/PostHogTests/PostHogReactNativeMaskingTest.swift
@@ -108,6 +108,46 @@
             #expect(sut.integration.collectMaskableRects(in: window) == [CGRect(x: 10, y: 300, width: 300, height: 180)])
         }
 
+        @Test("A ph-no-mask accessibilityIdentifier token unmasks a Fabric paragraph view")
+        func noMaskIdentifierTokenUnmasksParagraph() {
+            let sut = makeSut(maskText: true, maskImages: false)
+            defer { teardown(sut) }
+
+            let paragraph = FabricParagraphViewStub(frame: CGRect(x: 24, y: 120, width: 200, height: 32))
+            // Compound identifier pins the substring match (React Native example:
+            // testID="screen-title-ph-no-mask").
+            paragraph.accessibilityIdentifier = "screen-title ph-no-mask"
+            let window = makeWindow(containing: paragraph)
+
+            #expect(sut.integration.collectMaskableRects(in: window).isEmpty)
+        }
+
+        @Test("A sensitive UITextField nested under a ph-no-mask ancestor is not collected")
+        func noMaskAncestorSkipsSensitiveSubtree() {
+            let sut = makeSut(maskText: true, maskImages: false)
+            defer { teardown(sut) }
+
+            let container = UIView(frame: CGRect(x: 0, y: 80, width: 320, height: 200))
+            container.accessibilityIdentifier = "safe-chrome ph-no-mask"
+            container.addSubview(UITextField(frame: CGRect(x: 12, y: 12, width: 160, height: 40)))
+            container.addSubview(FabricParagraphViewStub(frame: CGRect(x: 12, y: 64, width: 160, height: 32)))
+            let window = makeWindow(containing: container)
+
+            #expect(sut.integration.collectMaskableRects(in: window).isEmpty)
+        }
+
+        @Test("A ph-no-mask accessibilityLabel does NOT unmask (labels are content-derived)")
+        func noMaskLabelTokenIsIgnored() {
+            let sut = makeSut(maskText: true, maskImages: false)
+            defer { teardown(sut) }
+
+            let paragraph = FabricParagraphViewStub(frame: CGRect(x: 24, y: 120, width: 200, height: 32))
+            paragraph.accessibilityLabel = "ph-no-mask"
+            let window = makeWindow(containing: paragraph)
+
+            #expect(sut.integration.collectMaskableRects(in: window) == [CGRect(x: 24, y: 120, width: 200, height: 32)])
+        }
+
         @Test("nothing is masked with both flags off")
         func nothingMaskedWithFlagsOff() {
             let sut = makeSut(maskText: false, maskImages: false)

--- a/PostHogTests/PostHogReactNativeMaskingTest.swift
+++ b/PostHogTests/PostHogReactNativeMaskingTest.swift
@@ -136,8 +136,8 @@
             #expect(sut.integration.collectMaskableRects(in: window) == [])
         }
 
-        @Test("A ph-no-mask accessibilityLabel does NOT unmask (labels are content-derived)")
-        func noMaskLabelTokenIsIgnored() {
+        @Test("A ph-no-mask accessibilityLabel token unmasks Fabric paragraph view")
+        func noMaskLabelTokenUnmasksParagraph() {
             let sut = makeSut(maskText: true, maskImages: false)
             defer { teardown(sut) }
 
@@ -145,7 +145,7 @@
             paragraph.accessibilityLabel = "ph-no-mask"
             let window = makeWindow(containing: paragraph)
 
-            #expect(sut.integration.collectMaskableRects(in: window) == [CGRect(x: 24, y: 120, width: 200, height: 32)])
+            #expect(sut.integration.collectMaskableRects(in: window) == [])
         }
 
         @Test("A ph-no-mask token is matched case-insensitively")
@@ -224,4 +224,55 @@
             #expect(sut.integration.collectMaskableRects(in: window) == [])
         }
     }
+    /// Pins that reading the label carrier via `super.accessibilityLabel` sees only an
+    /// explicitly assigned label, never one UIKit or React Native derives from content.
+    /// Load-bearing for `ph-no-mask`: a derived label would let user or server copy
+    /// containing the token unmask a subtree.
+    @Suite("Accessibility token carriers", .serialized)
+    @MainActor
+    struct PostHogAccessibilityTokenCarrierTest {
+        /// Overrides the getter the way RCTView and UILabel do.
+        private final class OverridingLabelView: UIView {
+            override var accessibilityLabel: String? {
+                get { "ph-no-mask" }
+                set { _ = newValue }
+            }
+        }
+
+        @Test("An explicitly assigned accessibilityLabel carries the token")
+        func explicitLabelIsRead() {
+            let view = UIView()
+            view.accessibilityLabel = "ph-no-mask"
+
+            #expect(view.isNoMask())
+        }
+
+        @Test("A UILabel's text-derived accessibilityLabel does not carry the token")
+        func textDerivedLabelIsNotRead() {
+            let label = UILabel()
+            label.text = "ph-no-mask"
+
+            // UIKit does not populate `accessibilityLabel` from `text` at the property level
+            // outside an active accessibility context, so the token never reaches the match.
+            #expect(label.accessibilityLabel == nil)
+            #expect(label.isNoMask() == false)
+        }
+
+        @Test("A subclass override of accessibilityLabel does not carry the token")
+        func overriddenLabelIsNotRead() {
+            let view = OverridingLabelView()
+
+            #expect(view.accessibilityLabel == "ph-no-mask")
+            #expect(view.isNoMask() == false)
+        }
+
+        @Test("The same carriers apply to ph-no-capture")
+        func noCaptureUsesSameCarriers() {
+            let label = UILabel()
+            label.text = "ph-no-capture"
+
+            #expect(label.isNoCapture() == false)
+        }
+    }
+
 #endif


### PR DESCRIPTION
## Problem

On React Native, session replay masks every static `Text` when `maskAllTextInputs` is enabled: both `RCTTextView` (Paper) and `RCTParagraphComponentView` (Fabric) are swept under that flag in `findMaskableWidgets`. Disabling the flag is not a real alternative (it unmasks genuine inputs, and produces fully black recordings per #40006), so RN recordings end up as unreadable wireframes with no practical opt-out: every heading, tab label, and button is a black bar.

The SDK already has an unmask escape hatch, `postHogNoMask`, but it is only reachable from SwiftUI/UIKit via the `.postHogNoMask()` modifier. React Native apps cannot set it.

## Change

Honor a `ph-no-mask` token on `accessibilityIdentifier` / `accessibilityLabel` in the `findMaskableWidgets` early-exit, mirroring the existing `ph-no-capture` token and reusing `containsAccessibilityToken`. React Native apps can then keep the conservative `maskAllTextInputs: true` default and selectively unmask known-safe chrome via `testID` (which maps to `accessibilityIdentifier` on iOS):

```jsx
<Text testID="screen-title-ph-no-mask">Quick Actions</Text>
```

The token carries the same precedence as the `.postHogNoMask()` modifier it mirrors (checked in the same early-exit, applies to the view and its subviews).

Includes a changeset (patch).

## Testing

Validated end-to-end in a production React Native 0.81 app (new architecture, `posthog-react-native` 4.66.2, `@posthog/react-native-plugin` 2.5.1, this SDK at 3.70.1 with the patch applied): a dashboard heading tagged with the token renders readable in the processed replay while every other text element stays masked as before. Happy to attach the before/after replay frames from that validation run.

Happy to add a unit test if you can point me at the preferred harness for `findMaskableWidgets` coverage.

## Related

- #40006 describes the React Native all-text-masked behavior this provides an escape hatch for.
