### PR TITLE
test(surveys): make feature flag matching deterministic

### DIFF
--- a/PostHogTests/PostHogSurveysTest.swift
+++ b/PostHogTests/PostHogSurveysTest.swift
@@ -1546,11 +1546,21 @@ enum PostHogSurveysTest {
         }
 
         @Test("returns only surveys with enabled feature flags")
-        func returnsOnlySurveysWithEnabledFeatureFlags() async {
+        func returnsOnlySurveysWithEnabledFeatureFlags() async throws {
             let sut = getSut(surveys: [surveysWithFeatureFlags])
+            // Seed surveys separately so this matching test does not race the remote-config listener's own flag refresh.
+            let surveys = sut.decodeSurveys(from: [
+                "surveys": try parseSurveys(surveysWithFeatureFlags),
+            ])
+            sut.updateSurveyCache(surveys, events: [:])
+            await withCheckedContinuation { continuation in
+                postHog.remoteConfig?.reloadFeatureFlags { _ in
+                    continuation.resume()
+                }
+            }
 
             let matchedSurveys: [PostHogSurvey] = await withCheckedContinuation { continuation in
-                sut.getActiveMatchingSurveys(forceReload: true) {
+                sut.getActiveMatchingSurveys {
                     continuation.resume(with: .success($0))
                 }
             }


### PR DESCRIPTION
## :bulb: Motivation and Context

The survey feature flag matching test sometimes checked surveys while a second feature flag refresh was still running. The test called `getActiveMatchingSurveys(forceReload: true)`, which reloaded remote config. Both the reload callback and the remote-config listener could then start feature flag work. If the listener started another refresh before matching completed, the SDK correctly excluded flag-dependent surveys and the test failed.

This caused the failure seen in the test job for #798.

The test now seeds its survey cache directly and waits for one explicit feature flag reload before checking the matching result. This keeps the test focused on feature flag matching without racing the remote-config listener.

## :green_heart: How did you test it?

- Repeated the focused test 50 times. All 50 runs passed after the change.
- Ran the `TestGetActiveSurveys` suite. All 10 tests passed.
- Ran `make test`. All 765 tests passed.
- Ran `make format` and `make lint`.
- Ran autoreview against `origin/main`. It reported no actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi investigated the failed GitHub Actions job, reproduced the race repeatedly, and prepared the test-only fix in an isolated worktree. The change avoids altering SDK behavior because the failure came from a test that combined feature flag matching with an unrelated remote-config refresh. No public session link is available.
