### PR TITLE
fix: declare required reason APIs in privacy manifest

### DIFF
--- a/.changeset/calm-clocks-tick.md
+++ b/.changeset/calm-clocks-tick.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': patch
+---
+
+Declare the system boot time and file timestamp APIs used by the SDK in its privacy manifest.

--- a/PostHog/Resources/PrivacyInfo.xcprivacy
+++ b/PostHog/Resources/PrivacyInfo.xcprivacy
@@ -39,6 +39,22 @@
 				<string>CA92.1</string>
 			</array>
 		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## :bulb: Motivation and Context

PostHog uses system boot time APIs to measure network request durations and detect rage clicks. It also reads creation timestamps for files in its persisted event queue. These required-reason APIs were missing from the SDK's privacy manifest, which can cause App Store validation failures for apps that include PostHog.

Addresses the required-reason API findings in https://github.com/PostHog/posthog-ios/issues/796. The collected Device ID declaration remains separate from this change.

This change declares system boot time with reason `35F9.1` and file timestamps with reason `C617.1`.

Closes https://github.com/PostHog/posthog-ios/issues/796

## :green_heart: How did you test it?

- Ran `plutil -lint PostHog/Resources/PrivacyInfo.xcprivacy`.
- Confirmed the built framework contains all three expected accessed API categories.
- Ran `CI=true pnpm changeset status`.
- Ran `make lint`.
- Ran `make buildSdk` across iOS, macOS, Mac Catalyst, tvOS, watchOS, and visionOS.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi investigated the missing declarations, compared them with Sentry Cocoa, and made the requested manifest-only fix. Pi's isolated autoreview found no actionable issues in commit `0cef05b73`.
