### PR TITLE
fix: exclude telemetry queues from iCloud backups

### DIFF
--- a/.changeset/quiet-queues-backup.md
+++ b/.changeset/quiet-queues-backup.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Exclude SDK storage folders from device backups, including existing event, session replay, replay buffer, and log queues.

--- a/PostHog/PostHogStorage.swift
+++ b/PostHog/PostHogStorage.swift
@@ -386,10 +386,20 @@ class PostHogStorage {
     }
 
     private static func getAppFolderUrl(from configuration: PostHogConfig) -> URL {
-        let apiDir = getBaseAppFolderUrl(from: configuration)
+        var apiDir = getBaseAppFolderUrl(from: configuration)
             .appendingPathComponent(configuration.projectToken)
 
         createDirectoryAtURLIfNeeded(url: apiDir)
+
+        // Exclude the entire SDK subtree, including queues and existing installations.
+        // The parent bundle/app-group folder may also contain unrelated application data.
+        do {
+            var resourceValues = URLResourceValues()
+            resourceValues.isExcludedFromBackup = true
+            try apiDir.setResourceValues(resourceValues)
+        } catch {
+            hedgeLog("Failed to exclude storage directory from backup: \(error)")
+        }
 
         return apiDir
     }

--- a/PostHogTests/PostHogStorageTest.swift
+++ b/PostHogTests/PostHogStorageTest.swift
@@ -191,3 +191,74 @@ class PostHogStorageTest {
         sut.reset()
     }
 }
+
+@Suite("PostHogStorage backup exclusion", .serialized)
+struct PostHogStorageBackupTest {
+    @Test("excludes new and existing project folders from backup", arguments: [false, true], [false, true])
+    func excludesProjectFolderFromBackup(existingFolder: Bool, appGroup: Bool) throws {
+        let config = PostHogConfig(projectToken: "backup-test-\(UUID().uuidString)")
+        if appGroup {
+            config.appGroupIdentifier = testAppGroupIdentifier
+        }
+        // Allow local test runs to prove filesystem isolation before creating storage.
+        if let isolatedHome = ProcessInfo.processInfo.environment["CFFIXED_USER_HOME"] {
+            try #require(applicationSupportDirectoryURL().path.hasPrefix(isolatedHome + "/"))
+            print("Backup test Application Support: \(applicationSupportDirectoryURL().path)")
+        }
+        let baseURL = try appGroup ? #require(appGroupContainerUrl(config: config)) : applicationSupportDirectoryURL()
+        let projectURL = baseURL.appendingPathComponent(config.projectToken, isDirectory: true)
+        defer { deleteSafely(projectURL) }
+        let queueKeys: [PostHogStorage.StorageKey] = [.queue, .replayQeueue, .replayBufferQueue, .logsQueue]
+        let payload = Data("queued telemetry".utf8)
+        let filename = UUID.v7String()
+        try FileManager.default.createDirectory(at: baseURL, withIntermediateDirectories: true)
+        let baseExcluded = try baseURL.resourceValues(forKeys: [.isExcludedFromBackupKey]).isExcludedFromBackup
+
+        if existingFolder {
+            for key in queueKeys {
+                let queueURL = projectURL.appendingPathComponent(key.rawValue)
+                try FileManager.default.createDirectory(at: queueURL, withIntermediateDirectories: true)
+                try payload.write(to: queueURL.appendingPathComponent(filename))
+            }
+            var url = projectURL
+            var values = URLResourceValues()
+            values.isExcludedFromBackup = false
+            try url.setResourceValues(values)
+        }
+
+        let storage = PostHogStorage(config)
+        #expect(storage.appFolderUrl.path == projectURL.path)
+        #expect(try projectURL.resourceValues(forKeys: [.isExcludedFromBackupKey]).isExcludedFromBackup == true)
+        // The bundle/app-group folder may also hold unrelated application data.
+        #expect(try baseURL.resourceValues(forKeys: [.isExcludedFromBackupKey]).isExcludedFromBackup == baseExcluded)
+
+        for key in queueKeys {
+            let queueURL = storage.url(forKey: key)
+            #expect(queueURL.deletingLastPathComponent() == projectURL)
+            if existingFolder {
+                #expect(try Data(contentsOf: queueURL.appendingPathComponent(filename)) == payload)
+            }
+            if key == .replayBufferQueue {
+                let buffer = PostHogReplayBufferQueue(queue: queueURL)
+                buffer.add(payload)
+                #expect(buffer.depth == 1)
+                buffer.clear()
+                buffer.add(payload)
+                #expect(buffer.depth == 1)
+            } else {
+                let queue = PostHogFileBackedQueue(queue: queueURL)
+                if existingFolder {
+                    #expect(queue.peek(1) == [payload])
+                }
+                queue.clear()
+                queue.add(payload)
+                #expect(queue.peek(1) == [payload])
+            }
+            // Recreating a child queue must not remove the ancestor's exclusion.
+            #expect(try projectURL.resourceValues(forKeys: [.isExcludedFromBackupKey]).isExcludedFromBackup == true)
+        }
+
+        let reopenedStorage = PostHogStorage(config)
+        #expect(try reopenedStorage.appFolderUrl.resourceValues(forKeys: [.isExcludedFromBackupKey]).isExcludedFromBackup == true)
+    }
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

File-backed telemetry queues in Application Support were eligible for iCloud backup because only individual key-value files were excluded. This addresses #664.

Storage initialization now excludes the per-project directory from backups, including existing installations. This covers event, replay, replay-buffer, and log queues without changing their contents or excluding unrelated data in the parent bundle or app-group directory. Attribute-write failures are logged without preventing storage initialization.

## :green_heart: How did you test it?

- Reproduced the bug before the fix: all four new/existing and standard/app-group regression cases failed on missing exclusion metadata. All four passed after the fix.
- Reran the related storage and queue suites through `make test`: 63 Swift Testing tests across seven suites passed. Standard Application Support was isolated and shared app-group fixture use was coordinated. The filtered run executed no legacy Quick/XCTest cases.
- `make format`, `make lint`, and `git diff --check` passed. Lint reports 27 existing warnings and no serious violations.
- Exact-HEAD branch autoreview against `origin/main` passed at `7dae52418c132f3fe0cf641fd99f12d15223c7a1` with no findings. Independent source review also passed.
- macOS SDK and test targets compiled through `make test`. Cross-platform `make buildSdk` validation, using lane-local build outputs, stopped before compilation because the Xcode project references a missing relative `../posthog-ios` package in this worktree layout. Other platforms, examples, and the full suite remain unvalidated. No project-path workaround was committed.
- Tests check filesystem exclusion metadata, not an actual device backup or restore. Existing project directories are updated when their storage initializes.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed. No public API or documentation changes were needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file. A patch changeset was added directly in `.changeset/quiet-queues-backup.md`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented and prepared with Pi using repository inspection, make targets, Git, GitHub CLI, and the isolated autoreview helper. Local publication session: `510ebebc-a750-45a5-88ce-92821ccd3256` (no public session link).

The fix uses the existing per-project storage boundary rather than changing each queue writer. It preserves the parent directory and existing per-file exclusions. Human review is required before merge.
