### PR TITLE
feat: upload dsym symbol sets release-independent by default

### DIFF
--- a/.changeset/dsym-no-release-bind-default.md
+++ b/.changeset/dsym-no-release-bind-default.md
@@ -2,4 +2,6 @@
 'posthog-ios': minor
 ---
 
-Upload dSYM symbol sets release-independent by default. The release is still created, and the server resolves each crash's release from the `$app_version` / `$app_namespace` / `$app_build` the SDK sends on every event, so two releases that ship the same dSYM no longer both report whichever release uploaded it first. Set `POSTHOG_NO_RELEASE_BIND=0` in the upload build phase to keep binding the symbol sets to the created release. The default needs posthog-cli >= 0.10.0, which the script checks before uploading anything.
+Upload dSYM symbol sets release-independent by default. The release is still created, and the server resolves each crash's release from the `$app_version` / `$app_namespace` / `$app_build` the SDK sends on every event. Two releases that ship the same dSYM no longer both report whichever release uploaded it first. Set `POSTHOG_NO_RELEASE_BIND=0` in the upload build phase to keep binding the symbol sets to the created release. The default needs posthog-cli 0.10.0 or newer, which the script checks before it uploads anything.
+
+A zero-padded `CFBundleVersion` such as `001` now creates the release under `1`. The SDK reports `$app_build` as a number, so the padded form matched no event and those crashes reported no release. A build that is not all digits, such as `1.2.3`, stays as written.

--- a/.changeset/dsym-no-release-bind-default.md
+++ b/.changeset/dsym-no-release-bind-default.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': minor
+---
+
+Upload dSYM symbol sets release-independent by default. The release is still created, and the server resolves each crash's release from the `$app_version` / `$app_namespace` / `$app_build` the SDK sends on every event, so two releases that ship the same dSYM no longer both report whichever release uploaded it first. Set `POSTHOG_NO_RELEASE_BIND=0` in the upload build phase to keep binding the symbol sets to the created release. The default needs posthog-cli >= 0.10.0, which the script checks before uploading anything.

--- a/build-tools/upload-symbols.sh
+++ b/build-tools/upload-symbols.sh
@@ -216,7 +216,23 @@ resolve_source_plist_value() {
 }
 
 POSTHOG_RELEASE_VERSION=$(resolve_source_plist_value "CFBundleShortVersionString")
-POSTHOG_BUILD_VERSION=$(resolve_source_plist_value "CFBundleVersion")
+# The SDK sends $app_build through `Int(value) ?? value`, so a zero-padded numeric build reaches
+# PostHog without its padding. Drop the padding here too. Otherwise the upload creates a release
+# under a version that no event carries, and an unbound symbol set has no binding to fall back on.
+# A build that is not all digits, such as "1.2.3", stays as written, which is what the SDK does.
+normalize_build_version() {
+    case "$1" in
+        ''|*[!0-9]*)
+            printf '%s' "$1"
+            ;;
+        *)
+            local stripped="${1#"${1%%[!0]*}"}"
+            printf '%s' "${stripped:-0}"
+            ;;
+    esac
+}
+
+POSTHOG_BUILD_VERSION=$(normalize_build_version "$(resolve_source_plist_value "CFBundleVersion")")
 
 # Build CLI arguments as an array so paths with spaces are preserved.
 CLI_ARGS=(--directory "${DWARF_DSYM_FOLDER_PATH}")
@@ -244,7 +260,7 @@ fi
 if [ -n "$POSTHOG_BUILD_VERSION" ]; then
     CLI_ARGS+=(--build "$POSTHOG_BUILD_VERSION")
 elif [ -n "${CURRENT_PROJECT_VERSION}" ]; then
-    CLI_ARGS+=(--build "${CURRENT_PROJECT_VERSION}")
+    CLI_ARGS+=(--build "$(normalize_build_version "${CURRENT_PROJECT_VERSION}")")
 fi
 # Include source if requested via env var
 if [ "${POSTHOG_INCLUDE_SOURCE}" = "1" ]; then

--- a/build-tools/upload-symbols.sh
+++ b/build-tools/upload-symbols.sh
@@ -12,7 +12,7 @@
 #   Basic:          "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
 #   With source:    POSTHOG_INCLUDE_SOURCE=1 "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
 #   Skip conflicts: POSTHOG_SKIP_ON_CONFLICT=1 "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
-#   No release bind: POSTHOG_NO_RELEASE_BIND=1 "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
+#   Bind to release: POSTHOG_NO_RELEASE_BIND=0 "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
 #
 # Build Settings (required):
 #   DEBUG_INFORMATION_FORMAT = DWARF with dSYM File
@@ -24,12 +24,13 @@
 #   POSTHOG_SKIP_ON_CONFLICT - Set to "1" to skip symbol sets that already exist
 #                              with different content instead of failing the build
 #   POSTHOG_DSYM_TIMEOUT - Seconds to wait for the current app dSYM before failing (default: 60)
-#   POSTHOG_NO_RELEASE_BIND - Set to "1" to upload symbol sets without binding them to the created
-#                              release (via `dsym upload --no-release-bind`). The release is still
-#                              created; the server resolves it from the `$app_version` /
-#                              `$app_namespace` / `$app_build` the SDK sends on every event, so the
-#                              uploaded chunks stay content-addressed and release-independent.
-#                              Requires posthog-cli >= 0.10.0.
+#   POSTHOG_NO_RELEASE_BIND - Set to "0" to bind the uploaded symbol sets to the created release.
+#                              On by default: symbol sets upload release-independent (via
+#                              `dsym upload --no-release-bind`). The release is still created; the
+#                              server resolves it from the `$app_version` / `$app_namespace` /
+#                              `$app_build` the SDK sends on every event, so the uploaded chunks
+#                              stay content-addressed and two releases that ship the same dSYM keep
+#                              one symbol set. On by default requires posthog-cli >= 0.10.0.
 #
 
 # Skip non-Release builds.
@@ -137,12 +138,20 @@ if [ -z "$(find "${DWARF_DSYM_FOLDER_PATH}" -name '*.dSYM' -type d 2>/dev/null)"
     exit 0
 fi
 
+# Whether to upload the symbol sets without binding them to the created release. On unless the
+# build opts out, so a dSYM shared by two releases is not stamped with whichever one uploaded it
+# first. Values other than the recognized opt-outs keep the default rather than silently binding.
+POSTHOG_NO_RELEASE_BIND_ENABLED=1
+case "${POSTHOG_NO_RELEASE_BIND:-}" in
+    0|false|no|NO|FALSE) POSTHOG_NO_RELEASE_BIND_ENABLED=0 ;;
+esac
+
 # Enforce minimum posthog-cli version (required for --release-name / --release-version flags)
 MIN_POSTHOG_CLI_VERSION="0.7.7"
 if [ "${POSTHOG_SKIP_ON_CONFLICT}" = "1" ]; then
     MIN_POSTHOG_CLI_VERSION="0.7.12"
 fi
-if [ "${POSTHOG_NO_RELEASE_BIND}" = "1" ]; then
+if [ "${POSTHOG_NO_RELEASE_BIND_ENABLED}" = "1" ]; then
     MIN_POSTHOG_CLI_VERSION="0.10.0"
 fi
 PH_CLI_VERSION=$("$PH_CLI_PATH" --version 2>/dev/null | grep -oE '[0-9]+(\.[0-9]+)+' | head -n1)
@@ -245,10 +254,10 @@ if [ "${POSTHOG_SKIP_ON_CONFLICT}" = "1" ]; then
     CLI_ARGS+=(--skip-on-conflict)
 fi
 
-# Optionally upload the symbol sets without binding them to the release. The release is still
-# created, and the server resolves it from the $app_version / $app_namespace / $app_build the SDK
-# sends on every event, so nothing is written into the built bundle.
-if [ "${POSTHOG_NO_RELEASE_BIND}" = "1" ]; then
+# Upload the symbol sets without binding them to the release. The release is still created, and
+# the server resolves it from the $app_version / $app_namespace / $app_build the SDK sends on every
+# event, so nothing is written into the built bundle.
+if [ "${POSTHOG_NO_RELEASE_BIND_ENABLED}" = "1" ]; then
     CLI_ARGS+=(--no-release-bind)
 fi
 

--- a/build-tools/upload-symbols.test.sh
+++ b/build-tools/upload-symbols.test.sh
@@ -54,6 +54,7 @@ create_fixture() {
     TEST_INFOPLIST_PREPROCESS="NO"
     TEST_INFOPLIST_PATH=""
     TEST_CLI_VERSION="0.10.0"
+    TEST_NO_RELEASE_BIND=""
 
     mkdir -p "$HOME_DIR/.posthog" "$FAKE_BIN" "$SRC_ROOT/Config" "$(dirname "$MAIN_DWARF")" "$(dirname "$APP_EXECUTABLE")"
     printf 'dwarf' > "$MAIN_DWARF"
@@ -137,6 +138,7 @@ run_upload() {
         TEST_LSOF_ATTEMPTS="$LSOF_ATTEMPTS" \
         TEST_XCRUN_MARKER="$XCRUN_MARKER" \
         TEST_CLI_VERSION="$TEST_CLI_VERSION" \
+        POSTHOG_NO_RELEASE_BIND="$TEST_NO_RELEASE_BIND" \
         bash "$UPLOAD_SCRIPT" 2>&1)
     STATUS=$?
     set -e
@@ -374,6 +376,46 @@ test_falls_back_for_malformed_source_plist() {
     assert_file_contains_line "$CLI_ARGS_FILE" "1"
 }
 
+test_uploads_release_independent_by_default() {
+    create_fixture "no-release-bind-default"
+
+    run_upload
+
+    [ "$STATUS" -eq 0 ] || fail "Expected upload to succeed, got status $STATUS: $OUTPUT"
+    assert_file_contains_line "$CLI_ARGS_FILE" "--no-release-bind"
+}
+
+test_binds_the_release_when_opted_out() {
+    create_fixture "no-release-bind-opt-out"
+    TEST_NO_RELEASE_BIND="0"
+
+    run_upload
+
+    [ "$STATUS" -eq 0 ] || fail "Expected upload to succeed, got status $STATUS: $OUTPUT"
+    assert_file_does_not_contain_line "$CLI_ARGS_FILE" "--no-release-bind"
+}
+
+test_requires_a_newer_cli_for_the_default() {
+    create_fixture "no-release-bind-floor"
+    TEST_CLI_VERSION="0.9.0"
+
+    run_upload
+
+    [ "$STATUS" -ne 0 ] || fail "Expected the version floor to stop the upload: $OUTPUT"
+    [ ! -f "$CLI_ARGS_FILE" ] || fail "Expected posthog-cli not to upload anything"
+}
+
+test_keeps_the_old_floor_when_opted_out() {
+    create_fixture "no-release-bind-floor-opt-out"
+    TEST_CLI_VERSION="0.9.0"
+    TEST_NO_RELEASE_BIND="0"
+
+    run_upload
+
+    [ "$STATUS" -eq 0 ] || fail "Expected upload to succeed, got status $STATUS: $OUTPUT"
+    assert_file_does_not_contain_line "$CLI_ARGS_FILE" "--no-release-bind"
+}
+
 bash -n "$UPLOAD_SCRIPT"
 test_waits_for_current_dsym_and_uses_source_plist_versions
 test_uses_info_plist_with_supported_cli_versions
@@ -386,5 +428,9 @@ test_resolves_compound_build_settings
 test_skips_cli_lookup_when_build_does_not_emit_dsyms
 test_falls_back_for_unresolved_source_plist_versions
 test_falls_back_for_malformed_source_plist
+test_uploads_release_independent_by_default
+test_binds_the_release_when_opted_out
+test_requires_a_newer_cli_for_the_default
+test_keeps_the_old_floor_when_opted_out
 
 echo "upload-symbols tests passed"

--- a/build-tools/upload-symbols.test.sh
+++ b/build-tools/upload-symbols.test.sh
@@ -416,6 +416,32 @@ test_keeps_the_old_floor_when_opted_out() {
     assert_file_does_not_contain_line "$CLI_ARGS_FILE" "--no-release-bind"
 }
 
+test_strips_padding_from_a_numeric_build() {
+    create_fixture "padded-build"
+    write_plist "$SRC_ROOT/Config/Info.plist" "2.10.0" "001"
+    TEST_INFOPLIST_FILE="Config/Info.plist"
+
+    run_upload
+
+    [ "$STATUS" -eq 0 ] || fail "Expected upload to succeed, got status $STATUS: $OUTPUT"
+    # The SDK reports 1 for CFBundleVersion 001, so the release this upload creates must use 1.
+    assert_file_contains_line "$CLI_ARGS_FILE" "--build"
+    assert_file_contains_line "$CLI_ARGS_FILE" "1"
+    assert_file_does_not_contain_line "$CLI_ARGS_FILE" "001"
+}
+
+test_keeps_a_dotted_build_as_written() {
+    create_fixture "dotted-build"
+    write_plist "$SRC_ROOT/Config/Info.plist" "2.10.0" "1.2.3"
+    TEST_INFOPLIST_FILE="Config/Info.plist"
+
+    run_upload
+
+    [ "$STATUS" -eq 0 ] || fail "Expected upload to succeed, got status $STATUS: $OUTPUT"
+    # The SDK keeps a dotted build as a string, so this one passes through unchanged.
+    assert_file_contains_line "$CLI_ARGS_FILE" "1.2.3"
+}
+
 bash -n "$UPLOAD_SCRIPT"
 test_waits_for_current_dsym_and_uses_source_plist_versions
 test_uses_info_plist_with_supported_cli_versions
@@ -432,5 +458,7 @@ test_uploads_release_independent_by_default
 test_binds_the_release_when_opted_out
 test_requires_a_newer_cli_for_the_default
 test_keeps_the_old_floor_when_opted_out
+test_strips_padding_from_a_numeric_build
+test_keeps_a_dotted_build_as_written
 
 echo "upload-symbols tests passed"


### PR DESCRIPTION
## Related PRs

Event mode is live today. Each build must ask for it. These PRs make it the default. The modes themselves do not change.

- PostHog/posthog#91823
- PostHog/posthog-js#4705
- PostHog/posthog-js#4706
- PostHog/posthog-android#739
- PostHog/posthog-ios#789 ← this PR

## Problem

- Two iOS releases that ship the same dSYM report their crashes on one release.
- The release that uploads the symbol set first takes them.

## Changes

- `upload-symbols.sh` passes `dsym upload --no-release-bind` by default.
- The script still creates the release. Each crash resolves its own release from the `$app_version`, `$app_namespace` and `$app_build` the SDK sends.
- `POSTHOG_NO_RELEASE_BIND=0` keeps the old behavior. `false` and `no` do the same.
- The posthog-cli floor moves to 0.10.0 for a default build. The script checks the version before it uploads.

Land PostHog/posthog-js#4706 with this PR. A React Native dSYM phase must name the opt-out once this default changes.

## How did you test this code?

- `bash build-tools/upload-symbols.test.sh`.
- Four new tests. `POSTHOG_NO_RELEASE_BIND` had no tests.
- The new default test fails against the previous script.
- Not run: an Xcode build.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). Skills invoked: `/writing-pr-descriptions`.

This repository keeps a boolean, because `dsym upload` takes `--no-release-bind` and not `--release-mode`. The other repositories use the `symbol-set` and `event` names.

The opt-out is a `case` statement and not a `= "1"` test. An unknown value keeps the new default.


