### PR TITLE
fix(surveys): tint selected emoji rating with ratingButtonActiveColor

### DIFF
--- a/.changeset/olive-mugs-shake.md
+++ b/.changeset/olive-mugs-shake.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Surveys: show the selected face on emoji rating questions. The selected face took a color that contrasts against `ratingButtonActiveColor`, but the face is tinted rather than drawn on a filled button, so nothing painted that color behind it. A dark `ratingButtonActiveColor` turned the selected face white on a white survey card, and it disappeared on tap. The face now takes `ratingButtonActiveColor` directly, which matches the Android SDK.

--- a/.changeset/olive-mugs-shake.md
+++ b/.changeset/olive-mugs-shake.md
@@ -2,4 +2,4 @@
 "posthog-ios": patch
 ---
 
-Surveys: show the selected face on emoji rating questions. The selected face took a color that contrasts against `ratingButtonActiveColor`, but the face is tinted rather than drawn on a filled button, so nothing painted that color behind it. A dark `ratingButtonActiveColor` turned the selected face white on a white survey card, and it disappeared on tap. The face now takes `ratingButtonActiveColor` directly, which matches the Android SDK.
+Surveys: show the selected face on emoji rating questions. The selected face took a color that contrasts against `ratingButtonActiveColor`, but the face is tinted rather than drawn on a filled button, so nothing painted that color behind it. PostHog pairs `ratingButtonActiveColor` with an opposing background, so the face blended into the card and disappeared on tap. This affected the default appearance and every built-in theme. The face now takes `ratingButtonActiveColor` directly, which matches the Android SDK.

--- a/PostHog/Surveys/Utils/EmojiRating.swift
+++ b/PostHog/Surveys/Utils/EmojiRating.swift
@@ -86,11 +86,10 @@
         }
 
         private func foregroundColor(selected: Bool) -> Color {
-            surveyRatingForegroundColor(
-                selected: selected,
-                activeColor: ratingButtonActiveColor,
-                inputTextColor: inputTextColor
-            )
+            // The glyph is tinted, not drawn on top of a filled button, so the active color is the
+            // glyph color itself. Do not use `surveyRatingForegroundColor` here: it returns a color
+            // that contrasts *against* the active color, which only suits a filled rating button.
+            selected ? ratingButtonActiveColor : inputTextColor.opacity(0.5)
         }
 
         private var ratingButtonActiveColor: Color {

--- a/PostHog/Surveys/Utils/EmojiRating.swift
+++ b/PostHog/Surveys/Utils/EmojiRating.swift
@@ -86,9 +86,7 @@
         }
 
         private func foregroundColor(selected: Bool) -> Color {
-            // The glyph is tinted, not drawn on top of a filled button, so the active color is the
-            // glyph color itself. Do not use `surveyRatingForegroundColor` here: it returns a color
-            // that contrasts *against* the active color, which only suits a filled rating button.
+            // The glyph is tinted, not drawn on a filled button, so the active color is the glyph color.
             selected ? ratingButtonActiveColor : inputTextColor.opacity(0.5)
         }
 

--- a/PostHog/Surveys/Utils/NumberRating.swift
+++ b/PostHog/Surveys/Utils/NumberRating.swift
@@ -65,11 +65,8 @@
         }
 
         private func foregroundTextColor(selected: Bool) -> Color {
-            surveyRatingForegroundColor(
-                selected: selected,
-                activeColor: ratingButtonActiveColor,
-                inputTextColor: inputTextColor
-            )
+            // The number sits on a rectangle filled with the active color, so contrast against it.
+            selected ? ratingButtonActiveColor.getContrastingTextColor() : inputTextColor.opacity(0.5)
         }
 
         private var ratingButtonColor: Color {

--- a/PostHog/Surveys/Utils/SwiftUI+Util.swift
+++ b/PostHog/Surveys/Utils/SwiftUI+Util.swift
@@ -41,19 +41,6 @@
         }
     }
 
-    /// Foreground color for a rating control that paints `activeColor` behind its content when selected.
-    ///
-    /// The selected color contrasts *against* `activeColor`, so a control that tints its content with
-    /// `activeColor` instead of filling a button with it must not use this.
-    @available(iOS 15.0, *)
-    func surveyRatingForegroundColor(selected: Bool, activeColor: Color, inputTextColor: Color) -> Color {
-        if selected {
-            return activeColor.getContrastingTextColor()
-        } else {
-            return inputTextColor.opacity(0.5)
-        }
-    }
-
     @available(iOS 14.0, *)
     private struct ReadFrameModifier: ViewModifier {
         /// Helper for notifying parents for child view frame changes

--- a/PostHog/Surveys/Utils/SwiftUI+Util.swift
+++ b/PostHog/Surveys/Utils/SwiftUI+Util.swift
@@ -41,6 +41,10 @@
         }
     }
 
+    /// Foreground color for a rating control that paints `activeColor` behind its content when selected.
+    ///
+    /// The selected color contrasts *against* `activeColor`, so a control that tints its content with
+    /// `activeColor` instead of filling a button with it must not use this.
     @available(iOS 15.0, *)
     func surveyRatingForegroundColor(selected: Bool, activeColor: Color, inputTextColor: Color) -> Color {
         if selected {


### PR DESCRIPTION
## :bulb: Motivation and Context

Tapping a face on an emoji rating survey question makes it disappear instead of showing a selected state. The other faces stay visible in grey, so people cannot tell which rating they picked before they submit.

`EmojiRating` tinted the selected face through `surveyRatingForegroundColor(...)`, which returns `activeColor.getContrastingTextColor()`. That gives a foreground meant to sit **on top of** the color passed in, which is only correct when something paints that color behind the content. `EmojiRating` never does. The face is a shape with `.frame`, `.font` and `.foregroundColor`, and the file has no `.background` or fill.

So when `ratingButtonActiveColor` is dark, the helper resolves the selected face to white and draws it on a white survey card. White on white.

This fired on the **default** appearance, not only on custom ones: `ratingButtonActiveColor` defaults to `.black`, and black has luminance 0, under the 0.6 threshold in `Survey+Util.swift`. The common case was the broken one.

Survey appearance is served from the API and shared across platforms, so this is not something a customer can configure around. Android tints the glyph with `ratingButtonActiveColor` directly, so a value that fixes iOS today hides the selected face on Android for the same reason.

- From https://us.posthog.com/project/2/support/tickets/70521

### Changes

- The selected emoji takes `ratingButtonActiveColor` directly, matching `posthog-android-surveys-compose`. The unselected branch is unchanged.
- `surveyRatingForegroundColor` is gone. It had one caller left and a name that did not say it needs `activeColor` painted behind the content, and that unstated precondition is what produced this bug. Both controls now read as a one-line ternary next to the reason for their own behavior: `EmojiRating` tints the glyph, `NumberRating` contrasts against the rectangle it fills. No behavior change for `NumberRating`.

### A deliberate tradeoff

Tinting directly moves the failure to the opposite end of the range: a light `ratingButtonActiveColor` on a light card is now invisible, where before it rendered black.

We are accepting that rather than adding a contrast guard. Cross-platform agreement is the point of this change, and an iOS-only guard puts the two SDKs back out of step. A customer who picks a light active color sees it break on Android too, so the feedback is not silent. No PostHog-generated appearance produces that pairing today: contrast was checked across the API default and all six appearance-wizard themes, and all seven land at 3.45:1 or better after this change, against six of seven at 1.17:1 or worse before it.

Reported by an SDK user who traced it to the line and checked it against the Android and web implementations.

## :green_heart: How did you test it?

Not built or run. This environment has no Swift or iOS toolchain, and the survey UI is `#if os(iOS)`, so I could not compile it or render the control. CI covers the build and is green.

Verified by reading the source:

- `EmojiRating.swift` has no `.background`, no fill, and no `ratingButtonColor` reference outside the `#DEBUG` preview, so nothing paints `ratingButtonActiveColor` behind the glyph.
- `NumberRating.swift` fills `ratingButtonActiveColor` via `indicatorView`, which `SegmentedControl` places as the selected segment's `.background`, so contrasting against it stays correct.
- `getContrastingTextColor()` returns `.white` below the 0.6 luminance threshold, which is what produced white on white.
- The emoji glyphs are `Shape` values, so `.foregroundColor` genuinely fills them.
- Nothing in `PostHogTests/` references the removed helper, `getContrastingTextColor`, `EmojiRating`, or `NumberRating`, so no existing test changes behavior.

**Please confirm on a simulator or device** with a dark `ratingButtonActiveColor` on a light survey background, and with a light one, that the selected face is visible in both.

No test added. The repo does have a golden-image harness (`PostHogTests/PostHogMaskSnapshotTest.swift`, with committed PNGs and a `mask-snapshots` CI job), but it is scoped to session-replay masking, compile-gated, and pinned to a specific Xcode and iOS pair, so a survey golden would be disproportionate for a color assertion. A pure-function test would need the tint logic extracted back out to a named helper, which is what this PR just removed, and it would assert little beyond restating the ternary.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Opus in PostHog Desktop, from an SDK user's bug report that already contained the diagnosis. I re-derived it from source rather than taking it on trust, reading `EmojiRating.swift`, `NumberRating.swift` and `Survey+Util.swift` here and the Android `EmojiRating.kt` through the GitHub API. Every claim in the report held up.

The PR then went through a multi-agent review (correctness, security, testing, architecture, maintainability). Three things changed as a result. Two reviewers independently argued for deleting `surveyRatingForegroundColor` rather than documenting its precondition, which is what the Changes section now describes; the first version of this PR kept it and added a doc comment. The testing reviewer caught that an earlier draft of this description claimed the repo has no snapshot infrastructure, which was wrong, and that has been corrected above. The correctness and architecture reviewers disagreed about whether to add a contrast guard for the inverted case, and the "deliberate tradeoff" section records where that landed and why.

The reviewers also flagged a pre-existing crash unrelated to this PR: `UIColor(hex:)` in `Survey+Util.swift` narrows a scanned `UInt64` with `CUnsignedInt(c)`, and `normalize` passes any string longer than seven characters straight through, so an appearance value like `#123456789` traps at runtime. That parse runs for every color field whenever a survey with an appearance is shown. Filing separately.

`posthog-js` takes a third approach (opacity 0.5 to 1, glyph filled from `--ph-survey-text-primary-color`, with `ratingButtonActiveColor` used only by `.ratings-number.rating-active`), so all three SDKs still differ. This PR only aligns iOS with Android.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
