### PR TITLE
fix: capture screen names inside custom view controllers

### DIFF
--- a/.changeset/fix-custom-container-screen-names.md
+++ b/.changeset/fix-custom-container-screen-names.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Fix automatic screen names for custom view controller containers with a single visible child. Use titles for plain UIViewController screens instead of reporting "UI".

--- a/.changeset/fix-custom-container-screen-names.md
+++ b/.changeset/fix-custom-container-screen-names.md
@@ -2,4 +2,4 @@
 "posthog-ios": patch
 ---
 
-Fix automatic screen names for custom view controller containers with a single visible child. Use titles for plain UIViewController screens instead of reporting "UI".
+Fix automatic screen names for custom view controller containers with a single visible child, excluding offscreen, empty, and fully clipped child views. Use titles for plain UIViewController screens instead of reporting "UI".

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -305,6 +305,7 @@
 		DA53DE7E2D3E66AA00C38DCA /* PostHogRemoteConfigTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA53DE7D2D3E66A300C38DCA /* PostHogRemoteConfigTest.swift */; };
 		DA578E982D6768BC00B3A56C /* PostHogScreenViewIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA578E972D6768B400B3A56C /* PostHogScreenViewIntegration.swift */; };
 		DA578E9C2D68578500B3A56C /* MockApplicationLifecyclePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA578E9B2D68578500B3A56C /* MockApplicationLifecyclePublisher.swift */; };
+		C02440012E00000100000244 /* PostHogViewControllerTraversalTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02440022E00000100000244 /* PostHogViewControllerTraversalTest.swift */; };
 		DA578E9E2D6858BA00B3A56C /* PostHogScreenViewIntegrationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA578E9D2D6858B200B3A56C /* PostHogScreenViewIntegrationTest.swift */; };
 		DA578EA02D6858CE00B3A56C /* MockScreenViewPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA578E9F2D6858C900B3A56C /* MockScreenViewPublisher.swift */; };
 		DA5AA7192CE245D2004EFB99 /* UIApplication+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5AA7132CE245CD004EFB99 /* UIApplication+.swift */; };
@@ -1088,6 +1089,7 @@
 		DA578E972D6768B400B3A56C /* PostHogScreenViewIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogScreenViewIntegration.swift; sourceTree = "<group>"; };
 		DA578E992D676AE700B3A56C /* ApplicationScreenViewPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationScreenViewPublisher.swift; sourceTree = "<group>"; };
 		DA578E9B2D68578500B3A56C /* MockApplicationLifecyclePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockApplicationLifecyclePublisher.swift; sourceTree = "<group>"; };
+		C02440022E00000100000244 /* PostHogViewControllerTraversalTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogViewControllerTraversalTest.swift; sourceTree = "<group>"; };
 		DA578E9D2D6858B200B3A56C /* PostHogScreenViewIntegrationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogScreenViewIntegrationTest.swift; sourceTree = "<group>"; };
 		DA578E9F2D6858C900B3A56C /* MockScreenViewPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockScreenViewPublisher.swift; sourceTree = "<group>"; };
 		DA5AA7132CE245CD004EFB99 /* UIApplication+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+.swift"; sourceTree = "<group>"; };
@@ -1743,6 +1745,7 @@
 				5CA51F0E2B5C9A0100000002 /* PostHogScreenNameTest.swift */,
 				DA6F24812D4A6CA100CA2777 /* PostHogApiTest.swift */,
 				DA578E9D2D6858B200B3A56C /* PostHogScreenViewIntegrationTest.swift */,
+				C02440022E00000100000244 /* PostHogViewControllerTraversalTest.swift */,
 				DACF6D5C2CD2F5BC00F14133 /* PostHogAutocaptureIntegrationSpec.swift */,
 				DA703C1D2D66346E0069097B /* PostHogAppLifeCycleIntegrationTest.swift */,
 				DAA5ED962D4043A500D437E0 /* PostHogSurveysTest.swift */,
@@ -3505,6 +3508,7 @@
 				DAF95F612D077C21001E82BB /* PostHogWebPTest.swift in Sources */,
 				69ED1AB62C90711D00FE7A91 /* PostHogSDKPersonProfilesTest.swift in Sources */,
 				DA578E9E2D6858BA00B3A56C /* PostHogScreenViewIntegrationTest.swift in Sources */,
+				C02440012E00000100000244 /* PostHogViewControllerTraversalTest.swift in Sources */,
 				3A62646A29C9E385007E8C07 /* MockPostHogServer.swift in Sources */,
 				690FF0BB2AEF8B8200A0B06B /* PostHogContextTest.swift in Sources */,
 				DAEA0FD12F6D5191000E33D8 /* PostHogReplayBufferQueueTest.swift in Sources */,

--- a/PostHog/Autocapture/PostHogAutocaptureEventTracker.swift
+++ b/PostHog/Autocapture/PostHogAutocaptureEventTracker.swift
@@ -374,21 +374,6 @@
         }
     }
 
-    extension UIViewController {
-        class func ph_topViewController(base: UIViewController? = UIApplication.getCurrentWindow()?.rootViewController) -> UIViewController? {
-            if let nav = base as? UINavigationController {
-                return ph_topViewController(base: nav.visibleViewController)
-
-            } else if let tab = base as? UITabBarController, let selected = tab.selectedViewController {
-                return ph_topViewController(base: selected)
-
-            } else if let presented = base?.presentedViewController {
-                return ph_topViewController(base: presented)
-            }
-            return base
-        }
-    }
-
     extension UIResponder {
         var nearestViewController: UIViewController? {
             self as? UIViewController ?? next?.nearestViewController

--- a/PostHog/ScreenViews/ApplicationScreenViewPublisher.swift
+++ b/PostHog/ScreenViews/ApplicationScreenViewPublisher.swift
@@ -87,7 +87,7 @@ final class ApplicationScreenViewPublisher: ScreenViewPublishing {
                 return
             }
 
-            guard let top = findVisibleViewController(viewController) else { return }
+            guard let top = UIViewController.ph_topViewController(base: viewController) else { return }
 
             guard let name = UIViewController.getViewControllerName(top) else { return }
 
@@ -95,20 +95,6 @@ final class ApplicationScreenViewPublisher: ScreenViewPublishing {
             handler?(name)
         }
 
-        private func findVisibleViewController(_ controller: UIViewController?) -> UIViewController? {
-            if let navigationController = controller as? UINavigationController {
-                return findVisibleViewController(navigationController.visibleViewController)
-            }
-            if let tabController = controller as? UITabBarController {
-                if let selected = tabController.selectedViewController {
-                    return findVisibleViewController(selected)
-                }
-            }
-            if let presented = controller?.presentedViewController {
-                return findVisibleViewController(presented)
-            }
-            return controller
-        }
     #else
         private func swizzleViewDidAppear() {
             // no-op if not UIKit
@@ -135,7 +121,6 @@ final class ApplicationScreenViewPublisher: ScreenViewPublishing {
             if let root = viewIfLoaded?.window?.rootViewController {
                 return root
             }
-            // TODO: handle container controllers (see ph_topViewController)
             return UIApplication.getCurrentWindow()?.rootViewController
         }
     }

--- a/PostHog/UIViewController.swift
+++ b/PostHog/UIViewController.swift
@@ -37,20 +37,34 @@
                     return false
                 }
 
-                // A child's view may be inside a hidden or transparent wrapper.
-                var view: UIView? = childView
-                while let current = view, current !== containerView {
-                    if current.isHidden || current.alpha <= 0 {
-                        return false
-                    }
-                    view = current.superview
-                }
-                return true
+                return isViewVisible(childView, in: window)
             }
             if visibleChildren.count == 1 {
                 return ph_topViewController(base: visibleChildren[0])
             }
             return base
+        }
+
+        private static func isViewVisible(_ childView: UIView, in window: UIWindow) -> Bool {
+            guard !childView.bounds.isEmpty else { return false }
+            var visibleRect = childView.convert(childView.bounds, to: window).intersection(window.bounds)
+            guard !visibleRect.isEmpty else { return false }
+
+            // Check the whole ancestor chain: attached paging views can be
+            // offscreen or clipped, even when they are not hidden/transparent.
+            var view: UIView? = childView
+            while let current = view {
+                if current.isHidden || current.alpha <= 0 {
+                    return false
+                }
+                if current.clipsToBounds {
+                    visibleRect = visibleRect.intersection(current.convert(current.bounds, to: window))
+                    if visibleRect.isEmpty { return false }
+                }
+                if current === window { break }
+                view = current.superview
+            }
+            return true
         }
 
         static func getViewControllerName(_ viewController: UIViewController) -> String? {

--- a/PostHog/UIViewController.swift
+++ b/PostHog/UIViewController.swift
@@ -13,10 +13,52 @@
     import UIKit
 
     extension UIViewController {
+        class func ph_topViewController(base: UIViewController? = UIApplication.getCurrentWindow()?.rootViewController) -> UIViewController? {
+            if let nav = base as? UINavigationController {
+                return ph_topViewController(base: nav.visibleViewController)
+            } else if let tab = base as? UITabBarController, let selected = tab.selectedViewController {
+                return ph_topViewController(base: selected)
+            } else if let presented = base?.presentedViewController {
+                return ph_topViewController(base: presented)
+            }
+
+            guard let base, let containerView = base.viewIfLoaded, let window = containerView.window else {
+                return base
+            }
+
+            // Custom containers have no selected/visibleViewController API. Only
+            // descend when one child is unambiguously visible; keep the container
+            // name for multi-pane layouts and overlapping transition views.
+            let visibleChildren = base.children.filter { child in
+                guard let childView = child.viewIfLoaded,
+                      childView.window === window,
+                      childView.isDescendant(of: containerView)
+                else {
+                    return false
+                }
+
+                // A child's view may be inside a hidden or transparent wrapper.
+                var view: UIView? = childView
+                while let current = view, current !== containerView {
+                    if current.isHidden || current.alpha <= 0 {
+                        return false
+                    }
+                    view = current.superview
+                }
+                return true
+            }
+            if visibleChildren.count == 1 {
+                return ph_topViewController(base: visibleChildren[0])
+            }
+            return base
+        }
+
         static func getViewControllerName(_ viewController: UIViewController) -> String? {
             var title: String? = String(describing: viewController.classForCoder).replacingOccurrences(of: "ViewController", with: "")
 
-            if title?.isEmpty == true {
+            // Plain storyboard controllers have no meaningful class name (stripping
+            // "ViewController" from "UIViewController" would otherwise leave "UI").
+            if title?.isEmpty == true || viewController.classForCoder == UIViewController.self {
                 title = viewController.title ?? nil
             }
 

--- a/PostHogTests/PostHogViewControllerTraversalTest.swift
+++ b/PostHogTests/PostHogViewControllerTraversalTest.swift
@@ -152,6 +152,73 @@
             }
         }
 
+        @Test("Offscreen, empty, and clipped children are ignored", arguments: ["offscreen", "zero width", "zero height", "clipped ancestor"])
+        func ignoresInvisibleGeometry(state: String) {
+            let root = InitialViewController()
+            withWindow(root: root) { window in
+                let inactive = TwoViewController()
+                add(inactive, to: root)
+                switch state {
+                case "offscreen":
+                    inactive.view.frame = root.view.bounds.offsetBy(dx: window.bounds.width, dy: 0)
+                case "zero width":
+                    inactive.view.frame = CGRect(x: 0, y: 0, width: 0, height: 50)
+                case "zero height":
+                    inactive.view.frame = CGRect(x: 0, y: 0, width: 50, height: 0)
+                case "clipped ancestor":
+                    let wrapper = UIView(frame: CGRect(x: 20, y: 20, width: 50, height: 50))
+                    wrapper.clipsToBounds = true
+                    root.view.addSubview(wrapper)
+                    wrapper.addSubview(inactive.view)
+                    // Still inside the window, but outside the clipping wrapper.
+                    inactive.view.frame = CGRect(x: 80, y: 0, width: 20, height: 20)
+                default: break
+                }
+                #expect(inactive.view.window === window)
+                #expect(UIViewController.ph_topViewController(base: root) === root)
+
+                let visible = OneViewController()
+                add(visible, to: root)
+                #expect(UIViewController.ph_topViewController(base: root) === visible)
+            }
+        }
+
+        @Test("Partially visible children remain eligible", arguments: [false, true])
+        func partiallyVisibleChild(clippedByWrapper: Bool) {
+            let root = InitialViewController()
+            withWindow(root: root) { window in
+                let child = OneViewController()
+                add(child, to: root)
+                if clippedByWrapper {
+                    let wrapper = UIView(frame: CGRect(x: 20, y: 20, width: 50, height: 50))
+                    wrapper.clipsToBounds = true
+                    root.view.addSubview(wrapper)
+                    wrapper.addSubview(child.view)
+                    child.view.frame = CGRect(x: 40, y: 0, width: 20, height: 20)
+                } else {
+                    child.view.frame = CGRect(x: window.bounds.width - 10, y: 0, width: 20, height: 20)
+                }
+                #expect(UIViewController.ph_topViewController(base: root) === child)
+            }
+        }
+
+        @Test("Overflow is visible only when its ancestor does not clip", arguments: [false, true])
+        func respectsAncestorClipping(clips: Bool) {
+            let root = InitialViewController()
+            withWindow(root: root) { _ in
+                let child = OneViewController()
+                add(child, to: root)
+                let wrapper = UIView(frame: CGRect(x: 20, y: 20, width: 50, height: 50))
+                wrapper.clipsToBounds = clips
+                // Exercise bounds conversion as used by scrolling containers.
+                wrapper.bounds.origin.x = 30
+                root.view.addSubview(wrapper)
+                wrapper.addSubview(child.view)
+                child.view.frame = CGRect(x: 90, y: 0, width: 20, height: 20)
+                #expect(UIViewController.ph_topViewController(base: root) === (clips ? root : child))
+            }
+        }
+
         @Test("Presented controllers still take precedence over custom children")
         func presentedController() {
             let root = InitialViewController()

--- a/PostHogTests/PostHogViewControllerTraversalTest.swift
+++ b/PostHogTests/PostHogViewControllerTraversalTest.swift
@@ -1,0 +1,180 @@
+//
+//  PostHogViewControllerTraversalTest.swift
+//  PostHogTests
+//
+
+#if os(iOS) || os(tvOS)
+    @testable import PostHog
+    import Testing
+    import UIKit
+
+    @Suite("Screen view controller traversal", .serialized)
+    @MainActor
+    struct PostHogViewControllerTraversalTest {
+        private final class InitialViewController: UIViewController {}
+        private final class OneViewController: UIViewController {}
+        private final class TwoViewController: UIViewController {}
+        private final class ThreeViewController: UIViewController {}
+
+        private func add(_ child: UIViewController, to parent: UIViewController) {
+            parent.addChild(child)
+            parent.view.addSubview(child.view)
+            child.view.frame = parent.view.bounds
+            child.didMove(toParent: parent)
+        }
+
+        private func withWindow(root: UIViewController, body: (UIWindow) throws -> Void) rethrows {
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+            window.rootViewController = root
+            window.isHidden = false
+            defer {
+                window.isHidden = true
+                window.rootViewController = nil
+            }
+            try body(window)
+        }
+
+        @Test("Screen autocapture follows navigation inside a custom container", arguments: [false, true], [false, true])
+        func capturesNavigationScreens(customContainer: Bool, titledControllers: Bool) {
+            let navigation = UINavigationController(rootViewController: OneViewController())
+            let root: UIViewController
+            if customContainer {
+                root = InitialViewController()
+                add(navigation, to: root)
+            } else {
+                root = navigation
+            }
+
+            withWindow(root: root) { window in
+                var names: [String] = []
+                ApplicationScreenViewPublisher.shared.startAutoCapture { names.append($0) }
+                defer { ApplicationScreenViewPublisher.shared.stopAutoCapture() }
+
+                let screens: [(UIViewController, String)] = [
+                    (OneViewController(), "One"),
+                    (TwoViewController(), "Two"),
+                    (ThreeViewController(), "Three"),
+                ]
+                for (customScreen, name) in screens {
+                    // The issue's storyboard uses plain UIViewControllers with titles.
+                    // Custom classes should continue to take precedence over titles.
+                    let screen = titledControllers ? UIViewController() : customScreen
+                    screen.title = titledControllers ? name : "Custom title"
+                    navigation.setViewControllers([screen], animated: false)
+                    navigation.view.layoutIfNeeded()
+                    #expect(screen.view.window === window)
+                    names.removeAll()
+                    // Exercise the real swizzle without relying on transition timing.
+                    screen.viewDidAppear(false)
+                    #expect(names == [name])
+                    #expect(UIViewController.ph_topViewController(base: root) === screen)
+                }
+            }
+        }
+
+        @Test("Nested custom containers preserve selected tab and navigation behavior")
+        func nestedContainers() {
+            let root = InitialViewController()
+            let nested = InitialViewController()
+            let screen = OneViewController()
+            let navigation = UINavigationController(rootViewController: screen)
+            let tabs = UITabBarController()
+            tabs.viewControllers = [TwoViewController(), navigation]
+            tabs.selectedIndex = 1
+            add(nested, to: root)
+            add(tabs, to: nested)
+
+            withWindow(root: root) { _ in
+                #expect(UIViewController.ph_topViewController(base: root) === screen)
+                tabs.selectedIndex = 0
+                #expect(UIViewController.ph_topViewController(base: root) === tabs.selectedViewController)
+            }
+        }
+
+        @Test("Custom containers follow replacement children")
+        func replacesChild() {
+            let root = InitialViewController()
+            let first = OneViewController()
+            let second = TwoViewController()
+            add(first, to: root)
+
+            withWindow(root: root) { _ in
+                #expect(UIViewController.ph_topViewController(base: root) === first)
+                first.willMove(toParent: nil)
+                first.view.removeFromSuperview()
+                first.removeFromParent()
+                add(second, to: root)
+                #expect(UIViewController.ph_topViewController(base: root) === second)
+            }
+        }
+
+        @Test("Multiple visible children keep the container name")
+        func ambiguousChildren() {
+            let root = InitialViewController()
+            add(OneViewController(), to: root)
+            add(TwoViewController(), to: root)
+            withWindow(root: root) { _ in
+                #expect(UIViewController.ph_topViewController(base: root) === root)
+            }
+        }
+
+        @Test("Inactive children are ignored", arguments: ["hidden", "transparent", "detached", "unloaded", "hidden ancestor"])
+        func ignoresInactiveChildren(state: String) {
+            let root = InitialViewController()
+            let visible = OneViewController()
+            let inactive = TwoViewController()
+            add(visible, to: root)
+            if state == "unloaded" {
+                root.addChild(inactive)
+                inactive.didMove(toParent: root)
+            } else {
+                add(inactive, to: root)
+                switch state {
+                case "hidden": inactive.view.isHidden = true
+                case "transparent": inactive.view.alpha = 0
+                case "detached": inactive.view.removeFromSuperview()
+                case "hidden ancestor":
+                    let wrapper = UIView(frame: root.view.bounds)
+                    root.view.addSubview(wrapper)
+                    wrapper.addSubview(inactive.view)
+                    wrapper.isHidden = true
+                default: break
+                }
+            }
+
+            withWindow(root: root) { _ in
+                #expect(UIViewController.ph_topViewController(base: root) === visible)
+                if state == "unloaded" {
+                    #expect(!inactive.isViewLoaded)
+                }
+                visible.view.isHidden = true
+                #expect(UIViewController.ph_topViewController(base: root) === root)
+            }
+        }
+
+        @Test("Presented controllers still take precedence over custom children")
+        func presentedController() {
+            let root = InitialViewController()
+            add(OneViewController(), to: root)
+            let presented = TwoViewController()
+            withWindow(root: root) { _ in
+                root.present(presented, animated: false)
+                defer { root.dismiss(animated: false) }
+                #expect(root.presentedViewController === presented)
+                #expect(UIViewController.ph_topViewController(base: root) === presented)
+            }
+        }
+
+        @Test("Traversal does not load detached controller views")
+        func detachedController() {
+            let root = InitialViewController()
+            let child = OneViewController()
+            root.addChild(child)
+            child.didMove(toParent: root)
+            #expect(UIViewController.ph_topViewController(base: root) === root)
+            #expect(!root.isViewLoaded)
+            #expect(!child.isViewLoaded)
+            #expect(UIViewController.ph_topViewController(base: nil) == nil)
+        }
+    }
+#endif


### PR DESCRIPTION
## :bulb: Motivation and Context

Fixes #244.

Apps that put a navigation controller inside a custom container report the container's name for every screen. Screen capture starts at the window root but does not inspect custom child controllers.

The shared controller lookup now follows a custom container's single visible child. It ignores unloaded, detached, hidden, transparent, offscreen, empty, and fully clipped child views. Visibility checks include the window bounds and clipping ancestors. Partially visible children and content overflowing a non-clipping parent remain eligible. When multiple children are visible, it keeps the container name rather than choosing one arbitrarily. Navigation, tab, and presented-controller handling stays unchanged.

Screen capture now uses the same lookup as interaction capture and screenshot replay. Plain `UIViewController` instances use their titles instead of the name `UI`, which also fixes the titled storyboard screens in the issue's sample. Custom controller classes still use their class names.

## :green_heart: How did you test it?

- Added simulator regression tests that recreate the reported hierarchy and exercise the real screen-capture swizzle. Before the fix, all three screens reported `Initial`. After the fix, they report `One`, `Two`, and `Three`.
- Covered nested containers, selected tabs, navigation, child replacement, ambiguous layouts, inactive children, presented controllers, and title fallback.
- Reproduced the review feedback with simulator tests for offscreen, zero-width, zero-height, and clipped children. The focused tests failed with nine assertions on the previous PR head and pass after the fix. Retained checks for partial visibility, non-clipping overflow, and scrolling bounds.
- `make test` and `make testOniOSSimulator` passed.
- `make format` and `make lint` passed. Lint reports existing warnings.
- `make build` passed all SDK platform builds and platform examples. It then stopped at the XCFramework client example because its package reference expects a checkout named `posthog-ios`, while the worktree is named `posthog-ios-issue-244`.
- `make buildSdk` passed again after the review fix, covering every supported SDK platform.
- Autoreview passed for `eecac372a` using `autoreview --mode branch --base origin/main`, with no actionable findings.

I did not launch or manually navigate the reporter's sample app. The simulator coverage above is automated testing, not an interactive sample-app smoke test.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed. No documentation changes were needed.
- [x] No breaking API change. Screen naming changes are covered by the patch changeset.

## If releasing new changes

- [x] Added a patch changeset file.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent using file editing tools, Git, GitHub CLI, and make/Xcode. Pi autoreview reviewed the final branch diff. The work was done in a dedicated worktree.

The fix deliberately keeps the container name when multiple children are visible because there is no general selected-child API for custom containers. Human review is required, and an interactive sample-app smoke test is still outstanding.
