### PR TITLE
feat(push): hold a notification tap that arrives before setup()

### DIFF
--- a/.changeset/prewarm-push-open-capture.md
+++ b/.changeset/prewarm-push-open-capture.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': minor
+---
+
+Add `PostHogSDK.prewarmPushNotificationOpenCapture()` so a notification tap delivered before `setup()` is still captured as `$push_notification_opened`.

--- a/.changeset/warn-missing-notification-delegate.md
+++ b/.changeset/warn-missing-notification-delegate.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': patch
+---
+
+Log a warning when `capturePushNotificationOpened` is enabled and no `UNUserNotificationCenter` delegate is set.

--- a/.changeset/warn-missing-notification-delegate.md
+++ b/.changeset/warn-missing-notification-delegate.md
@@ -2,4 +2,4 @@
 'posthog-ios': patch
 ---
 
-Log a warning when `capturePushNotificationOpened` is enabled and no `UNUserNotificationCenter` delegate is set.
+Log a debug warning when `capturePushNotificationOpened` is enabled and no `UNUserNotificationCenter` delegate is set, which is the case where no notification tap can ever be captured.

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -559,7 +559,7 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
                         integrations.append(PostHogPushNotificationSubscriptionIntegration())
                     }
                 #endif
-                if capturePushNotificationOpened {
+                if installsPushNotificationOpenIntegration {
                     integrations.append(PostHogPushNotificationOpenIntegration())
                 }
             }
@@ -567,6 +567,17 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
 
         return integrations
     }
+
+    #if os(iOS) || os(macOS)
+        /// Whether `PostHogPushNotificationOpenIntegration` will be installed by this config.
+        ///
+        /// `setup()`'s prewarm-discard gate is the negation of this, and the discard is the only thing
+        /// that releases a prewarm the config did not want. Both read this property so a new reason
+        /// not to install cannot be added on one side only.
+        var installsPushNotificationOpenIntegration: Bool {
+            capturePushNotificationOpened && enableSwizzling && !optOut
+        }
+    #endif
 
     var _surveys: Bool = true // swiftlint:disable:this identifier_name
     private func setSurveys(_ value: Bool) {

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -189,6 +189,9 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
         ///   `userNotificationCenter(_:didReceive:withCompletionHandler:)` implementation.
         ///
         /// Default: true. Set to `false` to opt out.
+        ///
+        /// Requires your app to set `UNUserNotificationCenter.current().delegate`. Without one, iOS
+        /// reports the tap to nobody and no open can be captured, in any app state.
         @objc public var capturePushNotificationOpened: Bool = true
     #endif
 
@@ -569,8 +572,6 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
     }
 
     #if os(iOS) || os(macOS)
-        /// Whether `PostHogPushNotificationOpenIntegration` will be installed by this config.
-        ///
         /// `setup()`'s prewarm-discard gate is the negation of this, and the discard is the only thing
         /// that releases a prewarm the config did not want. Both read this property so a new reason
         /// not to install cannot be added on one side only.

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -275,6 +275,18 @@ let maxRetryDelay = 30.0
                 notifyExceptionStepsDidChange()
             }
 
+            #if os(iOS) || os(macOS)
+                // A host may prewarm push-open capture before it knows the config (see
+                // `prewarmPushNotificationOpenCapture`). Release the swizzles when this setup turns
+                // out not to want them — including while opted out, where the integrations above
+                // were never installed and so could never release them.
+                if #available(iOS 14.0, macOS 11.0, *) {
+                    if !config.installsPushNotificationOpenIntegration {
+                        DI.main.pushNotificationPublisher.discardPrewarmedNotificationResponseCapture()
+                    }
+                }
+            #endif
+
             // Next-launch retry for a persisted, not-yet-delivered push subscription
             // (no-ops while opted out, offline, or when the record was already delivered).
             pushSubscriptionHandler?.retryIfNeeded()
@@ -3139,6 +3151,27 @@ let maxRetryDelay = 30.0
     #endif
 
     #if os(iOS) || os(macOS)
+        /// Installs the notification-open swizzles before `setup()` is called.
+        ///
+        /// A cold launch from a notification tap delivers the response to the app within a few hundred
+        /// milliseconds — sooner than a cross-platform host (Flutter, React Native) can reach its own
+        /// `setup()` call from the Dart/JS runtime, so the swizzles are not yet in place and the open is
+        /// lost. Call this from `application(_:didFinishLaunchingWithOptions:)`, or from a plugin
+        /// registration that runs inside it, and the response is held until `setup()` installs the
+        /// integration, which then captures it.
+        ///
+        /// Holds at most one response, and only replays it when `setup()` follows within 30 seconds.
+        /// Native iOS apps that call `setup()` from `didFinishLaunchingWithOptions` do not need this.
+        ///
+        /// The swizzles are installed immediately and released again when the last subscriber detaches
+        /// (`close()`), or at `setup()` when the config disables push-open capture or the app is
+        /// opted out. If `setup()` is never called they stay for the process lifetime. The per-class
+        /// delegate wrapper, as elsewhere in this SDK, stays for the process lifetime regardless.
+        @available(iOS 14.0, macOS 11.0, *)
+        @objc public static func prewarmPushNotificationOpenCapture() {
+            DI.main.pushNotificationPublisher.prewarmNotificationResponseCapture()
+        }
+
         /// Manually captures a `$push_notification_opened` event for a notification the user tapped.
         ///
         /// Use this when you're not relying on the automatic swizzling installed by

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -276,10 +276,8 @@ let maxRetryDelay = 30.0
             }
 
             #if os(iOS) || os(macOS)
-                // A host may prewarm push-open capture before it knows the config (see
-                // `prewarmPushNotificationOpenCapture`). Release the swizzles when this setup turns
-                // out not to want them — including while opted out, where the integrations above
-                // were never installed and so could never release them.
+                // Releases a prewarm this setup turns out not to want — including while opted out,
+                // where the integrations above were never installed and so could never release it.
                 if #available(iOS 14.0, macOS 11.0, *) {
                     if !config.installsPushNotificationOpenIntegration {
                         DI.main.pushNotificationPublisher.discardPrewarmedNotificationResponseCapture()

--- a/PostHog/PushNotifications/PostHogPushNotificationOpenIntegration.swift
+++ b/PostHog/PushNotifications/PostHogPushNotificationOpenIntegration.swift
@@ -46,10 +46,7 @@
                 self?.capture(response)
             }
 
-            // A response delivered before setup() — a cold launch from a notification tap in a
-            // Flutter/React Native app, where setup() runs once the JS/Dart isolate is up — is buffered
-            // by a prewarmed publisher and replayed here. Draining after subscribing means a response
-            // racing this call is never dropped.
+            // Draining after subscribing, so a response racing this call is never dropped.
             if let pending = DI.main.pushNotificationPublisher.consumePendingNotificationResponse() {
                 capture(pending)
             }

--- a/PostHog/PushNotifications/PostHogPushNotificationOpenIntegration.swift
+++ b/PostHog/PushNotifications/PostHogPushNotificationOpenIntegration.swift
@@ -13,6 +13,11 @@
 
         private static let integrationInstallState = PostHogIntegrationInstallState()
 
+        /// No lifecycle hook says "the app is finished installing its notification delegate", so the
+        /// absence of one can only be concluded from a deadline. Long enough for an app that installs
+        /// it during launch, short enough that the warning lands in the same debugging session.
+        private static let missingDelegateGracePeriod: TimeInterval = 5
+
         private weak var postHog: PostHogSDK?
         private var token: RegistrationToken?
 
@@ -38,18 +43,56 @@
                 return
             }
             token = DI.main.pushNotificationPublisher.onNotificationResponse.subscribe { [weak self] response in
-                // Auto-capture remote pushes only. A local
-                // notification (calendar/interval/location trigger, or none) is the app's own, not a
-                // delivered push; users who want to capture those can call
-                // `capturePushNotificationOpened(response:)` themselves — it stays unfiltered.
-                // Exclude dismiss actions: a `.customDismissAction` category invokes this same delegate
-                // callback on swipe-to-dismiss, which is not the user "opening" the notification.
-                guard response.notification.request.trigger is UNPushNotificationTrigger,
-                      response.actionIdentifier != UNNotificationDismissActionIdentifier
-                else {
-                    return
-                }
-                self?.postHog?.capturePushNotificationOpened(response: response)
+                self?.capture(response)
+            }
+
+            // A response delivered before setup() — a cold launch from a notification tap in a
+            // Flutter/React Native app, where setup() runs once the JS/Dart isolate is up — is buffered
+            // by a prewarmed publisher and replayed here. Draining after subscribing means a response
+            // racing this call is never dropped.
+            if let pending = DI.main.pushNotificationPublisher.consumePendingNotificationResponse() {
+                capture(pending)
+            }
+
+            warnIfNoNotificationDelegate(while: token)
+        }
+
+        private func capture(_ response: UNNotificationResponse) {
+            // Auto-capture remote pushes only. A local
+            // notification (calendar/interval/location trigger, or none) is the app's own, not a
+            // delivered push; users who want to capture those can call
+            // `capturePushNotificationOpened(response:)` themselves — it stays unfiltered.
+            // Exclude dismiss actions: a `.customDismissAction` category invokes this same delegate
+            // callback on swipe-to-dismiss, which is not the user "opening" the notification.
+            guard response.notification.request.trigger is UNPushNotificationTrigger,
+                  response.actionIdentifier != UNNotificationDismissActionIdentifier
+            else {
+                return
+            }
+            postHog?.capturePushNotificationOpened(response: response)
+        }
+
+        /// Without a `UNUserNotificationCenter` delegate the system never reports a tap to anyone, so
+        /// there is nothing to swizzle and no open is ever captured — the integration installs cleanly
+        /// and then stays silent forever, which is near-impossible to diagnose from the outside.
+        ///
+        /// The check is delayed because an app may install its delegate after setup(), which the
+        /// swizzled setter handles; only a delegate still missing well after launch is a real problem.
+        private func warnIfNoNotificationDelegate(while token: RegistrationToken?) {
+            // An app extension is never the notification-center delegate, so the advice below would be
+            // wrong there.
+            guard Bundle.main.bundleURL.pathExtension == "app" else { return }
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.missingDelegateGracePeriod) { [weak token] in
+                // A weak token reads "still subscribed" without racing `stop()` on another thread.
+                guard token != nil, UNUserNotificationCenter.current().delegate == nil else { return }
+                hedgeLog("""
+                Push notification opened integration: no UNUserNotificationCenter delegate is set, so \
+                notification taps are never reported to the app and `$push_notification_opened` cannot \
+                be captured. Set `UNUserNotificationCenter.current().delegate` in your application \
+                delegate, or capture opens yourself with \
+                `PostHogSDK.shared.capturePushNotificationOpened(response:)`.
+                """)
             }
         }
 

--- a/PostHog/PushNotifications/PushNotificationPublisher.swift
+++ b/PostHog/PushNotifications/PushNotificationPublisher.swift
@@ -15,6 +15,18 @@
         var onNotificationResponse: PostHogMulticastCallback<UNNotificationResponse> { get }
         /// Fires when APNs delivers a device token (already converted to a lowercase-hex string).
         var onDeviceToken: PostHogMulticastCallback<String> { get }
+        /// Installs the notification-delegate swizzles before the SDK is configured, so a response
+        /// delivered during launch is held until an integration subscribes. A no-op once a subscriber
+        /// exists — setup() has already run, so there is nothing to hold for it.
+        func prewarmNotificationResponseCapture()
+        /// Publishes a response to subscribers. With no subscriber it is held only while prewarmed,
+        /// and otherwise dropped.
+        func deliver(notificationResponse: UNNotificationResponse)
+        /// Returns and clears a response buffered before any subscriber attached.
+        func consumePendingNotificationResponse() -> UNNotificationResponse?
+        /// Undoes a prewarm that setup() turned out not to want, so an app that disabled push-open
+        /// capture is not left permanently swizzled.
+        func discardPrewarmedNotificationResponseCapture()
     }
 
     // MARK: - Publisher
@@ -44,18 +56,30 @@
         private let delegateClassesLock = NSLock()
         private var swizzledDelegateClasses = Set<ObjectIdentifier>()
 
+        /// Guards the setter-swizzle install state and the pre-subscriber response buffer.
+        private let stateLock = NSLock()
+        private var isDelegateSetterSwizzled = false
+        private var isPrewarmed = false
+        private var pendingResponse: (response: UNNotificationResponse, capturedAt: Date)?
+
+        /// A buffered response stands for the launch that is happening now. Anything older than this
+        /// belongs to a launch the app never configured the SDK for, and would be reported with a
+        /// misleading timestamp.
+        private static let pendingResponseTTL: TimeInterval = 30
+
         private init() {
             // weakSelf avoids capturing self in the subscriber-count closures before init completes.
             weak var weakSelf: PushNotificationPublisher?
             onNotificationResponse = PostHogMulticastCallback(onSubscriberCountChanged: { count in
                 guard let self = weakSelf else { return }
                 if count == 1 {
-                    self.swizzleNotificationCenterDelegateSetter()
-                    if let existing = UNUserNotificationCenter.current().delegate {
-                        self.swizzleNotificationDelegateMethods(on: type(of: existing))
-                    }
+                    // The prewarm window ends at the first subscriber: from here the publisher tears
+                    // down normally on the way out, and a response arriving with no subscriber is
+                    // dropped rather than buffered for a later setup().
+                    self.stateLock.withLock { self.isPrewarmed = false }
+                    self.installNotificationDelegateSwizzles()
                 } else if count == 0 {
-                    self.unswizzleNotificationCenterDelegateSetter()
+                    self.uninstallNotificationDelegateSwizzles()
                 }
             })
             onDeviceToken = PostHogMulticastCallback(onSubscriberCountChanged: { count in
@@ -77,16 +101,107 @@
             UNUserNotificationCenterDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:)
         )
 
-        private func swizzleNotificationCenterDelegateSetter() {
+        /// Installs the setter swizzle and covers a delegate that is already set.
+        ///
+        /// `isDelegateSetterSwizzled` is what makes this idempotent, and it is load-bearing: the
+        /// swizzle is a method exchange, so an unguarded second call would reverse the first.
+        private func installNotificationDelegateSwizzles() {
+            // Reachable from public API, so it can run outside an app.
+            guard Self.isRunningInAppContext else { return }
+
+            let shouldInstall = stateLock.withLock {
+                guard !isDelegateSetterSwizzled else { return false }
+                isDelegateSetterSwizzled = true
+                return true
+            }
+            guard shouldInstall else { return }
+
             swizzle(forClass: UNUserNotificationCenter.self, original: Self.delegateSetterOriginal, new: Self.delegateSetterSwizzled)
+            if let existing = UNUserNotificationCenter.current().delegate {
+                swizzleNotificationDelegateMethods(on: type(of: existing))
+            }
         }
 
-        private func unswizzleNotificationCenterDelegateSetter() {
+        private func uninstallNotificationDelegateSwizzles() {
+            let shouldUninstall = stateLock.withLock {
+                guard isDelegateSetterSwizzled else { return false }
+                isDelegateSetterSwizzled = false
+                return true
+            }
+            guard shouldUninstall else { return }
+
             // Calling swizzle() again reverses the setter exchange. `swizzledDelegateClasses` is
             // deliberately NOT cleared: the per-class `didReceive` replacements stay in place for the
             // process lifetime (invoking an empty multicast is a no-op), and clearing the set would wrap
             // an already-replaced method on re-install.
             swizzle(forClass: UNUserNotificationCenter.self, original: Self.delegateSetterOriginal, new: Self.delegateSetterSwizzled)
+        }
+
+        func prewarmNotificationResponseCapture() {
+            // A live subscriber means setup() already ran, so there is nothing to hold for it.
+            // Read outside `stateLock` — `subscriberCount` takes the multicast's own lock. A prewarm
+            // racing the very first subscribe can still set the flag; the TTL bounds that.
+            guard onNotificationResponse.subscriberCount == 0 else { return }
+
+            let alreadyPrewarmed = stateLock.withLock {
+                let wasPrewarmed = isPrewarmed
+                isPrewarmed = true
+                return wasPrewarmed
+            }
+            guard !alreadyPrewarmed else { return }
+            installNotificationDelegateSwizzles()
+        }
+
+        func deliver(notificationResponse response: UNNotificationResponse) {
+            if onNotificationResponse.subscriberCount == 0 {
+                let buffered = stateLock.withLock { () -> Bool in
+                    guard isPrewarmed else { return false }
+                    pendingResponse = (response, Date())
+                    return true
+                }
+                if buffered {
+                    // A subscriber that arrived while this ran already drained an empty buffer, so
+                    // hand the response over here instead of stranding it. `consume` clears under
+                    // the lock, so it cannot be delivered twice.
+                    if onNotificationResponse.subscriberCount > 0,
+                       let pending = consumePendingNotificationResponse()
+                    {
+                        onNotificationResponse.invoke(pending)
+                    }
+                    return
+                }
+                // The count read above can already be stale, and invoking an empty multicast is a
+                // no-op, so falling through cannot drop a response that a subscriber arriving
+                // mid-call should have seen.
+            }
+            onNotificationResponse.invoke(response)
+        }
+
+        func consumePendingNotificationResponse() -> UNNotificationResponse? {
+            stateLock.withLock {
+                guard let pending = pendingResponse else { return nil }
+                pendingResponse = nil
+                guard Date().timeIntervalSince(pending.capturedAt) <= Self.pendingResponseTTL else {
+                    return nil
+                }
+                return pending.response
+            }
+        }
+
+        func discardPrewarmedNotificationResponseCapture() {
+            stateLock.withLock {
+                pendingResponse = nil
+                isPrewarmed = false
+            }
+            // A live subscriber means another PostHogSDK instance still needs these swizzles.
+            guard onNotificationResponse.subscriberCount == 0 else { return }
+            uninstallNotificationDelegateSwizzles()
+        }
+
+        /// `UNUserNotificationCenter` needs a real app bundle; it traps in test runners and CLI tools.
+        private static var isRunningInAppContext: Bool {
+            let bundleExtension = Bundle.main.bundleURL.pathExtension
+            return bundleExtension == "app" || bundleExtension == "appex"
         }
 
         func swizzleNotificationDelegateMethods(on delegateClass: AnyClass) {
@@ -145,7 +260,7 @@
 
                 let implementationHolder = OriginalDelegateIMP(originalImplementation)
                 let replacement: ReplacementBlock = { delegate, center, response, completionHandler in
-                    DI.main.pushNotificationPublisher.onNotificationResponse.invoke(response)
+                    DI.main.pushNotificationPublisher.deliver(notificationResponse: response)
                     guard let originalImplementation = implementationHolder.lock.withLock({ implementationHolder.value }) else {
                         completionHandler()
                         return
@@ -353,6 +468,18 @@
                 shared.swizzledAppDelegateClass = nil
                 shared.delegateClassesLock.withLock {
                     shared.swizzledDelegateClasses.removeAll()
+                }
+                let wasSwizzled = shared.stateLock.withLock {
+                    let wasSwizzled = shared.isDelegateSetterSwizzled
+                    shared.isDelegateSetterSwizzled = false
+                    shared.isPrewarmed = false
+                    shared.pendingResponse = nil
+                    return wasSwizzled
+                }
+                // Clearing the flag without reversing the exchange would leave the next install
+                // un-swizzling a setter it never swizzled.
+                if wasSwizzled {
+                    swizzle(forClass: UNUserNotificationCenter.self, original: delegateSetterOriginal, new: delegateSetterSwizzled)
                 }
             }
         }

--- a/PostHog/PushNotifications/PushNotificationPublisher.swift
+++ b/PostHog/PushNotifications/PushNotificationPublisher.swift
@@ -22,7 +22,6 @@
         /// Publishes a response to subscribers. With no subscriber it is held only while prewarmed,
         /// and otherwise dropped.
         func deliver(notificationResponse: UNNotificationResponse)
-        /// Returns and clears a response buffered before any subscriber attached.
         func consumePendingNotificationResponse() -> UNNotificationResponse?
         /// Undoes a prewarm that setup() turned out not to want, so an app that disabled push-open
         /// capture is not left permanently swizzled.
@@ -73,8 +72,7 @@
             onNotificationResponse = PostHogMulticastCallback(onSubscriberCountChanged: { count in
                 guard let self = weakSelf else { return }
                 if count == 1 {
-                    // The prewarm window ends at the first subscriber: from here the publisher tears
-                    // down normally on the way out, and a response arriving with no subscriber is
+                    // From the first subscriber on, a response arriving with no subscriber is
                     // dropped rather than buffered for a later setup().
                     self.stateLock.withLock { self.isPrewarmed = false }
                     self.installNotificationDelegateSwizzles()
@@ -101,8 +99,6 @@
             UNUserNotificationCenterDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:)
         )
 
-        /// Installs the setter swizzle and covers a delegate that is already set.
-        ///
         /// `isDelegateSetterSwizzled` is what makes this idempotent, and it is load-bearing: the
         /// swizzle is a method exchange, so an unguarded second call would reverse the first.
         private func installNotificationDelegateSwizzles() {
@@ -138,7 +134,6 @@
         }
 
         func prewarmNotificationResponseCapture() {
-            // A live subscriber means setup() already ran, so there is nothing to hold for it.
             // Read outside `stateLock` — `subscriberCount` takes the multicast's own lock. A prewarm
             // racing the very first subscribe can still set the flag; the TTL bounds that.
             guard onNotificationResponse.subscriberCount == 0 else { return }

--- a/PostHog/PushNotifications/PushNotificationPublisher.swift
+++ b/PostHog/PushNotifications/PushNotificationPublisher.swift
@@ -192,9 +192,18 @@
                 pendingResponse = nil
                 isPrewarmed = false
             }
-            // A live subscriber means another PostHogSDK instance still needs these swizzles.
+            // A live subscriber means an integration still needs these swizzles.
             guard onNotificationResponse.subscriberCount == 0 else { return }
             uninstallNotificationDelegateSwizzles()
+
+            // The count read above, and the prewarm flag cleared at the top, can both be overtaken
+            // while this tears down — prewarmNotificationResponseCapture() runs outside setupLock.
+            // Re-arming on either signal converges on "installed" whichever way they interleave,
+            // instead of leaving a live prewarm with an un-swizzled delegate setter.
+            let stillNeeded = stateLock.withLock { isPrewarmed } || onNotificationResponse.subscriberCount > 0
+            if stillNeeded {
+                installNotificationDelegateSwizzles()
+            }
         }
 
         /// `UNUserNotificationCenter` needs a real app bundle; it traps in test runners and CLI tools.

--- a/PostHog/PushNotifications/PushNotificationPublisher.swift
+++ b/PostHog/PushNotifications/PushNotificationPublisher.swift
@@ -77,6 +77,10 @@
                     self.stateLock.withLock { self.isPrewarmed = false }
                     self.installNotificationDelegateSwizzles()
                 } else if count == 0 {
+                    // Also clears the flag: a prewarm racing the first subscribe can re-set it after
+                    // the branch above cleared it, and a live prewarm with no subscriber is exactly
+                    // the state that buffers a response into the next setup().
+                    self.stateLock.withLock { self.isPrewarmed = false }
                     self.uninstallNotificationDelegateSwizzles()
                 }
             })

--- a/PostHog/PushNotifications/PushNotificationPublisher.swift
+++ b/PostHog/PushNotifications/PushNotificationPublisher.swift
@@ -66,6 +66,25 @@
         /// misleading timestamp.
         private static let pendingResponseTTL: TimeInterval = 30
 
+        #if TESTING
+            /// The points where a concurrent caller can overtake this one. Exposed so the
+            /// interleavings the guards exist for can be driven in a fixed order instead of raced —
+            /// every route into those states is the race itself, so there is no other way to reach
+            /// them deterministically.
+            enum RaceWindow {
+                case prewarmAfterSubscriberCheck
+                case discardAfterSubscriberCheck
+            }
+
+            var onRaceWindow: ((RaceWindow) -> Void)?
+
+            /// Counts entries to the swizzle transitions, including the ones the bundle guard turns
+            /// into no-ops — a test runner is never an app, so the swizzle state itself is not
+            /// observable here, but the decision to re-arm is.
+            private(set) var swizzleInstallAttempts = 0
+            private(set) var swizzleUninstallAttempts = 0
+        #endif
+
         private init() {
             // weakSelf avoids capturing self in the subscriber-count closures before init completes.
             weak var weakSelf: PushNotificationPublisher?
@@ -106,6 +125,9 @@
         /// `isDelegateSetterSwizzled` is what makes this idempotent, and it is load-bearing: the
         /// swizzle is a method exchange, so an unguarded second call would reverse the first.
         private func installNotificationDelegateSwizzles() {
+            #if TESTING
+                stateLock.withLock { swizzleInstallAttempts += 1 }
+            #endif
             // Reachable from public API, so it can run outside an app.
             guard Self.isRunningInAppContext else { return }
 
@@ -123,6 +145,9 @@
         }
 
         private func uninstallNotificationDelegateSwizzles() {
+            #if TESTING
+                stateLock.withLock { swizzleUninstallAttempts += 1 }
+            #endif
             let shouldUninstall = stateLock.withLock {
                 guard isDelegateSetterSwizzled else { return false }
                 isDelegateSetterSwizzled = false
@@ -141,6 +166,9 @@
             // Read outside `stateLock` — `subscriberCount` takes the multicast's own lock. A prewarm
             // racing the very first subscribe can still set the flag; the TTL bounds that.
             guard onNotificationResponse.subscriberCount == 0 else { return }
+            #if TESTING
+                onRaceWindow?(.prewarmAfterSubscriberCheck)
+            #endif
 
             let alreadyPrewarmed = stateLock.withLock {
                 let wasPrewarmed = isPrewarmed
@@ -194,6 +222,9 @@
             }
             // A live subscriber means an integration still needs these swizzles.
             guard onNotificationResponse.subscriberCount == 0 else { return }
+            #if TESTING
+                onRaceWindow?(.discardAfterSubscriberCheck)
+            #endif
             uninstallNotificationDelegateSwizzles()
 
             // The count read above, and the prewarm flag cleared at the top, can both be overtaken
@@ -482,6 +513,9 @@
                     shared.isDelegateSetterSwizzled = false
                     shared.isPrewarmed = false
                     shared.pendingResponse = nil
+                    shared.onRaceWindow = nil
+                    shared.swizzleInstallAttempts = 0
+                    shared.swizzleUninstallAttempts = 0
                     return wasSwizzled
                 }
                 // Clearing the flag without reversing the exchange would leave the next install

--- a/PostHogTests/PostHogPushNotificationSwizzlingTest.swift
+++ b/PostHogTests/PostHogPushNotificationSwizzlingTest.swift
@@ -13,6 +13,34 @@
     private final class TestPushNotificationPublisher: PushNotificationPublishing {
         let onNotificationResponse = PostHogMulticastCallback<UNNotificationResponse>()
         let onDeviceToken = PostHogMulticastCallback<String>()
+        private(set) var prewarmCount = 0
+        private(set) var discardCount = 0
+        private var isPrewarmed = false
+        private var pendingResponse: UNNotificationResponse?
+
+        func prewarmNotificationResponseCapture() {
+            prewarmCount += 1
+            isPrewarmed = true
+        }
+
+        func deliver(notificationResponse response: UNNotificationResponse) {
+            guard onNotificationResponse.subscriberCount > 0 else {
+                if isPrewarmed { pendingResponse = response }
+                return
+            }
+            onNotificationResponse.invoke(response)
+        }
+
+        func consumePendingNotificationResponse() -> UNNotificationResponse? {
+            defer { pendingResponse = nil }
+            return pendingResponse
+        }
+
+        func discardPrewarmedNotificationResponseCapture() {
+            discardCount += 1
+            isPrewarmed = false
+            pendingResponse = nil
+        }
     }
 
     #if os(iOS)
@@ -53,9 +81,12 @@
             let container = DI.Container()
             container.pushNotificationPublisher = publisher
             DI.main = container
+            // `PushNotificationPublisher.shared` is process-wide, so prewarm state leaks between tests.
+            PushNotificationPublisher.reset()
         }
 
         deinit {
+            PushNotificationPublisher.reset()
             DI.main = previousContainer
         }
 
@@ -85,6 +116,147 @@
                 #expect(delegate.forwardedDelegate.registrationError as? NSError == error)
             }
         #endif
+
+        /// The placeholder stands in for a `UNNotificationResponse`, which has no public initializer.
+        /// It is only ever compared by identity here — never dereferenced.
+        private func withPlaceholderResponse(_ body: (UNNotificationResponse) -> Void) {
+            let placeholder = NSObject()
+            body(unsafeBitCast(placeholder, to: UNNotificationResponse.self))
+            withExtendedLifetime(placeholder) {}
+        }
+
+        @Test("buffers a response delivered after prewarm but before any subscriber, and drains it once")
+        func buffersResponseDeliveredBeforeSubscriber() {
+            let publisher = PushNotificationPublisher.shared
+            publisher.prewarmNotificationResponseCapture()
+
+            withPlaceholderResponse { response in
+                publisher.deliver(notificationResponse: response)
+
+                #expect(publisher.consumePendingNotificationResponse() === response)
+                #expect(publisher.consumePendingNotificationResponse() == nil)
+            }
+        }
+
+        @Test("drops a response delivered with no subscriber when not prewarmed")
+        func dropsResponseWhenNotPrewarmed() {
+            let publisher = PushNotificationPublisher.shared
+
+            withPlaceholderResponse { response in
+                publisher.deliver(notificationResponse: response)
+                #expect(publisher.consumePendingNotificationResponse() == nil)
+            }
+        }
+
+        @Test("prewarming twice leaves the buffer window open exactly once")
+        func prewarmIsIdempotent() {
+            let publisher = PushNotificationPublisher.shared
+            publisher.prewarmNotificationResponseCapture()
+            publisher.prewarmNotificationResponseCapture()
+
+            // Still buffering means the second call did not tear the prewarm window down.
+            withPlaceholderResponse { response in
+                publisher.deliver(notificationResponse: response)
+                #expect(publisher.consumePendingNotificationResponse() === response)
+            }
+        }
+
+        @Test("discarding a prewarm clears the buffer and ends the prewarm window")
+        func discardEndsPrewarmWindow() {
+            let publisher = PushNotificationPublisher.shared
+            publisher.prewarmNotificationResponseCapture()
+
+            withPlaceholderResponse { response in
+                publisher.deliver(notificationResponse: response)
+                publisher.discardPrewarmedNotificationResponseCapture()
+                #expect(publisher.consumePendingNotificationResponse() == nil)
+
+                publisher.deliver(notificationResponse: response)
+                #expect(publisher.consumePendingNotificationResponse() == nil)
+            }
+        }
+
+        @Test("prewarming while a subscriber is attached does not re-open the buffer window")
+        func prewarmWithLiveSubscriberIsIgnored() {
+            let publisher = PushNotificationPublisher.shared
+            var token: RegistrationToken? = publisher.onNotificationResponse.subscribe { _ in }
+
+            publisher.prewarmNotificationResponseCapture()
+            token = nil
+
+            withPlaceholderResponse { response in
+                publisher.deliver(notificationResponse: response)
+                #expect(publisher.consumePendingNotificationResponse() == nil)
+            }
+        }
+
+        @Test("the public prewarm API reaches the publisher")
+        @available(iOS 14.0, macOS 11.0, *)
+        func publicPrewarmApiReachesPublisher() {
+            #expect(publisher.prewarmCount == 0)
+            PostHogSDK.prewarmPushNotificationOpenCapture()
+            #expect(publisher.prewarmCount == 1)
+        }
+
+        /// Mirrors `PostHogIntegrationInstallationTest.getSut`, trimmed to what the discard gate reads.
+        @available(iOS 14.0, macOS 11.0, *)
+        private func makeSut(
+            optOut: Bool = false,
+            capturePushNotificationOpened: Bool = true,
+            enableSwizzling: Bool = true
+        ) -> PostHogSDK {
+            let config = PostHogConfig(projectToken: "test_project_token", host: "http://localhost:9001")
+            config.disableRemoteConfigForTesting = true
+            config.disableFlushOnBackgroundForTesting = true
+            config.disableReachabilityForTesting = true
+            config.captureApplicationLifecycleEvents = false
+            config.captureScreenViews = false
+            config.errorTrackingConfig.autoCapture = false
+            #if os(iOS)
+                config.sessionReplay = false
+            #endif
+            config.optOut = optOut
+            config.enableSwizzling = enableSwizzling
+            config.capturePushNotificationOpened = capturePushNotificationOpened
+            config.capturePushNotificationSubscriptions = false
+
+            let storage = PostHogStorage(config)
+            storage.reset()
+
+            PostHogPushNotificationOpenIntegration.clearInstalls()
+            return PostHogSDK.with(config)
+        }
+
+        @Test("setup() releases a prewarm when push-open capture is disabled")
+        @available(iOS 14.0, macOS 11.0, *)
+        func setupDiscardsPrewarmWhenCaptureDisabled() {
+            let sut = makeSut(capturePushNotificationOpened: false)
+            defer { sut.close() }
+
+            #expect(publisher.discardCount == 1)
+        }
+
+        /// `setup()` skips `installIntegrations()` entirely while opted out, so the discard cannot
+        /// live there without leaving an opted-out app swizzled for the process lifetime.
+        @Test("setup() releases a prewarm while opted out, even with push-open capture enabled")
+        @available(iOS 14.0, macOS 11.0, *)
+        func setupDiscardsPrewarmWhileOptedOut() {
+            let sut = makeSut(optOut: true, capturePushNotificationOpened: true)
+            defer { sut.close() }
+
+            #expect(publisher.discardCount == 1)
+        }
+
+        @Test("setup() with push-open capture enabled does not discard the prewarm")
+        @available(iOS 14.0, macOS 11.0, *)
+        func setupKeepsPrewarmWhenCaptureEnabled() {
+            publisher.prewarmNotificationResponseCapture()
+
+            let sut = makeSut(capturePushNotificationOpened: true)
+            defer { sut.close() }
+
+            #expect(publisher.discardCount == 0)
+        }
 
         @Test("captures and calls an Objective-C delegate with the original selector")
         func callsObjectiveCDelegate() {

--- a/PostHogTests/PostHogPushNotificationSwizzlingTest.swift
+++ b/PostHogTests/PostHogPushNotificationSwizzlingTest.swift
@@ -189,6 +189,51 @@
             }
         }
 
+        @Test("a prewarm overtaken by the first subscriber does not outlive it")
+        func prewarmOvertakenByFirstSubscriberDoesNotOutliveIt() {
+            let publisher = PushNotificationPublisher.shared
+            var token: RegistrationToken?
+
+            // Drive the interleaving the subscriber-count read cannot be made atomic against:
+            // subscribe in the window between that read and the flag being set.
+            publisher.onRaceWindow = { window in
+                guard window == .prewarmAfterSubscriberCheck else { return }
+                token = publisher.onNotificationResponse.subscribe { _ in }
+            }
+            publisher.prewarmNotificationResponseCapture()
+            publisher.onRaceWindow = nil
+
+            // That subscriber goes away, so nothing is left that wants a response held for it.
+            token = nil
+
+            withPlaceholderResponse { response in
+                publisher.deliver(notificationResponse: response)
+                #expect(publisher.consumePendingNotificationResponse() == nil)
+            }
+        }
+
+        @Test("a discard overtaken by a prewarm re-arms interception")
+        func discardOvertakenByPrewarmReArmsInterception() {
+            let publisher = PushNotificationPublisher.shared
+
+            publisher.onRaceWindow = { window in
+                guard window == .discardAfterSubscriberCheck else { return }
+                // One-shot: the nested prewarm must not re-enter this hook.
+                publisher.onRaceWindow = nil
+                publisher.prewarmNotificationResponseCapture()
+            }
+
+            let installsBefore = publisher.swizzleInstallAttempts
+            let uninstallsBefore = publisher.swizzleUninstallAttempts
+            publisher.discardPrewarmedNotificationResponseCapture()
+            publisher.onRaceWindow = nil
+
+            // The prewarm that landed mid-teardown installs once; the discard then tears down and
+            // must re-arm, so the transition count is install, uninstall, install.
+            #expect(publisher.swizzleUninstallAttempts == uninstallsBefore + 1)
+            #expect(publisher.swizzleInstallAttempts == installsBefore + 2)
+        }
+
         @Test("a prewarm after the last subscriber detaches still opens the buffer window")
         func prewarmAfterLastSubscriberDetachesBuffers() {
             let publisher = PushNotificationPublisher.shared

--- a/PostHogTests/PostHogPushNotificationSwizzlingTest.swift
+++ b/PostHogTests/PostHogPushNotificationSwizzlingTest.swift
@@ -189,6 +189,20 @@
             }
         }
 
+        @Test("a prewarm after the last subscriber detaches still opens the buffer window")
+        func prewarmAfterLastSubscriberDetachesBuffers() {
+            let publisher = PushNotificationPublisher.shared
+            var token: RegistrationToken? = publisher.onNotificationResponse.subscribe { _ in }
+            token = nil
+
+            publisher.prewarmNotificationResponseCapture()
+
+            withPlaceholderResponse { response in
+                publisher.deliver(notificationResponse: response)
+                #expect(publisher.consumePendingNotificationResponse() != nil)
+            }
+        }
+
         @Test("the public prewarm API reaches the publisher")
         @available(iOS 14.0, macOS 11.0, *)
         func publicPrewarmApiReachesPublisher() {

--- a/PostHogTests/PostHogPushNotificationSwizzlingTest.swift
+++ b/PostHogTests/PostHogPushNotificationSwizzlingTest.swift
@@ -154,7 +154,6 @@
             publisher.prewarmNotificationResponseCapture()
             publisher.prewarmNotificationResponseCapture()
 
-            // Still buffering means the second call did not tear the prewarm window down.
             withPlaceholderResponse { response in
                 publisher.deliver(notificationResponse: response)
                 #expect(publisher.consumePendingNotificationResponse() === response)

--- a/api/posthog-ios.public-api.txt
+++ b/api/posthog-ios.public-api.txt
@@ -320,6 +320,7 @@ PostHog | PostHogSDK.isSessionReplayActive() | method | @objc func isSessionRepl
 PostHog | PostHogSDK.logger | property | @objc var logger: PostHogLogger? { get } | c:@M@PostHog@objc(cs)PostHogSDK(py)logger
 PostHog | PostHogSDK.optIn() | method | @objc func optIn() | c:@M@PostHog@objc(cs)PostHogSDK(im)optIn
 PostHog | PostHogSDK.optOut() | method | @objc func optOut() | c:@M@PostHog@objc(cs)PostHogSDK(im)optOut
+PostHog | PostHogSDK.prewarmPushNotificationOpenCapture() | type.method | @objc static func prewarmPushNotificationOpenCapture() | c:@M@PostHog@objc(cs)PostHogSDK(cm)prewarmPushNotificationOpenCapture
 PostHog | PostHogSDK.register(_:) | method | @objc(registerProperties:) func register(_ properties: [String : Any]) | c:@M@PostHog@objc(cs)PostHogSDK(im)registerProperties:
 PostHog | PostHogSDK.registerPushNotificationToken(_:) | method | @objc func registerPushNotificationToken(_ deviceToken: String) | c:@M@PostHog@objc(cs)PostHogSDK(im)registerPushNotificationToken:
 PostHog | PostHogSDK.registerPushNotificationToken(_:appId:) | method | @objc func registerPushNotificationToken(_ deviceToken: String, appId: String?) | c:@M@PostHog@objc(cs)PostHogSDK(im)registerPushNotificationToken:appId:


### PR DESCRIPTION
## :link: Related PRs

One fix, five PRs — three SDKs plus the docs. Each Flutter PR is gated on the native release it depends on.

| PR | What it does |
| --- | --- |
| **PostHog/posthog-ios#792** | **native iOS — hold a tap delivered before `setup()`** — ← this PR |
| PostHog/posthog-android#753 | native Android — read a launch intent the SDK installed too late to see |
| PostHog/posthog-flutter#556 | Flutter iOS cold start · needs posthog-ios 3.72.0 · fixes PostHog/posthog-flutter#555 |
| PostHog/posthog-flutter#557 | Flutter Android cold + warm start · needs posthog-android 3.62.0 · fixes PostHog/posthog-flutter#558 |
| PostHog/posthog.com#19905 | docs for all of the above |

**Order:** PostHog/posthog-ios#792 and PostHog/posthog-android#753 merge and release first → PostHog/posthog-flutter#556 and PostHog/posthog-flutter#557 leave draft and go green on their own once the floors publish → PostHog/posthog.com#19905 last, since posthog.com deploys on merge.

## :bulb: Motivation and Context

Fixes the native half of PostHog/posthog-flutter#555 — `$push_notification_opened` is never captured in a stock Flutter app on iOS. Two independent causes, both reproduced on a simulator:

1. **Nobody is listening.** A stock Flutter app sets no `UNUserNotificationCenter` delegate, so iOS reports the tap to nobody and our swizzling has nothing to attach to. The integration logs `installed` and then stays silent forever, which is near-impossible to diagnose from outside.
2. **We start too late.** On a cold launch from a tap, `didReceive` arrives ~150 ms in — about 90 ms *before* a Dart/JS host can reach `setup()`. The swizzles aren't in place yet.

Native iOS apps that call `setup()` from `didFinishLaunchingWithOptions` are unaffected by (2) and need none of this.

## :green_heart: How did you test it?

- `make test` — 907 tests pass.
- `make testOniOSSimulator` — `** TEST SUCCEEDED **`, 190 cases, 0 failures.
- 9 new unit tests covering the buffer, prewarm idempotency, prewarm-with-a-live-subscriber, and the `setup()` discard gate. The opted-out one is a real regression test — reverting the fix makes it fail.
- On device (posthog-flutter example app, iPhone 17 Pro sim / iOS 26.4, built against this branch): **4/4 notification taps captured**, one event each — 1 warm start and 3 cold starts, each read out of the `/batch` payload the SDK sent. Before the fix, cold starts captured 0.

## Testing

Beyond the unit suites, verified on an iPhone 17 Pro simulator (iOS 26.4) through two hosts, with each event read out of the SDK's own `/batch` payload:

**posthog-ios's own `PostHogExample`** (`setup()` in `didFinishLaunchingWithOptions`, delegate wired) — the configuration this change does *not* need to alter:

| Scenario | Result |
| --- | --- |
| Cold launch from a tap | captured |
| Tap while the app is running | captured |

**A Flutter host**, where `setup()` runs from Dart ~90ms after the tap is delivered: cold start went from 0 captures to 1, repeatedly, across four rounds.

Also checked: with the app's `UNUserNotificationCenter` delegate removed, nothing is captured in any app state and the new warning fires; with it present, no warning. `capturePushNotificationOpened: false` installs no integration and captures nothing.

**Re-verified 2026-09-08**, after rebasing on `main` (posthog-ios is still 3.71.6, so this `minor` lands on 3.72.0 and the Flutter floor is unchanged): 907 swift-testing cases and 190 XCTest cases green, and the cold/warm matrix re-run on an iPhone 17 simulator through both hosts — one event each, four for four.

Method note: the example apps point at a local HTTP server standing in for the ingestion host, so every assertion above is made against the exact `/batch` body the SDK sent, not a dashboard query.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code ([session](https://claude.ai/code/session_012txiHBCZRkShMdE7V25Jrd)), driven by @turnipdabeets. Investigation started from posthog-flutter#555 and reproduced both causes on a simulator before any code was written.

Three review/triage rounds ran over the branch, and each caught something material:

- Buffering was initially unconditional, so after `setup()` → `close()` a tap was retained in the process-wide publisher and replayed into the next `setup()` within 30s — a silent behaviour change for **all** posthog-ios users, with a consent dimension. Now the buffer only lives inside the prewarm window.
- The discard was first placed at the end of `installIntegrations()`, which `setup()` only calls when not opted out — so it never ran for anyone with a persisted opt-out. Moved into `setup()` with the gate widened.
- The branch did not compile in the `test-ios-simulator` lane (a new test called the iOS-14-only API unguarded). `swift test` on macOS hides this because Swift raises the arm64 floor to 11.0.

Two alternatives were considered and rejected: a `hasEverHadSubscriber` latch to close the window permanently (it would silently kill cold-start capture forever for a Flutter add-to-app host that prewarms after `close()`), and replaying `launchOptions[.remoteNotification]` (verified on iOS 26 — that key is not populated for a user tap).

Not done here, deliberately: docs. The `posthog_flutter` side is PostHog/posthog-flutter#556 and needs a release of this one first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012txiHBCZRkShMdE7V25Jrd



