### PR TITLE
chore: deprecate POSTHOG_NO_RELEASE_BIND in the dsym upload

### DIFF
--- a/.changeset/deprecate-dsym-no-release-bind.md
+++ b/.changeset/deprecate-dsym-no-release-bind.md
@@ -1,5 +1,5 @@
 ---
-'posthog-ios': minor
+'posthog-ios': patch
 ---
 
 Deprecate `POSTHOG_NO_RELEASE_BIND` in the dSYM upload build phase. The script ignores it, prints a warning when it is set, and uploads symbol sets bound to the release it creates, which is what it did before the variable existed. `dsym upload` no longer receives `--no-release-bind`.

--- a/.changeset/deprecate-dsym-no-release-bind.md
+++ b/.changeset/deprecate-dsym-no-release-bind.md
@@ -1,0 +1,7 @@
+---
+'posthog-ios': minor
+---
+
+Deprecate `POSTHOG_NO_RELEASE_BIND` in the dSYM upload build phase. The script ignores it, prints a warning when it is set, and uploads symbol sets bound to the release it creates, which is what it did before the variable existed. `dsym upload` no longer receives `--no-release-bind`.
+
+Event mode only helps when two releases ship a byte-identical binary, because the symbol id is the Mach-O `LC_UUID`. It also cost release attribution for embedded targets: the upload covers every extension dSYM but creates one release, so an extension crash resolved no release once the binding was gone.

--- a/.changeset/remove-dsym-no-release-bind.md
+++ b/.changeset/remove-dsym-no-release-bind.md
@@ -1,0 +1,7 @@
+---
+'posthog-ios': minor
+---
+
+Remove `POSTHOG_NO_RELEASE_BIND` from the dSYM upload build phase. The script uploads symbol sets bound to the release it creates, which is what it did before the variable existed.
+
+Event mode only helps when two releases ship a byte-identical binary, because the symbol id is the Mach-O `LC_UUID`. It also cost release attribution for embedded targets: the upload covers every extension dSYM but creates one release, so an extension crash resolved no release once the binding was gone. The variable was experimental and undocumented, so it goes out directly.

--- a/.changeset/remove-dsym-no-release-bind.md
+++ b/.changeset/remove-dsym-no-release-bind.md
@@ -1,7 +1,0 @@
----
-'posthog-ios': minor
----
-
-Remove `POSTHOG_NO_RELEASE_BIND` from the dSYM upload build phase. The script uploads symbol sets bound to the release it creates, which is what it did before the variable existed.
-
-Event mode only helps when two releases ship a byte-identical binary, because the symbol id is the Mach-O `LC_UUID`. It also cost release attribution for embedded targets: the upload covers every extension dSYM but creates one release, so an extension crash resolved no release once the binding was gone. The variable was experimental and undocumented, so it goes out directly.

--- a/build-tools/upload-symbols.sh
+++ b/build-tools/upload-symbols.sh
@@ -23,6 +23,8 @@
 #   POSTHOG_SKIP_ON_CONFLICT - Set to "1" to skip symbol sets that already exist
 #                              with different content instead of failing the build
 #   POSTHOG_DSYM_TIMEOUT - Seconds to wait for the current app dSYM before failing (default: 60)
+#   POSTHOG_NO_RELEASE_BIND - Deprecated and ignored. dSYMs always upload bound to the release
+#                              this build creates. The script warns when the variable is set.
 #
 
 # Skip non-Release builds.
@@ -32,6 +34,11 @@
 if [ -n "${CONFIGURATION}" ] && [ "${CONFIGURATION}" != "Release" ]; then
     echo "info: Skipping dSYM upload for configuration '${CONFIGURATION}' (not Release)."
     exit 0
+fi
+
+# The unbind behavior is removed, but a phase written for it may still export the variable.
+if [ -n "${POSTHOG_NO_RELEASE_BIND:-}" ]; then
+    echo "warning: POSTHOG_NO_RELEASE_BIND is deprecated and ignored. dSYMs upload bound to the release this build creates. Remove the variable."
 fi
 
 # Validate the path before looking for posthog-cli.

--- a/build-tools/upload-symbols.sh
+++ b/build-tools/upload-symbols.sh
@@ -12,7 +12,6 @@
 #   Basic:          "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
 #   With source:    POSTHOG_INCLUDE_SOURCE=1 "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
 #   Skip conflicts: POSTHOG_SKIP_ON_CONFLICT=1 "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
-#   No release bind: POSTHOG_NO_RELEASE_BIND=1 "${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh"
 #
 # Build Settings (required):
 #   DEBUG_INFORMATION_FORMAT = DWARF with dSYM File
@@ -24,12 +23,6 @@
 #   POSTHOG_SKIP_ON_CONFLICT - Set to "1" to skip symbol sets that already exist
 #                              with different content instead of failing the build
 #   POSTHOG_DSYM_TIMEOUT - Seconds to wait for the current app dSYM before failing (default: 60)
-#   POSTHOG_NO_RELEASE_BIND - Set to "1" to upload symbol sets without binding them to the created
-#                              release (via `dsym upload --no-release-bind`). The release is still
-#                              created; the server resolves it from the `$app_version` /
-#                              `$app_namespace` / `$app_build` the SDK sends on every event, so the
-#                              uploaded chunks stay content-addressed and release-independent.
-#                              Requires posthog-cli >= 0.10.0.
 #
 
 # Skip non-Release builds.
@@ -142,9 +135,6 @@ MIN_POSTHOG_CLI_VERSION="0.7.7"
 if [ "${POSTHOG_SKIP_ON_CONFLICT}" = "1" ]; then
     MIN_POSTHOG_CLI_VERSION="0.7.12"
 fi
-if [ "${POSTHOG_NO_RELEASE_BIND}" = "1" ]; then
-    MIN_POSTHOG_CLI_VERSION="0.10.0"
-fi
 PH_CLI_VERSION=$("$PH_CLI_PATH" --version 2>/dev/null | grep -oE '[0-9]+(\.[0-9]+)+' | head -n1)
 
 if [ -z "$PH_CLI_VERSION" ]; then
@@ -243,13 +233,6 @@ if [ "${POSTHOG_INCLUDE_SOURCE}" = "1" ]; then
 fi
 if [ "${POSTHOG_SKIP_ON_CONFLICT}" = "1" ]; then
     CLI_ARGS+=(--skip-on-conflict)
-fi
-
-# Optionally upload the symbol sets without binding them to the release. The release is still
-# created, and the server resolves it from the $app_version / $app_namespace / $app_build the SDK
-# sends on every event, so nothing is written into the built bundle.
-if [ "${POSTHOG_NO_RELEASE_BIND}" = "1" ]; then
-    CLI_ARGS+=(--no-release-bind)
 fi
 
 "${PH_CLI_PATH}" dsym upload "${CLI_ARGS[@]}" || exit 1

--- a/build-tools/upload-symbols.test.sh
+++ b/build-tools/upload-symbols.test.sh
@@ -374,6 +374,23 @@ test_falls_back_for_malformed_source_plist() {
     assert_file_contains_line "$CLI_ARGS_FILE" "1"
 }
 
+test_warns_on_deprecated_no_release_bind_and_uploads_bound() {
+    create_fixture "no-release-bind"
+    write_plist "$SRC_ROOT/Config/Info.plist" "2.10.0" "154"
+    TEST_INFOPLIST_FILE="Config/Info.plist"
+
+    export POSTHOG_NO_RELEASE_BIND=1
+    run_upload
+    unset POSTHOG_NO_RELEASE_BIND
+
+    [ "$STATUS" -eq 0 ] || fail "Expected upload to succeed, got status $STATUS: $OUTPUT"
+    case "$OUTPUT" in
+        *"POSTHOG_NO_RELEASE_BIND is deprecated"*) ;;
+        *) fail "Expected a deprecation warning, got: $OUTPUT" ;;
+    esac
+    assert_file_does_not_contain_line "$CLI_ARGS_FILE" "--no-release-bind"
+}
+
 bash -n "$UPLOAD_SCRIPT"
 test_waits_for_current_dsym_and_uses_source_plist_versions
 test_uses_info_plist_with_supported_cli_versions
@@ -386,5 +403,6 @@ test_resolves_compound_build_settings
 test_skips_cli_lookup_when_build_does_not_emit_dsyms
 test_falls_back_for_unresolved_source_plist_versions
 test_falls_back_for_malformed_source_plist
+test_warns_on_deprecated_no_release_bind_and_uploads_bound
 
 echo "upload-symbols tests passed"


### PR DESCRIPTION
## Related PRs

Event mode is live today, and it is opt-in. These PRs settle where it stays and where it goes.

**Deprecating the mobile knobs.** The symbol id on these paths is already a content hash, so two releases collide only when they ship a byte-identical artifact. An ordinary release that changes code gets its own symbol set and never collides. The dSYM path also lost release attribution for embedded targets, because one upload covers every target while it creates one release. Review asked for deprecation instead of removal, so every knob stays accepted as a warned no-op.

- PostHog/posthog#92401
- PostHog/posthog-android#747
- PostHog/posthog-ios#791 ← this PR

**Making it the default.**

- PostHog/posthog#91823 (stacked on PostHog/posthog#92401)
- PostHog/posthog-js#4705

**React Native.** Scopes the mode to the Hermes upload and defaults it to event. That is the one path where two releases really do ship the same artifact.

- PostHog/posthog-js#4717

## Problem

- Event mode helps only when two releases ship a byte-identical binary. The symbol id is the Mach-O `LC_UUID`.
- The unbound path also lost release attribution for embedded targets.
- The upload covers every extension dSYM, but it creates one release, from `PRODUCT_BUNDLE_IDENTIFIER`.
- An extension reports its own bundle identifier as `$app_namespace`, so its crashes matched no release.
- A silent removal would leave an opted-in user with no signal that their dSYMs bind again.

## Changes

- A build that sets `POSTHOG_NO_RELEASE_BIND` sees a build-log warning naming the deprecation and the fix. The script ignores the variable and uploads symbol sets bound to the release it creates.
- `dsym upload` no longer receives `--no-release-bind`.
- The script header documents the variable as deprecated instead of dropping it.
- The posthog-cli floor returns to 0.7.7, or 0.7.12 with `POSTHOG_SKIP_ON_CONFLICT`.

## How did you test this code?

- `bash build-tools/upload-symbols.test.sh` passes.
- A new case sets the variable and asserts the warning prints, the upload succeeds, and `--no-release-bind` is not forwarded. It catches the flag forwarding coming back, which would fail the Xcode phase against a CLI that removes the flag for real.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5); the warning added with Claude Code (Fable 5) per the review comment. Skills invoked: `/writing-pr-descriptions`, `/writing-tests`.

This replaces PostHog/posthog-ios#789. That PR also carried a fix for a zero-padded `CFBundleVersion`, which follows in a separate PR. PostHog/posthog#92401 keeps `dsym upload --no-release-bind` parseable as a hidden no-op, which covers a build that upgrades the CLI before this pod.
