### PR TITLE
fix: capture trailing replay screen updates

### DIFF
--- a/.changeset/replay-trailing-capture.md
+++ b/.changeset/replay-trailing-capture.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Capture the latest replay screen state after layouts occur inside the throttle window instead of dropping it.

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -272,7 +272,7 @@
             // flutter captures snapshots, so we don't need to capture them here
             if isNotFlutter() {
                 let interval = postHog.config.sessionReplayConfig.throttleDelay
-                viewLayoutToken = DI.main.viewLayoutPublisher.onViewLayout.subscribe(throttle: interval) { [weak self] in
+                viewLayoutToken = DI.main.viewLayoutPublisher.onViewLayout.subscribe(throttle: interval, trailing: true) { [weak self] in
                     // called on main thread
                     self?.snapshot()
                 }

--- a/PostHog/Utils/PostHogMulticastCallback.swift
+++ b/PostHog/Utils/PostHogMulticastCallback.swift
@@ -111,7 +111,7 @@ final class PostHogThrottledMulticastCallback<T> {
         target: .global(qos: .utility)
     )
 
-    /// Earliest instant at which any subscriber becomes eligible to fire again. Guarded by
+    /// Earliest instant at which any leading-only subscriber becomes eligible to fire again. Guarded by
     /// `lock`. May be stale-early (worst case: one extra no-op dispatch), but never
     /// stale-late: `subscribe` resets it, and only the drain on `throttleQueue` moves it
     /// forward from the live subscriber map.
@@ -126,12 +126,14 @@ final class PostHogThrottledMulticastCallback<T> {
     /// Subscribe to this callback with a throttle interval.
     /// - Parameters:
     ///   - throttle: The minimum interval between callback invocations for this subscriber.
+    ///   - trailing: Deliver the latest value received inside a window when that window closes.
+    ///     Values are coalesced while delivery is waiting for the main thread.
     ///   - callback: The callback to invoke when `invoke()` is called (on main thread).
     /// - Returns: A `RegistrationToken` that unsubscribes when deallocated.
-    func subscribe(throttle interval: TimeInterval, _ callback: @escaping (T) -> Void) -> RegistrationToken {
+    func subscribe(throttle interval: TimeInterval, trailing: Bool = false, _ callback: @escaping (T) -> Void) -> RegistrationToken {
         let id = UUID()
         let newCount = lock.withLock {
-            callbacks[id] = ThrottledCallback(handler: callback, interval: interval)
+            callbacks[id] = ThrottledCallback(handler: callback, interval: interval, trailing: trailing)
             // A new subscriber is immediately eligible; without this reset the invoke()
             // gate could suppress its first fire until the other subscribers' windows open.
             nextEligibleFire = .distantPast
@@ -151,25 +153,27 @@ final class PostHogThrottledMulticastCallback<T> {
     /// Invoke all subscribed callbacks, respecting each subscriber's throttle interval.
     /// - Parameter value: The value to pass to all callbacks.
     func invoke(_ value: T) {
-        // Synchronous cheap gate: skip the dispatch (queue hop + closure allocation)
-        // entirely when nobody is subscribed or no subscriber's throttle window has
-        // elapsed yet. This is the steady state when invoked per view layout.
         let shouldDispatch = lock.withLock {
-            !callbacks.isEmpty && now() >= nextEligibleFire
+            // Record trailing values before the eligibility gate. Updating an already pending
+            // value does not allocate another work item or dispatch for every view layout.
+            for callback in callbacks.values where callback.trailing {
+                callback.invokeTrailing(value)
+            }
+            return callbacks.values.contains { !$0.trailing } && now() >= nextEligibleFire
         }
         guard shouldDispatch else { return }
 
         throttleQueue.async { [weak self] in
             guard let self else { return }
-            let callbacks = self.lock.withLock { Array(self.callbacks.values) }
+            let callbacks = self.lock.withLock { self.callbacks.values.filter { !$0.trailing } }
             for callback in callbacks {
                 callback.invokeIfReady(value)
             }
             // Recompute from the live subscriber map (not the drained copy) so a
             // subscriber added mid-drain — eligible immediately — is not gated out.
-            // `lastFired` is only mutated on this serial queue, so reading it here is safe.
+            // Leading-only subscribers' `lastFired` is only mutated on this serial queue.
             self.lock.withLock {
-                self.nextEligibleFire = self.callbacks.values.map(\.nextEligibleTime).min() ?? .distantFuture
+                self.nextEligibleFire = self.callbacks.values.filter { !$0.trailing }.map(\.nextEligibleTime).min() ?? .distantFuture
             }
         }
     }
@@ -182,16 +186,65 @@ final class PostHogThrottledMulticastCallback<T> {
     private final class ThrottledCallback {
         let interval: TimeInterval
         let handler: (T) -> Void
+        let trailing: Bool
         private var lastFired: Date = .distantPast
 
-        /// Read only on the owning callback's `throttleQueue` (same place `lastFired` mutates).
+        // Trailing subscriptions accept values synchronously, rather than queueing every layout.
+        // Their state is shared with the delayed main-queue delivery and guarded by this lock.
+        private let trailingLock = NSLock()
+        private var pendingValue: T?
+        private var pendingWork: DispatchWorkItem?
+
+        /// Used only for leading-only subscriptions on the owning callback's `throttleQueue`.
         var nextEligibleTime: Date {
             lastFired.addingTimeInterval(interval)
         }
 
-        init(handler: @escaping (T) -> Void, interval: TimeInterval) {
+        init(handler: @escaping (T) -> Void, interval: TimeInterval, trailing: Bool) {
             self.handler = handler
             self.interval = interval
+            self.trailing = trailing
+        }
+
+        deinit {
+            // Scheduled work only weakly references this subscription, so dropping its token
+            // (including replay stop/reset) releases the handler and cancels pending delivery.
+            pendingWork?.cancel()
+        }
+
+        func invokeTrailing(_ value: T) {
+            guard interval > 0 else {
+                DispatchQueue.main.async { [weak self] in
+                    self?.handler(value)
+                }
+                return
+            }
+            trailingLock.withLock {
+                // .some preserves a pending nil when T itself is Optional.
+                pendingValue = .some(value)
+                guard pendingWork == nil else { return }
+                let remaining = max(0, interval - now().timeIntervalSince(lastFired))
+                let work = DispatchWorkItem { [weak self] in
+                    self?.fireTrailing()
+                }
+                pendingWork = work
+                DispatchQueue.main.asyncAfter(deadline: .now() + remaining, execute: work)
+            }
+        }
+
+        private func fireTrailing() {
+            let value: T? = trailingLock.withLock {
+                let value = pendingValue
+                pendingValue = nil
+                pendingWork = nil
+                // Start the next window at delivery, not scheduling: a busy main thread must
+                // not accumulate snapshots that then fire back-to-back when it becomes free.
+                lastFired = now()
+                return value
+            }
+            if let value {
+                handler(value)
+            }
         }
 
         func invokeIfReady(_ value: T) {

--- a/PostHogTests/PostHogMulticastCallbackTest.swift
+++ b/PostHogTests/PostHogMulticastCallbackTest.swift
@@ -363,3 +363,217 @@ class PostHogThrottledMulticastCallbackTests {
         _ = token
     }
 }
+
+@MainActor
+@Suite("PostHog trailing throttle tests", .resetsGlobalState)
+struct PostHogTrailingThrottleTests {
+    private func waitUntil(_ condition: () -> Bool) async {
+        let deadline = DispatchTime.now().uptimeNanoseconds + 2 * NSEC_PER_SEC
+        while !condition(), DispatchTime.now().uptimeNanoseconds < deadline {
+            try? await Task.sleep(nanoseconds: 5 * NSEC_PER_MSEC)
+        }
+        #expect(condition())
+    }
+
+    @Test("A burst delivers only the latest pending value without another invoke")
+    func latestPendingValue() async {
+        let callback = PostHogThrottledMulticastCallback<Int>()
+        var values: [Int] = []
+        let token = callback.subscribe(throttle: 0.2, trailing: true) { values.append($0) }
+        callback.invoke(0)
+        await waitUntil { values == [0] }
+        for value in 1 ... 100 {
+            callback.invoke(value)
+        }
+        #expect(values == [0])
+        await waitUntil { values == [0, 100] }
+        try? await Task.sleep(nanoseconds: 300 * NSEC_PER_MSEC)
+        #expect(values == [0, 100], "No recurring snapshots once the screen is quiet")
+        withExtendedLifetime(token) {}
+    }
+
+    @Test("Trailing delivery starts the next throttle window and stays on main")
+    func trailingStartsNextWindow() async {
+        let callback = PostHogThrottledMulticastCallback<Int>()
+        var values: [Int] = []
+        var times: [TimeInterval] = []
+        let token = callback.subscribe(throttle: 0.2, trailing: true) { value in
+            #expect(Thread.isMainThread)
+            values.append(value)
+            times.append(ProcessInfo.processInfo.systemUptime)
+            if value < 2 {
+                callback.invoke(value + 1)
+            }
+        }
+        callback.invoke(0)
+        await waitUntil { values == [0, 1, 2] }
+        #expect(times.count == 3)
+        if times.count == 3 {
+            #expect(times[2] - times[1] >= 0.18)
+        }
+        withExtendedLifetime(token) {}
+    }
+
+    @Test("A pending optional nil is delivered")
+    func optionalPendingValue() async {
+        let callback = PostHogThrottledMulticastCallback<Int?>()
+        var values: [Int?] = []
+        let token = callback.subscribe(throttle: 0.2, trailing: true) { values.append($0) }
+        callback.invoke(1)
+        await waitUntil { values.count == 1 }
+        callback.invoke(nil)
+        await waitUntil { values.count == 2 }
+        #expect(values == [1, nil])
+        withExtendedLifetime(token) {}
+    }
+
+    @Test("Default subscribers still drop while trailing subscribers recapture")
+    func defaultStillDrops() async {
+        let callback = PostHogThrottledMulticastCallback<Int>()
+        var leading: [Int] = []
+        var trailing: [Int] = []
+        let leadingToken = callback.subscribe(throttle: 0.2) { leading.append($0) }
+        let trailingToken = callback.subscribe(throttle: 0.2, trailing: true) { trailing.append($0) }
+        callback.invoke(1)
+        await waitUntil { leading == [1] && trailing == [1] }
+        callback.invoke(2)
+        await waitUntil { trailing == [1, 2] }
+        #expect(leading == [1])
+        withExtendedLifetime((leadingToken, trailingToken)) {}
+    }
+
+    @Test("An isolated invocation does not schedule an extra capture")
+    func noUnnecessaryTrailingCapture() async {
+        let callback = PostHogThrottledMulticastCallback<Int>()
+        var values: [Int] = []
+        let token = callback.subscribe(throttle: 0.1, trailing: true) { values.append($0) }
+        callback.invoke(1)
+        await waitUntil { values == [1] }
+        try? await Task.sleep(nanoseconds: 250 * NSEC_PER_MSEC)
+        #expect(values == [1])
+        callback.invoke(2)
+        await waitUntil { values == [1, 2] }
+        withExtendedLifetime(token) {}
+    }
+
+    @Test("Unsubscribing cancels pending work and resubscribing starts fresh")
+    func unsubscribeAndResubscribe() async {
+        let callback = PostHogThrottledMulticastCallback<Int>()
+        var values: [Int] = []
+        var token: RegistrationToken? = callback.subscribe(throttle: 0.2, trailing: true) { values.append($0) }
+        callback.invoke(1)
+        await waitUntil { values == [1] }
+        callback.invoke(2)
+        token = nil
+        #expect(callback.subscriberCount == 0)
+        token = callback.subscribe(throttle: 0.2, trailing: true) { values.append($0) }
+        callback.invoke(3)
+        await waitUntil { values == [1, 3] }
+        try? await Task.sleep(nanoseconds: 300 * NSEC_PER_MSEC)
+        #expect(values == [1, 3])
+        withExtendedLifetime(token) {}
+    }
+
+    @Test("Queued leading delivery is cancelled before main can run it")
+    func cancelQueuedLeadingDelivery() async {
+        let callback = PostHogThrottledMulticastCallback<Int>()
+        var values: [Int] = []
+        var token: RegistrationToken? = callback.subscribe(throttle: 0.2, trailing: true) { values.append($0) }
+        callback.invoke(1)
+        token = nil
+        try? await Task.sleep(nanoseconds: 100 * NSEC_PER_MSEC)
+        #expect(values.isEmpty)
+        withExtendedLifetime(token) {}
+    }
+
+    @Test("Pending work retains neither the publisher nor the subscriber")
+    func pendingWorkDoesNotRetainOwner() async {
+        final class Owner {}
+        var owner: Owner? = Owner()
+        weak var weakOwner = owner
+        var callback: PostHogThrottledMulticastCallback<Int>? = PostHogThrottledMulticastCallback<Int>()
+        weak var weakCallback = callback
+        var values: [Int] = []
+        let token = callback?.subscribe(throttle: 0.2, trailing: true) { [owner] value in
+            withExtendedLifetime(owner) { values.append(value) }
+        }
+        owner = nil
+        callback?.invoke(1)
+        await waitUntil { values == [1] }
+        callback?.invoke(2)
+        callback = nil
+        #expect(weakCallback == nil)
+        #expect(weakOwner == nil)
+        try? await Task.sleep(nanoseconds: 300 * NSEC_PER_MSEC)
+        #expect(values == [1])
+        withExtendedLifetime(token) {}
+    }
+
+    @Test("A busy main thread coalesces overdue captures instead of queueing snapshots")
+    func busyMainThread() async {
+        let callback = PostHogThrottledMulticastCallback<Int>()
+        var values: [Int] = []
+        let token = callback.subscribe(throttle: 0.1, trailing: true) { values.append($0) }
+        // Deliberately hold main across multiple windows without yielding to delivery.
+        // A synchronous helper keeps Thread.sleep out of the async context.
+        func holdMain() {
+            callback.invoke(1)
+            Thread.sleep(forTimeInterval: 0.15)
+            callback.invoke(2)
+            Thread.sleep(forTimeInterval: 0.15)
+            callback.invoke(3)
+        }
+        holdMain()
+        await waitUntil { !values.isEmpty }
+        try? await Task.sleep(nanoseconds: 150 * NSEC_PER_MSEC)
+        #expect(values == [3])
+        withExtendedLifetime(token) {}
+    }
+
+    @Test("Concurrent layouts schedule one trailing capture")
+    func concurrentInvocations() async {
+        let callback = PostHogThrottledMulticastCallback<Int>()
+        var values: [Int] = []
+        let token = callback.subscribe(throttle: 0.2, trailing: true) { values.append($0) }
+        callback.invoke(0)
+        await waitUntil { values == [0] }
+        DispatchQueue.concurrentPerform(iterations: 100) { callback.invoke($0) }
+        callback.invoke(100)
+        await waitUntil { values == [0, 100] }
+        try? await Task.sleep(nanoseconds: 250 * NSEC_PER_MSEC)
+        #expect(values == [0, 100])
+        withExtendedLifetime(token) {}
+    }
+
+    @Test("Trailing subscribers have independent windows and new subscribers fire immediately")
+    func independentWindows() async {
+        let callback = PostHogThrottledMulticastCallback<Int>()
+        var slow: [Int] = []
+        var fast: [Int] = []
+        let slowToken = callback.subscribe(throttle: 0.8, trailing: true) { slow.append($0) }
+        callback.invoke(1)
+        await waitUntil { slow == [1] }
+        let fastToken = callback.subscribe(throttle: 0.1, trailing: true) { fast.append($0) }
+        callback.invoke(2)
+        await waitUntil { fast == [2] }
+        #expect(slow == [1])
+        callback.invoke(3)
+        await waitUntil { fast == [2, 3] }
+        #expect(slow == [1])
+        await waitUntil { slow == [1, 3] }
+        withExtendedLifetime((slowToken, fastToken)) {}
+    }
+
+    @Test("Zero interval preserves every invocation")
+    func zeroInterval() async {
+        let callback = PostHogThrottledMulticastCallback<Int>()
+        var values: [Int] = []
+        let token = callback.subscribe(throttle: 0, trailing: true) { values.append($0) }
+        for value in 0 ..< 10 {
+            callback.invoke(value)
+        }
+        await waitUntil { values.count == 10 }
+        #expect(values == Array(0 ..< 10))
+        withExtendedLifetime(token) {}
+    }
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

Replay drops layout changes received inside the throttle window. If the screen then stays quiet, the recording can miss its final state. Addresses #766.

Replay now opts into trailing delivery. Layout changes inside the window produce one callback with the latest pending value. The next window starts when that callback runs, so a busy main thread does not accumulate snapshots. Releasing the subscription cancels queued delivery. Surveys and other default subscribers keep their existing behavior.

Includes a patch changeset. No public API changes.

## :green_heart: How did you test it?

- Reproduced the missing trailing delivery with failing assertions before the fix.
- Added 12 Swift Testing regressions for coalescing, cancellation, deallocation, concurrent layouts, busy-main behavior, independent windows, optional values, and zero throttle.
- Targeted callback suites passed all 28 tests in three implementation runs and again before committing.
- The full macOS suite passed 777 tests during implementation. `make format` and `make lint` passed again before committing. Lint reports 27 existing warnings and no serious violations.
- Exact-HEAD branch autoreview passed at `ffb9cc966` against `origin/main`, with no findings.
- iOS build validation stopped before compilation because the Xcode project references a missing relative `../posthog-ios` package in this worktree layout. iOS simulator, other platform, and example builds remain unvalidated. No package-path or project workaround was committed.

Cancellation tests cover subscription teardown, not rendered screenshots. Existing session and in-flight rendering guards are unchanged. No manual device testing was performed.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed. No documentation change is needed for this internal fix.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

The existing patch changeset is included at `.changeset/replay-trailing-capture.md`. The generator was not rerun.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented and published with Pi using repository inspection, make-based checks, Git, GitHub CLI, and the isolated autoreview helper. The human-directed scope was a replay-only trailing throttle, preserving survey behavior and existing capture guards. Independent source review passed before publication, and exact-HEAD autoreview reported no findings. Human review is required before merge.
