### PR TITLE
feat(surveys): collect partial responses and resume unfinished surveys

### DIFF
--- a/.changeset/sparkly-mangos-sip.md
+++ b/.changeset/sparkly-mangos-sip.md
@@ -5,3 +5,5 @@
 Support survey partial response collection. When enabled, submit cumulative answers after each question with a stable submission ID and completion status, matching posthog-js.
 
 Persist unfinished surveys across app restarts and restore the submission ID, saved answers, and next question. Completion, dismissal, SDK reset, and incompatible survey updates clear progress. Custom survey delegates should honor `initialQuestionIndex` when presenting a restored survey.
+
+Serialize progress updates with identity reset and reject callbacks from earlier survey attempts. Resumed completion and dismissal preserve the seen-survey history.

--- a/.changeset/sparkly-mangos-sip.md
+++ b/.changeset/sparkly-mangos-sip.md
@@ -3,3 +3,5 @@
 ---
 
 Support survey partial response collection. When enabled, submit cumulative answers after each question with a stable submission ID and completion status, matching posthog-js.
+
+Persist unfinished surveys across app restarts and restore the submission ID, saved answers, and next question. Completion, dismissal, SDK reset, and incompatible survey updates clear progress. Custom survey delegates should honor `initialQuestionIndex` when presenting a restored survey.

--- a/.changeset/sparkly-mangos-sip.md
+++ b/.changeset/sparkly-mangos-sip.md
@@ -9,3 +9,5 @@ Persist unfinished surveys across app restarts and restore the submission ID, sa
 Serialize progress updates with identity reset and reject callbacks from earlier survey attempts. Resumed completion and dismissal preserve the seen-survey history.
 
 Coordinate app-group survey persistence across processes with a durable reset epoch. Old writers and callbacks cannot restore progress after another SDK resets, including when the anonymous ID is reused. Progress records without an epoch are discarded.
+
+Preserve unfinished progress when remote configuration is unavailable, and clean up the configured survey delegate when closing the SDK.

--- a/.changeset/sparkly-mangos-sip.md
+++ b/.changeset/sparkly-mangos-sip.md
@@ -7,3 +7,5 @@ Support survey partial response collection. When enabled, submit cumulative answ
 Persist unfinished surveys across app restarts and restore the submission ID, saved answers, and next question. Completion, dismissal, SDK reset, and incompatible survey updates clear progress. Custom survey delegates should honor `initialQuestionIndex` when presenting a restored survey.
 
 Serialize progress updates with identity reset and reject callbacks from earlier survey attempts. Resumed completion and dismissal preserve the seen-survey history.
+
+Coordinate app-group survey persistence across processes with a durable reset epoch. Old writers and callbacks cannot restore progress after another SDK resets, including when the anonymous ID is reused. Progress records without an epoch are discarded.

--- a/.changeset/sparkly-mangos-sip.md
+++ b/.changeset/sparkly-mangos-sip.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": minor
+---
+
+Support survey partial response collection. When enabled, submit cumulative answers after each question with a stable submission ID and completion status, matching posthog-js.

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		EFAA01000000000000000001 /* SurveyProgressStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFAA01000000000000000002 /* SurveyProgressStore.swift */; };
 		B74800000000000000000001 /* PostHogPushNotificationSwizzlingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B74800000000000000000003 /* PostHogPushNotificationSwizzlingTest.swift */; };
 		B74800000000000000000002 /* PHNotificationDelegateTestFixture.m in Sources */ = {isa = PBXBuildFile; fileRef = B74800000000000000000006 /* PHNotificationDelegateTestFixture.m */; };
 		BF5E00000000000000000001 /* PHBeforeSendExceptionTestFixture.m in Sources */ = {isa = PBXBuildFile; fileRef = BF5E00000000000000000005 /* PHBeforeSendExceptionTestFixture.m */; };
@@ -778,6 +779,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		EFAA01000000000000000002 /* SurveyProgressStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyProgressStore.swift; sourceTree = "<group>"; };
 		B74800000000000000000003 /* PostHogPushNotificationSwizzlingTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogPushNotificationSwizzlingTest.swift; sourceTree = "<group>"; };
 		B74800000000000000000004 /* PostHogTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PostHogTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		B74800000000000000000005 /* PHNotificationDelegateTestFixture.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PHNotificationDelegateTestFixture.h; sourceTree = "<group>"; };
@@ -2016,6 +2018,7 @@
 				DAFF02652D7B1A9000BD5B1D /* SurveysRootView.swift */,
 				DAD4B2EF2D79E24D00DA503C /* SurveysWindow.swift */,
 				DA0E43B82D70437D00D39B93 /* PostHogSurveyIntegration.swift */,
+				EFAA01000000000000000002 /* SurveyProgressStore.swift */,
 				DA263D452D800EA9004C100D /* Utils */,
 			);
 			path = Surveys;
@@ -3394,6 +3397,7 @@
 				DA263D422D80085D004C100D /* SurveyButton.swift in Sources */,
 				69EE82BA2BA9C50400EB9542 /* PostHogReplayIntegration.swift in Sources */,
 				DA0E43BE2D70438100D39B93 /* PostHogSurveyIntegration.swift in Sources */,
+				EFAA01000000000000000001 /* SurveyProgressStore.swift in Sources */,
 				DAFEC4572E03F91A0064535E /* PostHogDisplaySurveyQuestion.swift in Sources */,
 				3AE3FB472992AB0000AFFC18 /* Hedgelog.swift in Sources */,
 				69B7F60C2CF7703400A48BCC /* UIImage+Util.swift in Sources */,

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -575,6 +575,7 @@
 		DAB9F6C42D6C49BB00A988A1 /* ApplicationEventPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB9F6C32D6C49B300A988A1 /* ApplicationEventPublisher.swift */; };
 		DABDF9C32E02994000C7E498 /* PostHogDisplaySurvey.swift in Sources */ = {isa = PBXBuildFile; fileRef = DABDF9C22E02994000C7E498 /* PostHogDisplaySurvey.swift */; };
 		DABF95052E8FEB6F0029CBBB /* PostHogSurveyEventsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DABF95042E8FEB6F0029CBBB /* PostHogSurveyEventsTest.swift */; };
+		5C8B936B0A7A4DC6A54015FA /* PostHogSurveySharedStorageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85AB3DFD5C84D3EB5FF4A5B /* PostHogSurveySharedStorageTest.swift */; };
 		DAC0A2BF2F2C419400BAA602 /* PostHogDebugImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3BB4DE2ED992780097A97A /* PostHogDebugImageProvider.swift */; };
 		DAC699D62CC790D9000D1D6B /* PostHogAutocaptureIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC699D52CC790D9000D1D6B /* PostHogAutocaptureIntegration.swift */; };
 		DAC699EC2CCA73E5000D1D6B /* ForwardingPickerViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC699EB2CCA73E5000D1D6B /* ForwardingPickerViewDelegate.swift */; };
@@ -1418,6 +1419,7 @@
 		DAB9F6C32D6C49B300A988A1 /* ApplicationEventPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationEventPublisher.swift; sourceTree = "<group>"; };
 		DABDF9C22E02994000C7E498 /* PostHogDisplaySurvey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogDisplaySurvey.swift; sourceTree = "<group>"; };
 		DABF95042E8FEB6F0029CBBB /* PostHogSurveyEventsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSurveyEventsTest.swift; sourceTree = "<group>"; };
+		F85AB3DFD5C84D3EB5FF4A5B /* PostHogSurveySharedStorageTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSurveySharedStorageTest.swift; sourceTree = "<group>"; };
 		DAC699D52CC790D9000D1D6B /* PostHogAutocaptureIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogAutocaptureIntegration.swift; sourceTree = "<group>"; };
 		DAC699EB2CCA73E5000D1D6B /* ForwardingPickerViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForwardingPickerViewDelegate.swift; sourceTree = "<group>"; };
 		DACB3ED12E0193B20061FC7D /* PostHogSurvey+Display.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostHogSurvey+Display.swift"; sourceTree = "<group>"; };
@@ -1752,6 +1754,7 @@
 				DA703C1D2D66346E0069097B /* PostHogAppLifeCycleIntegrationTest.swift */,
 				DAA5ED962D4043A500D437E0 /* PostHogSurveysTest.swift */,
 				DABF95042E8FEB6F0029CBBB /* PostHogSurveyEventsTest.swift */,
+				F85AB3DFD5C84D3EB5FF4A5B /* PostHogSurveySharedStorageTest.swift */,
 				DA5E52EA2E0996C400159D20 /* PostHogSurveyEnumsTest.swift */,
 				DA979D7A2CD370B700F56BAE /* PostHogAutocaptureEventTrackerSpec.swift */,
 				699C5FEE2C20242A007DB818 /* UUIDTest.swift */,
@@ -3501,6 +3504,7 @@
 				DA578E9C2D68578500B3A56C /* MockApplicationLifecyclePublisher.swift in Sources */,
 				DA4FFBB52DAD5B01006BAEEA /* PostHogIdentityTests.swift in Sources */,
 				DABF95052E8FEB6F0029CBBB /* PostHogSurveyEventsTest.swift in Sources */,
+				5C8B936B0A7A4DC6A54015FA /* PostHogSurveySharedStorageTest.swift in Sources */,
 				DACF6D5D2CD2F5BC00F14133 /* PostHogAutocaptureIntegrationSpec.swift in Sources */,
 				3A62647529CB0168007E8C07 /* TestPostHog.swift in Sources */,
 				DA27AEC12F56B3E3002A59CE /* PostHogSessionReplayEventTriggersTest.swift in Sources */,

--- a/PostHog.xcodeproj/project.pbxproj
+++ b/PostHog.xcodeproj/project.pbxproj
@@ -614,6 +614,8 @@
 		F22413BB1C82340F203271A4 /* fixture_survey_question_rating_no_bounds.json in Resources */ = {isa = PBXBuildFile; fileRef = 45D65956292974AA707263FA /* fixture_survey_question_rating_no_bounds.json */; };
 		F6DADC57034D5B70B502F251 /* PostHogLogsConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDAA5E5DBE9861837899D553 /* PostHogLogsConfig.swift */; };
 		FAAA4C305C550B22060A9905 /* PLCrashReportMachineInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 42CE9EE391A5AE700A1D688F /* PLCrashReportMachineInfo.m */; };
+		31EB43B360294C13A802C709 /* PostHogSurveyResumeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049D76DAE7AD4E5EBF9CE9AE /* PostHogSurveyResumeTest.swift */; };
+		D9DC2552C32A4CE4BFA2E752 /* StoredSurveyResponseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58DAE01C4B44F928E985217 /* StoredSurveyResponseTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1456,6 +1458,8 @@
 		F808F6F63C4473F4570FE32B /* PLCrashReport.pb-c.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = "PLCrashReport.pb-c.c"; path = "vendor/PHPLCrashReporter/Source/PLCrashReport.pb-c.c"; sourceTree = "<group>"; };
 		F9BB47DFE51AFE8F516B8550 /* PLCrashReportExceptionInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = PLCrashReportExceptionInfo.m; path = vendor/PHPLCrashReporter/Source/PLCrashReportExceptionInfo.m; sourceTree = "<group>"; };
 		FB9F9CC224AC280F8A3C55E0 /* PLCrashAsync.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = PLCrashAsync.c; path = vendor/PHPLCrashReporter/Source/PLCrashAsync.c; sourceTree = "<group>"; };
+		049D76DAE7AD4E5EBF9CE9AE /* PostHogSurveyResumeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogSurveyResumeTest.swift; sourceTree = "<group>"; };
+		B58DAE01C4B44F928E985217 /* StoredSurveyResponseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredSurveyResponseTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1755,6 +1759,8 @@
 				DAA5ED962D4043A500D437E0 /* PostHogSurveysTest.swift */,
 				DABF95042E8FEB6F0029CBBB /* PostHogSurveyEventsTest.swift */,
 				F85AB3DFD5C84D3EB5FF4A5B /* PostHogSurveySharedStorageTest.swift */,
+				B58DAE01C4B44F928E985217 /* StoredSurveyResponseTest.swift */,
+				049D76DAE7AD4E5EBF9CE9AE /* PostHogSurveyResumeTest.swift */,
 				DA5E52EA2E0996C400159D20 /* PostHogSurveyEnumsTest.swift */,
 				DA979D7A2CD370B700F56BAE /* PostHogAutocaptureEventTrackerSpec.swift */,
 				699C5FEE2C20242A007DB818 /* UUIDTest.swift */,
@@ -3505,6 +3511,8 @@
 				DA4FFBB52DAD5B01006BAEEA /* PostHogIdentityTests.swift in Sources */,
 				DABF95052E8FEB6F0029CBBB /* PostHogSurveyEventsTest.swift in Sources */,
 				5C8B936B0A7A4DC6A54015FA /* PostHogSurveySharedStorageTest.swift in Sources */,
+				D9DC2552C32A4CE4BFA2E752 /* StoredSurveyResponseTest.swift in Sources */,
+				31EB43B360294C13A802C709 /* PostHogSurveyResumeTest.swift in Sources */,
 				DACF6D5D2CD2F5BC00F14133 /* PostHogAutocaptureIntegrationSpec.swift in Sources */,
 				3A62647529CB0168007E8C07 /* TestPostHog.swift in Sources */,
 				DA27AEC12F56B3E3002A59CE /* PostHogSessionReplayEventTriggersTest.swift in Sources */,

--- a/PostHog/Models/Surveys/PostHogSurvey+Display.swift
+++ b/PostHog/Models/Surveys/PostHogSurvey+Display.swift
@@ -4,7 +4,8 @@
     extension PostHogSurvey {
         func toDisplaySurvey(
             surveyTranslation: PostHogSurveyTranslation? = nil,
-            questionTranslations: [PostHogSurveyQuestionTranslation?]? = nil
+            questionTranslations: [PostHogSurveyQuestionTranslation?]? = nil,
+            initialQuestionIndex: Int = 0
         ) -> PostHogDisplaySurvey {
             let translatedQuestions = questions.enumerated().compactMap { index, question in
                 let translation = questionTranslations.flatMap { index < $0.count ? $0[index] : nil }
@@ -16,7 +17,8 @@
                 questions: translatedQuestions,
                 appearance: appearance?.toDisplayAppearance(translation: surveyTranslation),
                 startDate: startDate,
-                endDate: endDate
+                endDate: endDate,
+                initialQuestionIndex: initialQuestionIndex
             )
         }
     }

--- a/PostHog/Models/Surveys/PostHogSurvey.swift
+++ b/PostHog/Models/Surveys/PostHogSurvey.swift
@@ -41,7 +41,7 @@ struct PostHogSurvey: Decodable, Identifiable {
     /// The schedule for the survey (optional). Determines how often the survey can be shown.
     let schedule: PostHogSurveySchedule?
     let translations: [String: PostHogSurveyTranslation]?
-    var enablePartialResponses: Bool? = nil
+    var enablePartialResponses: Bool?
 }
 
 struct PostHogSurveyFeatureFlagKeyValue: Equatable, Decodable {

--- a/PostHog/Models/Surveys/PostHogSurvey.swift
+++ b/PostHog/Models/Surveys/PostHogSurvey.swift
@@ -48,3 +48,26 @@ struct PostHogSurveyFeatureFlagKeyValue: Equatable, Decodable {
     let key: String
     let value: String?
 }
+
+extension PostHogSurvey {
+    var eventProperties: [String: Any] {
+        // TODO: Add session replay screen name
+        let props: [String: Any?] = [
+            "$survey_name": name,
+            "$survey_id": id,
+            "$survey_iteration": currentIteration,
+            "$survey_iteration_start_date": currentIterationStartDate.map(toISO8601String),
+        ]
+        return props.compactMapValues { $0 }
+    }
+
+    func interactionProperty(_ property: String) -> String {
+        var surveyProperty = "$survey_\(property)/\(id)"
+
+        if let currentIteration = currentIteration, currentIteration > 0 {
+            surveyProperty = "$survey_\(property)/\(id)/\(currentIteration)"
+        }
+
+        return surveyProperty
+    }
+}

--- a/PostHog/Models/Surveys/PostHogSurvey.swift
+++ b/PostHog/Models/Surveys/PostHogSurvey.swift
@@ -41,6 +41,7 @@ struct PostHogSurvey: Decodable, Identifiable {
     /// The schedule for the survey (optional). Determines how often the survey can be shown.
     let schedule: PostHogSurveySchedule?
     let translations: [String: PostHogSurveyTranslation]?
+    var enablePartialResponses: Bool? = nil
 }
 
 struct PostHogSurveyFeatureFlagKeyValue: Equatable, Decodable {

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -675,8 +675,12 @@ let maxRetryDelay = 30.0
         }
 
         // storage also removes all feature flags
-        storage?.reset(keepAnonymousId: config.reuseAnonymousId)
-        config.storageManager?.reset(keepAnonymousId: config.reuseAnonymousId)
+        if let storage {
+            storage.withSurveyState { _ in
+                storage.reset(keepAnonymousId: config.reuseAnonymousId)
+                config.storageManager?.reset(keepAnonymousId: config.reuseAnonymousId)
+            }
+        }
         flagCallReportedLock.withLock {
             flagCallReported.removeAll()
         }

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -69,6 +69,7 @@ let maxRetryDelay = 30.0
     private(set) var replayQueue: PostHogReplayQueue?
     private(set) var logsQueue: PostHogQueue<PostHogLogRecord>?
     private(set) var storage: PostHogStorage?
+    private var surveyIdentityGeneration: String?
     #if !os(watchOS)
         private var reachability: Reachability?
     #endif
@@ -653,6 +654,27 @@ let maxRetryDelay = 30.0
         replayQueue?.flush()
         logsQueue?.flush()
         pushSubscriptionHandler?.retryIfNeeded()
+    }
+
+    func surveyEventDistinctId(generation: String?) -> String? {
+        guard let storage else { return nil }
+        let snapshot = storage.withSurveyState { currentGeneration -> (epoch: String, distinctId: String?)? in
+            guard generation == nil || generation == currentGeneration,
+                  storage.isSurveyGenerationCurrent(currentGeneration) else { return nil }
+            if surveyIdentityGeneration != currentGeneration {
+                config.storageManager?.reset()
+                surveyIdentityGeneration = currentGeneration
+            }
+            return (currentGeneration, storage.getString(forKey: .distinctId) ?? storage.getString(forKey: .anonymousId))
+        }
+        guard let snapshot else { return nil }
+        if let distinctId = snapshot.distinctId { return distinctId }
+        // Identity generation may call user code, so it cannot hold the shared file lock.
+        _ = getDistinctId()
+        return storage.withSurveyState { currentGeneration in
+            guard currentGeneration == snapshot.epoch else { return nil }
+            return storage.getString(forKey: .distinctId) ?? storage.getString(forKey: .anonymousId)
+        }
     }
 
     /// Resets local identity, super properties, feature flag cache, and session state.

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -2581,7 +2581,6 @@ let maxRetryDelay = 30.0
             bufferToClear?.clear()
             config.storageManager?.reset(keepAnonymousId: config.reuseAnonymousId)
             config.storageManager = nil
-            config = PostHogConfig(projectToken: "")
             remoteConfig = nil
             storage = nil
             #if !os(watchOS)
@@ -2598,6 +2597,7 @@ let maxRetryDelay = 30.0
             toggleHedgeLog(false)
 
             uninstallIntegrations()
+            config = PostHogConfig(projectToken: "")
         }
         // Outside setupLock to avoid lock-ordering coupling between
         // setupLock and lastScreenLock.

--- a/PostHog/PostHogStorage.swift
+++ b/PostHog/PostHogStorage.swift
@@ -5,6 +5,7 @@
 //  Created by Ben White on 08.02.23.
 //
 
+import Darwin
 import Foundation
 
 /**
@@ -245,6 +246,7 @@ class PostHogStorage {
         case personProcessingEnabled = "posthog.enabledPersonProcessing"
         case remoteConfig = "posthog.remoteConfig"
         case surveyProgress = "posthog.surveyProgress"
+        case surveyResetEpoch = "posthog.surveyResetEpoch"
         case surveySeen = "posthog.surveySeen"
         case lastSeenSurveyDate = "posthog.lastSeenSurveyDate"
         case requestId = "posthog.requestId"
@@ -261,17 +263,83 @@ class PostHogStorage {
     }
 
     private let surveyStateLock = NSRecursiveLock()
-    private var surveyResetGeneration = 0
+    private var surveyStateDepth = 0
+    private var surveyStateCoordinated = false
+    private var surveyEpochUnavailable = false
     #if TESTING
         var testOnSurveyProgressRead: (() -> Void)?
     #endif
 
-    /// Serializes survey read-modify-write operations with identity reset, including reentrant reset.
-    func withSurveyState<T>(_ operation: (Int) -> T) -> T {
-        surveyStateLock.withLock { operation(surveyResetGeneration) }
+    /// The lock file survives reset so other app-group processes keep locking the same inode.
+    func withSurveyState<T>(_ operation: (String) -> T) -> T {
+        surveyStateLock.withLock {
+            if surveyStateDepth > 0 { return operation(currentSurveyEpoch()) }
+            let descriptor = open(appFolderUrl.appendingPathComponent("posthog.surveyState.lock").path, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)
+            if descriptor >= 0 {
+                var result: Int32
+                repeat {
+                    result = flock(descriptor, LOCK_EX)
+                } while result != 0 && errno == EINTR
+                surveyStateCoordinated = result == 0
+            }
+            if !surveyStateCoordinated { hedgeLog("Unable to coordinate shared survey storage; survey progress is disabled") }
+            surveyStateDepth += 1
+            defer {
+                surveyStateDepth -= 1
+                if surveyStateCoordinated { flock(descriptor, LOCK_UN) }
+                if descriptor >= 0 { close(descriptor) }
+                surveyStateCoordinated = false
+            }
+            return operation(currentSurveyEpoch())
+        }
     }
 
-    func isSurveyGenerationCurrent(_ generation: Int) -> Bool {
+    private func currentSurveyEpoch() -> String {
+        // A different token on every failed read makes all validation fail closed.
+        guard surveyStateCoordinated, !surveyEpochUnavailable,
+              !FileManager.default.fileExists(atPath: surveyRevocationUrl.path) else { return UUID().uuidString }
+        if let epoch = getString(forKey: .surveyResetEpoch), UUID(uuidString: epoch) != nil { return epoch }
+        let epoch = UUID().uuidString
+        return persistSurveyEpoch(epoch) ? epoch : UUID().uuidString
+    }
+
+    private func persistSurveyEpoch(_ epoch: String) -> Bool {
+        do {
+            let data = try JSONSerialization.data(withJSONObject: [StorageKey.surveyResetEpoch.rawValue: epoch])
+            try data.write(to: url(forKey: .surveyResetEpoch), options: .atomic)
+            return getString(forKey: .surveyResetEpoch) == epoch
+        } catch {
+            hedgeLog("Failed to persist survey reset epoch: \(error)")
+            return false
+        }
+    }
+
+    private var surveyRevocationUrl: URL { appFolderUrl.appendingPathComponent("posthog.surveyResetRevoked") }
+
+    private func rotateSurveyEpoch() {
+        surveyEpochUnavailable = true
+        if persistSurveyEpoch(UUID().uuidString) {
+            do {
+                if FileManager.default.fileExists(atPath: surveyRevocationUrl.path) { try FileManager.default.removeItem(at: surveyRevocationUrl) }
+                surveyEpochUnavailable = false
+            } catch { hedgeLog("Unable to clear survey epoch revocation: \(error)") }
+            return
+        }
+        do {
+            // Revoke the previous token when a recoverable write error prevents replacement.
+            let epochUrl = url(forKey: .surveyResetEpoch)
+            if FileManager.default.fileExists(atPath: epochUrl.path) { try FileManager.default.removeItem(at: epochUrl) }
+            surveyEpochUnavailable = false
+        } catch {
+            // An immutable epoch can coexist with writable identity files in the same directory.
+            do {
+                try Data().write(to: surveyRevocationUrl, options: .atomic)
+                surveyEpochUnavailable = false
+            } catch { hedgeLog("Unable to revoke survey reset epoch; shared reset could not be persisted: \(error)") }
+        }
+    }
+
+    func isSurveyGenerationCurrent(_ generation: String) -> Bool {
         withSurveyState { $0 == generation }
     }
 
@@ -422,7 +490,7 @@ class PostHogStorage {
 
     func reset(keepAnonymousId: Bool = false) {
         withSurveyState { _ in
-            surveyResetGeneration &+= 1
+            rotateSurveyEpoch()
             // sadly the StorageKey.allCases does not work here
             deleteSafely(url(forKey: .distinctId))
             if !keepAnonymousId {
@@ -442,6 +510,7 @@ class PostHogStorage {
             deleteSafely(url(forKey: .optOut))
             deleteSafely(url(forKey: .isIdentified))
             deleteSafely(url(forKey: .personProcessingEnabled))
+            // .surveyResetEpoch and its lock file survive reset to invalidate other processes.
             // .remoteConfig is project-level config (not user data); kept across reset() so features re-arm
             deleteSafely(url(forKey: .surveySeen))
             deleteSafely(url(forKey: .surveyProgress))

--- a/PostHog/PostHogStorage.swift
+++ b/PostHog/PostHogStorage.swift
@@ -260,6 +260,21 @@ class PostHogStorage {
         case pushAppIdsMigrated = "posthog.pushAppIdsMigrated"
     }
 
+    private let surveyStateLock = NSRecursiveLock()
+    private var surveyResetGeneration = 0
+    #if TESTING
+        var testOnSurveyProgressRead: (() -> Void)?
+    #endif
+
+    /// Serializes survey read-modify-write operations with identity reset, including reentrant reset.
+    func withSurveyState<T>(_ operation: (Int) -> T) -> T {
+        surveyStateLock.withLock { operation(surveyResetGeneration) }
+    }
+
+    func isSurveyGenerationCurrent(_ generation: Int) -> Bool {
+        withSurveyState { $0 == generation }
+    }
+
     // The location for storing data that we always want to keep
     let appFolderUrl: URL
 
@@ -406,44 +421,47 @@ class PostHogStorage {
     }
 
     func reset(keepAnonymousId: Bool = false) {
-        // sadly the StorageKey.allCases does not work here
-        deleteSafely(url(forKey: .distinctId))
-        if !keepAnonymousId {
-            deleteSafely(url(forKey: .anonymousId))
+        withSurveyState { _ in
+            surveyResetGeneration &+= 1
+            // sadly the StorageKey.allCases does not work here
+            deleteSafely(url(forKey: .distinctId))
+            if !keepAnonymousId {
+                deleteSafely(url(forKey: .anonymousId))
+            }
+            // .queue, .replayQeueue, .logsQueue not deleted here — each queue manages its own
+            // disk state via clear() and the per-record distinctId captured at enqueue time
+            // (see PostHogLogRecord) lets in-flight telemetry survive an identity change.
+            deleteSafely(url(forKey: .oldQueueFolder))
+            deleteSafely(url(forKey: .oldQueuePlist))
+            deleteSafely(url(forKey: .oldReplayQueue))
+            deleteSafely(url(forKey: .flags))
+            deleteSafely(url(forKey: .enabledFeatureFlags))
+            deleteSafely(url(forKey: .enabledFeatureFlagPayloads))
+            deleteSafely(url(forKey: .groups))
+            deleteSafely(url(forKey: .registerProperties))
+            deleteSafely(url(forKey: .optOut))
+            deleteSafely(url(forKey: .isIdentified))
+            deleteSafely(url(forKey: .personProcessingEnabled))
+            // .remoteConfig is project-level config (not user data); kept across reset() so features re-arm
+            deleteSafely(url(forKey: .surveySeen))
+            deleteSafely(url(forKey: .surveyProgress))
+            deleteSafely(url(forKey: .lastSeenSurveyDate))
+            deleteSafely(url(forKey: .requestId))
+            deleteSafely(url(forKey: .minimalFlagCalledEvents))
+            deleteSafely(url(forKey: .personPropertiesForFlags))
+            deleteSafely(url(forKey: .groupPropertiesForFlags))
+            // legacy slices, no longer written (config now lives in .remoteConfig); drop stragglers from older SDKs
+            deleteSafely(url(forKey: .sessionReplay))
+            deleteSafely(url(forKey: .errorTracking))
+            deleteSafely(url(forKey: .capturePerformance))
+            // .pushSubscription is deliberately NOT cleared here: PostHogPushSubscriptionHandler.recordForReset()
+            // clears it under its own recordLock (before this runs) so a concurrent send() can't write a
+            // fresh record into the gap and have it erased unlocked. When there is no push handler
+            // (feature disabled/absent), no record exists to leak, so skipping the clear here is safe.
+            // .pushPendingUnregister is deliberately NOT cleared here: it holds a durable "delete this
+            // subscription" intent for the identity being logged out of, and must outlive reset() so an
+            // offline/failed unregister keeps retrying on flush()/next launch (see PostHogPushSubscriptionHandler).
         }
-        // .queue, .replayQeueue, .logsQueue not deleted here — each queue manages its own
-        // disk state via clear() and the per-record distinctId captured at enqueue time
-        // (see PostHogLogRecord) lets in-flight telemetry survive an identity change.
-        deleteSafely(url(forKey: .oldQueueFolder))
-        deleteSafely(url(forKey: .oldQueuePlist))
-        deleteSafely(url(forKey: .oldReplayQueue))
-        deleteSafely(url(forKey: .flags))
-        deleteSafely(url(forKey: .enabledFeatureFlags))
-        deleteSafely(url(forKey: .enabledFeatureFlagPayloads))
-        deleteSafely(url(forKey: .groups))
-        deleteSafely(url(forKey: .registerProperties))
-        deleteSafely(url(forKey: .optOut))
-        deleteSafely(url(forKey: .isIdentified))
-        deleteSafely(url(forKey: .personProcessingEnabled))
-        // .remoteConfig is project-level config (not user data); kept across reset() so features re-arm
-        deleteSafely(url(forKey: .surveySeen))
-        deleteSafely(url(forKey: .surveyProgress))
-        deleteSafely(url(forKey: .lastSeenSurveyDate))
-        deleteSafely(url(forKey: .requestId))
-        deleteSafely(url(forKey: .minimalFlagCalledEvents))
-        deleteSafely(url(forKey: .personPropertiesForFlags))
-        deleteSafely(url(forKey: .groupPropertiesForFlags))
-        // legacy slices, no longer written (config now lives in .remoteConfig); drop stragglers from older SDKs
-        deleteSafely(url(forKey: .sessionReplay))
-        deleteSafely(url(forKey: .errorTracking))
-        deleteSafely(url(forKey: .capturePerformance))
-        // .pushSubscription is deliberately NOT cleared here: PostHogPushSubscriptionHandler.recordForReset()
-        // clears it under its own recordLock (before this runs) so a concurrent send() can't write a
-        // fresh record into the gap and have it erased unlocked. When there is no push handler
-        // (feature disabled/absent), no record exists to leak, so skipping the clear here is safe.
-        // .pushPendingUnregister is deliberately NOT cleared here: it holds a durable "delete this
-        // subscription" intent for the identity being logged out of, and must outlive reset() so an
-        // offline/failed unregister keeps retrying on flush()/next launch (see PostHogPushSubscriptionHandler).
     }
 
     func remove(key: StorageKey) {
@@ -461,7 +479,11 @@ class PostHogStorage {
     }
 
     func getDictionary(forKey key: StorageKey) -> [AnyHashable: Any]? {
-        getJson(forKey: key) as? [AnyHashable: Any]
+        let dictionary = getJson(forKey: key) as? [AnyHashable: Any]
+        #if TESTING
+            if key == .surveyProgress { testOnSurveyProgressRead?() }
+        #endif
+        return dictionary
     }
 
     func setDictionary(forKey key: StorageKey, contents: [AnyHashable: Any]) {

--- a/PostHog/PostHogStorage.swift
+++ b/PostHog/PostHogStorage.swift
@@ -244,6 +244,7 @@ class PostHogStorage {
         case isIdentified = "posthog.isIdentified"
         case personProcessingEnabled = "posthog.enabledPersonProcessing"
         case remoteConfig = "posthog.remoteConfig"
+        case surveyProgress = "posthog.surveyProgress"
         case surveySeen = "posthog.surveySeen"
         case lastSeenSurveyDate = "posthog.lastSeenSurveyDate"
         case requestId = "posthog.requestId"
@@ -426,6 +427,7 @@ class PostHogStorage {
         deleteSafely(url(forKey: .personProcessingEnabled))
         // .remoteConfig is project-level config (not user data); kept across reset() so features re-arm
         deleteSafely(url(forKey: .surveySeen))
+        deleteSafely(url(forKey: .surveyProgress))
         deleteSafely(url(forKey: .lastSeenSurveyDate))
         deleteSafely(url(forKey: .requestId))
         deleteSafely(url(forKey: .minimalFlagCalledEvents))

--- a/PostHog/Surveys/Models/PostHogDisplaySurvey.swift
+++ b/PostHog/Surveys/Models/PostHogDisplaySurvey.swift
@@ -15,6 +15,8 @@ import Foundation
     public let name: String
     /// Array of questions to be presented in the survey
     public let questions: [PostHogDisplaySurveyQuestion]
+    /// The question to show when restoring an unfinished survey. Zero for a new survey.
+    public let initialQuestionIndex: Int
     /// Optional appearance configuration for customizing the survey's look and feel
     public let appearance: PostHogDisplaySurveyAppearance?
     /// Optional date indicating when the survey should start being shown
@@ -28,7 +30,8 @@ import Foundation
         questions: [PostHogDisplaySurveyQuestion],
         appearance: PostHogDisplaySurveyAppearance?,
         startDate: Date?,
-        endDate: Date?
+        endDate: Date?,
+        initialQuestionIndex: Int = 0
     ) {
         self.id = id
         self.name = name
@@ -36,6 +39,7 @@ import Foundation
         self.appearance = appearance
         self.startDate = startDate
         self.endDate = endDate
+        self.initialQuestionIndex = initialQuestionIndex
         super.init()
     }
 }

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -56,6 +56,8 @@
 
         private var activeSurveyLock = NSLock()
         private var activeSurvey: PostHogSurvey?
+        private var progressStore: SurveyProgressStore?
+        private var activeProgressWasPersisted = false
         private var activeSurveySubmissionId: String?
         private var activeSurveyLanguage: String?
         /// Language the survey was rendered with, frozen at show time and reused as `$survey_language` on
@@ -66,6 +68,7 @@
         /// keeping them in `$survey_language` rather than a later live re-translation.
         private var activeSurveyRenderedQuestionTranslations: [PostHogSurveyQuestionTranslation?]?
         private var activeSurveyResponses: [String: PostHogSurveyResponse] = [:] // keyed by question identifier
+        private var activeSurveyResponseLanguage: String?
         /// Question text as shown when each question was answered, keyed like `activeSurveyResponses`, so
         /// a later re-translation can't rewrite the language a question was answered in.
         private var activeSurveyResponseQuestionText: [String: String] = [:]
@@ -75,6 +78,7 @@
         func install(_ postHog: PostHogSDK) -> PostHogIntegrationInstallResult {
             installIfNeeded(using: Self.integrationInstallState) {
                 self.postHog = postHog
+                if let storage = postHog.storage { progressStore = SurveyProgressStore(storage: storage) }
                 start()
             }
         }
@@ -113,6 +117,7 @@
             didBecomeActiveToken = nil
             didLayoutViewToken = nil
             personPropertiesChangedToken = nil
+            clearActiveSurvey()
             unsubscribeFromRemoteConfigUpdates()
             #if os(iOS)
                 if #available(iOS 15.0, *) {
@@ -132,7 +137,7 @@
                 let matchingSurveys = surveys
                     .lazy
                     .filter { // 1. unseen surveys,
-                        !self.getSurveySeen(survey: $0)
+                        self.hasProgress($0) || !self.getSurveySeen(survey: $0)
                     }
                     .filter(\.isActive) // 2. that are active,
                     .filter { survey in // 3. and match display conditions,
@@ -146,12 +151,11 @@
                         self.hasWaitPeriodPassed(survey: survey)
                     }
                     .filter { survey in // 4. and match linked flags
-                        guard !survey.requiresFeatureFlagEvaluation || self.canEvaluateSurveyFeatureFlags else { return false }
                         let allKeys: [String?] = [
                             [survey.linkedFlagKey],
                             [survey.targetingFlagKey],
                             // we check internal targeting flags only if this survey cannot be activated repeatedly
-                            [survey.canActivateRepeatedly ? nil : survey.internalTargetingFlagKey],
+                            [survey.canActivateRepeatedly || self.hasProgress(survey) ? nil : survey.internalTargetingFlagKey],
                             survey.featureFlagKeys?.compactMap { kvp in
                                 kvp.key.isEmpty ? nil : kvp.value
                             } ?? [],
@@ -160,6 +164,7 @@
                         .compactMap { $0 }
                         .filter { !$0.isEmpty }
 
+                        guard allKeys.isEmpty || self.canEvaluateSurveyFeatureFlags else { return false }
                         // all keys must be enabled
                         return Set(allKeys)
                             .allSatisfy(self.isSurveyFeatureFlagEnabled)
@@ -168,7 +173,7 @@
                         survey.hasEvents ? self.isSurveyEventActivated(survey: survey) : true
                     }
 
-                callback(Array(matchingSurveys))
+                callback(Array(matchingSurveys).sorted { self.hasProgress($0) && !self.hasProgress($1) })
             }
         }
 
@@ -264,6 +269,7 @@
             allSurveysLock.withLock { allSurveys = surveys }
             eventsToSurveysLock.withLock { eventsToSurveys = events }
             reconcileEventActivations(with: surveys)
+            progressStore?.reconcile(surveys)
         }
 
         private func isSurveyFeatureFlagEnabled(flagKey: String?) -> Bool {
@@ -306,7 +312,8 @@
                         self.postHog?.config.surveysConfig.surveysDelegate.renderSurvey(
                             survey.toDisplaySurvey(
                                 surveyTranslation: translations.survey,
-                                questionTranslations: translations.questions
+                                questionTranslations: translations.questions,
+                                initialQuestionIndex: self.activeSurveyLock.withLock { self.activeSurveyQuestionIndex }
                             ),
                             onSurveyShown: self.handleSurveyShown,
                             onSurveyResponse: self.handleSurveyResponse,
@@ -549,11 +556,17 @@
         /// - Returns: The next question to display based on branching logic, or nil if there was an error
         private func handleSurveyResponse(survey: PostHogDisplaySurvey, index: Int, response: PostHogSurveyResponse) -> PostHogNextSurveyQuestion? {
             let (activeSurvey, activeSurveyQuestionIndex, shownLanguage, renderedQuestionTranslations, submissionId) = activeSurveyLock.withLock {
-                (self.activeSurvey, self.activeSurveyQuestionIndex, self.activeSurveyRenderedLanguage, self.activeSurveyRenderedQuestionTranslations, self.activeSurveySubmissionId)
+                (self.activeSurvey, self.activeSurveyQuestionIndex, self.activeSurveyRenderedLanguage,
+                 self.activeSurveyRenderedQuestionTranslations, self.activeSurveySubmissionId)
             }
 
             guard let activeSurvey, survey.id == activeSurvey.id else {
                 hedgeLog("[Surveys] Received a response event for a non-active survey")
+                return nil
+            }
+
+            guard !activeProgressWasPersisted || progressStore?.load(activeSurvey)?.submissionId == submissionId else {
+                clearActiveSurvey()
                 return nil
             }
 
@@ -617,7 +630,7 @@
                     self.activeSurvey,
                     self.activeSurveyCompleted,
                     self.activeSurveyResponses,
-                    self.activeSurveyRenderedLanguage,
+                    self.activeSurveyResponses.isEmpty ? self.activeSurveyRenderedLanguage : self.activeSurveyResponseLanguage,
                     self.activeSurveyRenderedQuestionTranslations,
                     self.activeSurveyResponseQuestionText,
                     self.activeSurveySubmissionId
@@ -626,6 +639,11 @@
 
             guard let activeSurvey, survey.id == activeSurvey.id else {
                 hedgeLog("Received a close event for a non-active survey")
+                return
+            }
+
+            guard activeSurveyCompleted || !activeProgressWasPersisted || progressStore?.load(activeSurvey)?.submissionId == submissionId else {
+                clearActiveSurvey()
                 return
             }
 
@@ -640,6 +658,8 @@
                     responseQuestionText: activeSurveyResponseQuestionText
                 )
             }
+
+            progressStore?.remove(activeSurvey)
 
             // mark as seen
             setSurveySeen(survey: activeSurvey)
@@ -814,24 +834,50 @@
         private func setActiveSurvey(survey: PostHogSurvey, language: String? = nil, questionTranslations: [PostHogSurveyQuestionTranslation?]? = nil) {
             activeSurveyLock.withLock {
                 if activeSurvey == nil {
+                    let progress = progressStore?.load(survey) ?? SurveyProgress(
+                        submissionId: UUID().uuidString,
+                        questionOrder: SurveyProgress.questionOrder(for: survey)
+                    )
                     activeSurvey = survey
-                    activeSurveySubmissionId = UUID().uuidString
+                    activeSurveySubmissionId = progress.submissionId
                     activeSurveyLanguage = language
                     activeSurveyRenderedLanguage = language
                     activeSurveyQuestionTranslations = questionTranslations
                     activeSurveyRenderedQuestionTranslations = questionTranslations
                     activeSurveyCompleted = false
-                    activeSurveyResponses = [:]
-                    activeSurveyResponseQuestionText = [:]
-                    activeSurveyQuestionIndex = 0
+                    activeSurveyResponses = progress.responses.compactMapValues { $0.response }
+                    activeSurveyResponseQuestionText = progress.questionText
+                    activeSurveyResponseLanguage = progress.language
+                    activeSurveyQuestionIndex = progress.questionIndex
+                    activeProgressWasPersisted = progressStore?.load(survey) != nil
                 }
             }
+        }
+
+        private func hasProgress(_ survey: PostHogSurvey) -> Bool {
+            progressStore?.load(survey) != nil
+        }
+
+        private func persistActiveProgressLocked() {
+            guard let survey = activeSurvey, let submissionId = activeSurveySubmissionId else { return }
+            if activeSurveyCompleted {
+                progressStore?.remove(survey)
+                return
+            }
+            var progress = SurveyProgress(submissionId: submissionId, questionOrder: SurveyProgress.questionOrder(for: survey))
+            progress.questionIndex = activeSurveyQuestionIndex
+            progress.responses = activeSurveyResponses.mapValues(StoredSurveyResponse.init)
+            progress.questionText = activeSurveyResponseQuestionText
+            progress.language = activeSurveyResponseLanguage
+            progressStore?.save(progress, for: survey)
+            activeProgressWasPersisted = progressStore?.load(survey) != nil
         }
 
         private func clearActiveSurvey() {
             activeSurveyLock.withLock {
                 activeSurvey = nil
                 activeSurveySubmissionId = nil
+                activeProgressWasPersisted = false
                 activeSurveyLanguage = nil
                 activeSurveyRenderedLanguage = nil
                 activeSurveyQuestionTranslations = nil
@@ -839,6 +885,7 @@
                 activeSurveyCompleted = false
                 activeSurveyResponses = [:]
                 activeSurveyResponseQuestionText = [:]
+                activeSurveyResponseLanguage = nil
                 activeSurveyQuestionIndex = 0
             }
         }
@@ -881,8 +928,10 @@
                     activeSurveyResponses[getNewResponseKey(for: id)] = response
                 }
                 activeSurveyResponseQuestionText[responseKey(questionId: id, index: index)] = displayedText
+                activeSurveyResponseLanguage = activeSurveyRenderedLanguage
                 activeSurveyQuestionIndex = nextQuestion.questionIndex
                 activeSurveyCompleted = nextQuestion.isSurveyCompleted
+                persistActiveProgressLocked()
                 return (activeSurveyResponses, activeSurveyResponseQuestionText)
             }
         }
@@ -999,61 +1048,6 @@
             }
         }
 
-        /// Returns next question index based on a branching step result
-        /// - Parameters:
-        ///   - nextIndex: The next index to process
-        ///   - totalQuestions: The total number of questions in the survey
-        /// - Returns: The next question index if found, or nil if not
-        private func processBranchingStep(nextIndex: Any, totalQuestions: Int) -> NextSurveyQuestion? {
-            if let nextIndex = nextIndex as? Int {
-                return .index(min(nextIndex, totalQuestions - 1))
-            }
-            if let nextIndex = nextIndex as? String, nextIndex.lowercased() == "end" {
-                return .end
-            }
-            return nil
-        }
-
-        // Gets the response bucket for a given rating response value, given the scale.
-        // For example, for a scale of 3, the buckets are "negative", "neutral" and "positive".
-        private func getRatingBucketForResponseValue(scale: PostHogSurveyRatingScale, value: Int) -> String? {
-            // swiftlint:disable:previous cyclomatic_complexity
-            // Validate input ranges
-            switch scale {
-            case .threePoint where RatingBucket.threePointRange.contains(value):
-                switch value {
-                case BucketThresholds.ThreePoint.negatives: return RatingBucket.negative
-                case BucketThresholds.ThreePoint.neutrals: return RatingBucket.neutral
-                default: return RatingBucket.positive
-                }
-
-            case .fivePoint where RatingBucket.fivePointRange.contains(value):
-                switch value {
-                case BucketThresholds.FivePoint.negatives: return RatingBucket.negative
-                case BucketThresholds.FivePoint.neutrals: return RatingBucket.neutral
-                default: return RatingBucket.positive
-                }
-
-            case .sevenPoint where RatingBucket.sevenPointRange.contains(value):
-                switch value {
-                case BucketThresholds.SevenPoint.negatives: return RatingBucket.negative
-                case BucketThresholds.SevenPoint.neutrals: return RatingBucket.neutral
-                default: return RatingBucket.positive
-                }
-
-            case .tenPoint where RatingBucket.tenPointRange.contains(value):
-                switch value {
-                case BucketThresholds.TenPoint.detractors: return RatingBucket.detractors
-                case BucketThresholds.TenPoint.passives: return RatingBucket.passives
-                default: return RatingBucket.promoters
-                }
-
-            default:
-                hedgeLog("[Surveys] Cannot get rating bucket for invalid scale: \(scale). The scale must be one of: 3 (1-3), 5 (1-5), 7 (1-7), 10 (0-10).")
-                return nil
-            }
-        }
-
         // Returns the old survey response key for a specific question index
         private func getOldResponseKey(for index: Int) -> String {
             index == 0 ? kSurveyResponseKey : "\(kSurveyResponseKey)_\(index)"
@@ -1085,6 +1079,9 @@
                 clearActiveSurvey()
                 setActiveSurvey(survey: survey, language: language, questionTranslations: questionTranslations)
             }
+
+            var testActiveQuestionIndex: Int { activeSurveyLock.withLock { activeSurveyQuestionIndex } }
+            var testActiveSubmissionId: String? { activeSurveyLock.withLock { activeSurveySubmissionId } }
 
             var testActiveSurveyLanguage: String? {
                 activeSurveyLock.withLock { self.activeSurveyLanguage }

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -33,9 +33,6 @@
         private var eventsToSurveysLock = NSLock()
         private var eventsToSurveys: [String: [(surveyId: String, condition: PostHogEventCondition)]] = [:]
 
-        private var seenSurveyKeysLock = NSLock()
-        private var seenSurveyKeys: [AnyHashable: Any]?
-
         let eventActivatedSurveysLock = NSLock()
         var eventActivatedSurveys: [String: [PostHogEventCondition]] = [:]
         let freshFeatureFlagsLock = NSLock()
@@ -56,6 +53,8 @@
 
         private var activeSurveyLock = NSLock()
         private var activeSurvey: PostHogSurvey?
+        private var activeSurveyAttemptId: UUID?
+        private var activeSurveyGeneration: Int?
         private var progressStore: SurveyProgressStore?
         private var activeProgressWasPersisted = false
         private var activeSurveySubmissionId: String?
@@ -308,6 +307,7 @@
                         let translations = resolveSurveyTranslations(survey: survey, targetLanguage: language)
                         self.setActiveSurvey(survey: survey, language: translations.matchedKey, questionTranslations: translations.questions)
 
+                        let callbacks = self.makeSurveyCallbacks()
                         // render the survey
                         self.postHog?.config.surveysConfig.surveysDelegate.renderSurvey(
                             survey.toDisplaySurvey(
@@ -315,9 +315,9 @@
                                 questionTranslations: translations.questions,
                                 initialQuestionIndex: self.activeSurveyLock.withLock { self.activeSurveyQuestionIndex }
                             ),
-                            onSurveyShown: self.handleSurveyShown,
-                            onSurveyResponse: self.handleSurveyResponse,
-                            onSurveyClosed: self.handleSurveyClosed
+                            onSurveyShown: callbacks.shown,
+                            onSurveyResponse: callbacks.response,
+                            onSurveyClosed: callbacks.closed
                         )
                     }
                 }
@@ -383,25 +383,19 @@
         }
 
         /// Mark a survey as seen
-        private func setSurveySeen(survey: PostHogSurvey) {
-            let key = getSurveySeenKey(survey)
-            let seenKeys = seenSurveyKeysLock.withLock {
-                seenSurveyKeys?[key] = true
-                return seenSurveyKeys
+        private func setSurveySeen(survey: PostHogSurvey, generation: Int? = nil) {
+            storage?.withSurveyState { currentGeneration in
+                guard generation == nil || generation == currentGeneration else { return }
+                var seenKeys = storage?.getDictionary(forKey: .surveySeen) ?? [:]
+                seenKeys[getSurveySeenKey(survey)] = true
+                storage?.setDictionary(forKey: .surveySeen, contents: seenKeys)
+                setLastSeenSurveyDate(Date())
             }
-
-            storage?.setDictionary(forKey: .surveySeen, contents: seenKeys ?? [:])
-            setLastSeenSurveyDate(Date())
         }
 
-        /// Returns survey seen list (and mem-cache from disk if needed)
+        /// Returns the current survey seen list from disk, including changes made by reset.
         private func getSeenSurveyKeys() -> [AnyHashable: Any] {
-            seenSurveyKeysLock.withLock {
-                if seenSurveyKeys == nil {
-                    seenSurveyKeys = storage?.getDictionary(forKey: .surveySeen) ?? [:]
-                }
-                return seenSurveyKeys ?? [:]
-            }
+            storage?.withSurveyState { _ in storage?.getDictionary(forKey: .surveySeen) ?? [:] } ?? [:]
         }
 
         /// Returns given match type or default value if nil
@@ -495,39 +489,63 @@
             return activatedConditions.contains { currentConditions.contains($0) }
         }
 
-        /// Handle a survey that is shown
-        private func handleSurveyShown(survey: PostHogDisplaySurvey) {
-            let activeSurvey = activeSurveyLock.withLock { self.activeSurvey }
+        private func makeSurveyCallbacks() -> SurveyCallbacks {
+            let attemptId = activeSurveyLock.withLock { activeSurveyAttemptId }
+            return SurveyCallbacks(
+                shown: { [weak self] in self?.handleSurveyShown(survey: $0, attemptId: attemptId) },
+                response: { [weak self] in self?.handleSurveyResponse(survey: $0, index: $1, response: $2, attemptId: attemptId) },
+                closed: { [weak self] in self?.handleSurveyClosed(survey: $0, attemptId: attemptId) }
+            )
+        }
 
-            guard let activeSurvey, survey.id == activeSurvey.id else {
-                hedgeLog("[Surveys] Received a show event for a non-active survey")
-                return
-            }
-
-            reconcileRenderedTranslationOnShow(activeSurvey: activeSurvey)
-
-            // Read after the reconcile so the shown event reports the reconciled language.
-            let language = activeSurveyLock.withLock { self.activeSurveyLanguage }
-            sendSurveyShownEvent(survey: activeSurvey, language: language)
-
-            // clear up event-activated surveys
-            if activeSurvey.hasEvents {
-                eventActivatedSurveysLock.withLock {
-                    _ = eventActivatedSurveys.removeValue(forKey: activeSurvey.id)
+        private func withActiveSurveyAttempt<T>(_ attemptId: UUID?, _ operation: (Int) -> T?) -> T? {
+            activeSurveyLock.withLock {
+                guard let attemptId, attemptId == activeSurveyAttemptId, let storage else { return nil }
+                return storage.withSurveyState { generation in
+                    guard activeSurveyGeneration == generation else {
+                        clearActiveSurveyLocked()
+                        return nil
+                    }
+                    let result = operation(generation)
+                    guard storage.isSurveyGenerationCurrent(generation) else {
+                        clearActiveSurveyLocked()
+                        return nil
+                    }
+                    return result
                 }
             }
+        }
+
+        /// Handle a survey that is shown
+        private func handleSurveyShown(survey: PostHogDisplaySurvey, attemptId: UUID?) {
+            let shown: (survey: PostHogSurvey, generation: Int)? = withActiveSurveyAttempt(attemptId) { generation in
+                guard let activeSurvey, survey.id == activeSurvey.id else {
+                    hedgeLog("[Surveys] Received a show event for a non-active survey")
+                    return nil
+                }
+                // clear up event-activated surveys
+                if activeSurvey.hasEvents {
+                    eventActivatedSurveysLock.withLock { _ = eventActivatedSurveys.removeValue(forKey: activeSurvey.id) }
+                }
+                return (activeSurvey, generation)
+            }
+            guard let shown else { return }
+            reconcileRenderedTranslationOnShow(activeSurvey: shown.survey, attemptId: attemptId)
+            // Read after the reconcile so the shown event reports the reconciled language.
+            let language = activeSurveyLock.withLock { self.activeSurveyLanguage }
+            sendSurveyShownEvent(survey: shown.survey, language: language, generation: shown.generation)
         }
 
         /// Re-delivers the current translation for a language change that committed after `setActiveSurvey`
         /// but before the survey was on screen — a window where `updateSurvey` is dropped and later
         /// refreshes no-op. Pushes one update to catch up.
-        private func reconcileRenderedTranslationOnShow(activeSurvey: PostHogSurvey) {
+        private func reconcileRenderedTranslationOnShow(activeSurvey: PostHogSurvey, attemptId: UUID?) {
             guard #available(iOS 15.0, *),
                   let updateSurvey = postHog?.config._surveysConfig.surveysDelegate.updateSurvey
             else { return }
 
             activeSurveyLock.withLock {
-                guard activeSurveyRenderedLanguage != activeSurveyLanguage else { return }
+                guard attemptId == activeSurveyAttemptId, activeSurveyRenderedLanguage != activeSurveyLanguage else { return }
 
                 let language = resolveDisplayLanguage()
                 let translations = resolveSurveyTranslations(survey: activeSurvey, targetLanguage: language)
@@ -554,131 +572,118 @@
         ///   - index: The index of the current question being answered
         ///   - response: The user's response to the current question
         /// - Returns: The next question to display based on branching logic, or nil if there was an error
-        private func handleSurveyResponse(survey: PostHogDisplaySurvey, index: Int, response: PostHogSurveyResponse) -> PostHogNextSurveyQuestion? {
-            let (activeSurvey, activeSurveyQuestionIndex, shownLanguage, renderedQuestionTranslations, submissionId) = activeSurveyLock.withLock {
-                (self.activeSurvey, self.activeSurveyQuestionIndex, self.activeSurveyRenderedLanguage,
-                 self.activeSurveyRenderedQuestionTranslations, self.activeSurveySubmissionId)
-            }
+        private func handleSurveyResponse(
+            survey: PostHogDisplaySurvey, index: Int, response: PostHogSurveyResponse, attemptId: UUID?
+        ) -> PostHogNextSurveyQuestion? {
+            let result: (next: PostHogNextSurveyQuestion, capture: () -> Void)? = withActiveSurveyAttempt(attemptId) { generation in
+                let (activeSurvey, activeSurveyQuestionIndex, shownLanguage, renderedQuestionTranslations, submissionId) =
+                    (self.activeSurvey, self.activeSurveyQuestionIndex, self.activeSurveyRenderedLanguage,
+                     self.activeSurveyRenderedQuestionTranslations, self.activeSurveySubmissionId)
 
-            guard let activeSurvey, survey.id == activeSurvey.id else {
-                hedgeLog("[Surveys] Received a response event for a non-active survey")
-                return nil
-            }
+                guard let activeSurvey, survey.id == activeSurvey.id else {
+                    hedgeLog("[Surveys] Received a response event for a non-active survey")
+                    return nil
+                }
 
-            guard !activeProgressWasPersisted || progressStore?.load(activeSurvey)?.submissionId == submissionId else {
-                clearActiveSurvey()
-                return nil
-            }
+                guard !activeProgressWasPersisted || progressStore?.load(activeSurvey)?.submissionId == submissionId else {
+                    clearActiveSurveyLocked()
+                    return nil
+                }
 
-            // TODO: ideally the handleSurveyResponse should pass the question ID as param but it would break the Flutter SDK for older versions
-            let questionId: String
-            if index < survey.questions.count {
-                let question = survey.questions[index]
-                questionId = question.id
-            } else {
-                // this should not happen, its only for back compatibility
-                questionId = ""
-            }
+                guard !activeSurveyCompleted, index >= 0, index == activeSurveyQuestionIndex, activeSurvey.questions.indices.contains(index) else { return nil }
 
-            // 2. Get next step
-            let nextStep = getNextSurveyStep(
-                survey: activeSurvey,
-                questionIndex: activeSurveyQuestionIndex,
-                response: response
-            )
+                // TODO: ideally the handleSurveyResponse should pass the question ID as param but it would break the Flutter SDK for older versions
+                let questionId: String
+                if index < survey.questions.count {
+                    let question = survey.questions[index]
+                    questionId = question.id
+                } else {
+                    // this should not happen, its only for back compatibility
+                    questionId = ""
+                }
 
-            let (isCompleted, nextIndex) = switch nextStep {
-            case let .index(nextIndex): (false, nextIndex)
-            case .end: (true, activeSurveyQuestionIndex)
-            }
-
-            let nextSurveyQuestion = PostHogNextSurveyQuestion(
-                questionIndex: nextIndex,
-                isSurveyCompleted: isCompleted
-            )
-
-            let stored = setActiveSurveyResponse(id: questionId, index: index, response: response, nextQuestion: nextSurveyQuestion)
-
-            // send event if needed
-            if activeSurvey.enablePartialResponses == true || isCompleted {
-                sendSurveySentEvent(
+                // 2. Get next step
+                let nextStep = getNextSurveyStep(
                     survey: activeSurvey,
-                    responses: stored.responses,
-                    submissionId: submissionId,
-                    isCompleted: isCompleted,
-                    language: shownLanguage,
-                    questionTranslations: renderedQuestionTranslations,
-                    responseQuestionText: stored.questionText
+                    questionIndex: activeSurveyQuestionIndex,
+                    response: response
                 )
-            }
 
-            return nextSurveyQuestion
+                let (isCompleted, nextIndex) = switch nextStep {
+                case let .index(nextIndex): (false, nextIndex)
+                case .end: (true, activeSurveyQuestionIndex)
+                }
+
+                let nextSurveyQuestion = PostHogNextSurveyQuestion(
+                    questionIndex: nextIndex,
+                    isSurveyCompleted: isCompleted
+                )
+
+                let stored = setActiveSurveyResponseLocked(id: questionId, index: index, response: response, nextQuestion: nextSurveyQuestion)
+
+                return (nextSurveyQuestion, { [weak self] in
+                    // send event if needed
+                    if activeSurvey.enablePartialResponses == true || isCompleted {
+                        self?.sendSurveySentEvent(
+                            survey: activeSurvey, responses: stored.responses, submissionId: submissionId,
+                            isCompleted: isCompleted, language: shownLanguage,
+                            questionTranslations: renderedQuestionTranslations, responseQuestionText: stored.questionText,
+                            generation: generation
+                        )
+                    }
+                })
+            }
+            result?.capture()
+            return result?.next
         }
 
         /// Handle a survey dismiss
-        private func handleSurveyClosed(survey: PostHogDisplaySurvey) {
-            let (
-                activeSurvey,
-                activeSurveyCompleted,
-                activeSurveyResponses,
-                shownLanguage,
-                renderedQuestionTranslations,
-                activeSurveyResponseQuestionText,
-                submissionId
-            ) = activeSurveyLock.withLock {
-                (
-                    self.activeSurvey,
-                    self.activeSurveyCompleted,
-                    self.activeSurveyResponses,
-                    self.activeSurveyResponses.isEmpty ? self.activeSurveyRenderedLanguage : self.activeSurveyResponseLanguage,
-                    self.activeSurveyRenderedQuestionTranslations,
-                    self.activeSurveyResponseQuestionText,
-                    self.activeSurveySubmissionId
-                )
+        private func handleSurveyClosed(survey: PostHogDisplaySurvey, attemptId: UUID?) {
+            let capture: (() -> Void)? = withActiveSurveyAttempt(attemptId) { generation in
+                let activeSurvey = self.activeSurvey
+                let completed = activeSurveyCompleted
+                let responses = activeSurveyResponses
+                let language = responses.isEmpty ? activeSurveyRenderedLanguage : activeSurveyResponseLanguage
+                let translations = activeSurveyRenderedQuestionTranslations
+                let questionText = activeSurveyResponseQuestionText
+                let submissionId = activeSurveySubmissionId
+
+                guard let activeSurvey, survey.id == activeSurvey.id else {
+                    hedgeLog("Received a close event for a non-active survey")
+                    return nil
+                }
+
+                guard activeSurveyCompleted || !activeProgressWasPersisted || progressStore?.load(activeSurvey)?.submissionId == submissionId else {
+                    clearActiveSurveyLocked()
+                    return nil
+                }
+
+                progressStore?.remove(activeSurvey)
+                setSurveySeen(survey: activeSurvey, generation: generation)
+                clearActiveSurveyLocked()
+                return { [weak self] in
+                    if !completed {
+                        self?.sendSurveyDismissedEvent(
+                            survey: activeSurvey, responses: responses, submissionId: submissionId,
+                            language: language, questionTranslations: translations,
+                            responseQuestionText: questionText, generation: generation
+                        )
+                    }
+                }
             }
-
-            guard let activeSurvey, survey.id == activeSurvey.id else {
-                hedgeLog("Received a close event for a non-active survey")
-                return
-            }
-
-            guard activeSurveyCompleted || !activeProgressWasPersisted || progressStore?.load(activeSurvey)?.submissionId == submissionId else {
-                clearActiveSurvey()
-                return
-            }
-
-            // send survey dismissed event if needed
-            if !activeSurveyCompleted {
-                sendSurveyDismissedEvent(
-                    survey: activeSurvey,
-                    responses: activeSurveyResponses,
-                    submissionId: submissionId,
-                    language: shownLanguage,
-                    questionTranslations: renderedQuestionTranslations,
-                    responseQuestionText: activeSurveyResponseQuestionText
-                )
-            }
-
-            progressStore?.remove(activeSurvey)
-
-            // mark as seen
-            setSurveySeen(survey: activeSurvey)
-
-            // clear active survey
-            clearActiveSurvey()
-
+            guard let capture else { return }
+            capture()
             // show next survey in queue, if any, after a short delay
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) {
-                self.showNextSurvey()
-            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) { [weak self] in self?.showNextSurvey() }
         }
 
         /// Sends a `survey shown` event to PostHog instance
-        private func sendSurveyShownEvent(survey: PostHogSurvey, language: String? = nil) {
+        private func sendSurveyShownEvent(survey: PostHogSurvey, language: String? = nil, generation: Int? = nil) {
             sendSurveyEvent(
                 event: "survey shown",
                 survey: survey,
-                language: language
+                language: language,
+                generation: generation
             )
         }
 
@@ -694,7 +699,8 @@
             isCompleted: Bool = true,
             language: String? = nil,
             questionTranslations: [PostHogSurveyQuestionTranslation?]? = nil,
-            responseQuestionText: [String: String] = [:]
+            responseQuestionText: [String: String] = [:],
+            generation: Int? = nil
         ) {
             var additionalProperties = buildSurveyResponseProperties(
                 survey: survey,
@@ -704,18 +710,19 @@
             ).merging(
                 [
                     "$survey_completed": isCompleted,
-                    "$set": [getSurveyInteractionProperty(survey: survey, property: "responded"): true],
+                    "$set": [survey.interactionProperty("responded"): true],
                 ],
                 uniquingKeysWith: { _, new in new }
             )
 
             additionalProperties["$survey_submission_id"] = submissionId
-            setSurveySeen(survey: survey)
+            setSurveySeen(survey: survey, generation: generation)
             sendSurveyEvent(
                 event: "survey sent",
                 survey: survey,
                 additionalProperties: additionalProperties,
-                language: language
+                language: language,
+                generation: generation
             )
         }
 
@@ -726,7 +733,8 @@
             submissionId: String? = nil,
             language: String? = nil,
             questionTranslations: [PostHogSurveyQuestionTranslation?]? = nil,
-            responseQuestionText: [String: String] = [:]
+            responseQuestionText: [String: String] = [:],
+            generation: Int? = nil
         ) {
             var additionalProperties = buildSurveyResponseProperties(
                 survey: survey,
@@ -737,7 +745,7 @@
                 [
                     "$survey_partially_completed": surveyHasResponses(responses),
                     "$set": [
-                        getSurveyInteractionProperty(survey: survey, property: "dismissed"): true,
+                        survey.interactionProperty("dismissed"): true,
                     ],
                 ],
                 uniquingKeysWith: { _, new in new }
@@ -748,7 +756,8 @@
                 event: "survey dismissed",
                 survey: survey,
                 additionalProperties: additionalProperties,
-                language: language
+                language: language,
+                generation: generation
             )
         }
 
@@ -795,61 +804,54 @@
             }
         }
 
-        private func sendSurveyEvent(event: String, survey: PostHogSurvey, additionalProperties: [String: Any] = [:], language: String? = nil) {
+        private func sendSurveyEvent(
+            event: String, survey: PostHogSurvey, additionalProperties: [String: Any] = [:], language: String? = nil, generation: Int? = nil
+        ) {
             guard let postHog else {
                 hedgeLog("[\(event)] event not captured, PostHog instance not found.")
                 return
             }
 
-            var properties = getBaseSurveyEventProperties(for: survey)
+            var properties = survey.eventProperties
             properties.merge(additionalProperties) { _, new in new }
             if let language, !language.isEmpty {
                 properties["$survey_language"] = language
             }
 
-            postHog.capture(event, properties: properties)
-        }
-
-        private func getBaseSurveyEventProperties(for survey: PostHogSurvey) -> [String: Any] {
-            // TODO: Add session replay screen name
-            let props: [String: Any?] = [
-                "$survey_name": survey.name,
-                "$survey_id": survey.id,
-                "$survey_iteration": survey.currentIteration,
-                "$survey_iteration_start_date": survey.currentIterationStartDate.map(toISO8601String),
-            ]
-            return props.compactMapValues { $0 }
-        }
-
-        private func getSurveyInteractionProperty(survey: PostHogSurvey, property: String) -> String {
-            var surveyProperty = "$survey_\(property)/\(survey.id)"
-
-            if let currentIteration = survey.currentIteration, currentIteration > 0 {
-                surveyProperty = "$survey_\(property)/\(survey.id)/\(currentIteration)"
+            let distinctId = storage?.withSurveyState { currentGeneration -> String? in
+                guard generation == nil || generation == currentGeneration else { return nil }
+                return postHog.getDistinctId()
             }
-
-            return surveyProperty
+            guard let distinctId else { return }
+            // Keep user hooks outside the state locks: a hook may reset or start another survey.
+            postHog.capture(event, distinctId: distinctId, properties: properties)
         }
 
         private func setActiveSurvey(survey: PostHogSurvey, language: String? = nil, questionTranslations: [PostHogSurveyQuestionTranslation?]? = nil) {
             activeSurveyLock.withLock {
-                if activeSurvey == nil {
-                    let progress = progressStore?.load(survey) ?? SurveyProgress(
-                        submissionId: UUID().uuidString,
-                        questionOrder: SurveyProgress.questionOrder(for: survey)
-                    )
-                    activeSurvey = survey
-                    activeSurveySubmissionId = progress.submissionId
-                    activeSurveyLanguage = language
-                    activeSurveyRenderedLanguage = language
-                    activeSurveyQuestionTranslations = questionTranslations
-                    activeSurveyRenderedQuestionTranslations = questionTranslations
-                    activeSurveyCompleted = false
-                    activeSurveyResponses = progress.responses.compactMapValues { $0.response }
-                    activeSurveyResponseQuestionText = progress.questionText
-                    activeSurveyResponseLanguage = progress.language
-                    activeSurveyQuestionIndex = progress.questionIndex
-                    activeProgressWasPersisted = progressStore?.load(survey) != nil
+                guard let storage else { return }
+                storage.withSurveyState { generation in
+                    if activeSurvey == nil {
+                        let progress = progressStore?.load(survey) ?? SurveyProgress(
+                            submissionId: UUID().uuidString,
+                            questionOrder: SurveyProgress.questionOrder(for: survey)
+                        )
+                        guard storage.isSurveyGenerationCurrent(generation) else { return }
+                        activeSurvey = survey
+                        activeSurveyAttemptId = UUID()
+                        activeSurveyGeneration = generation
+                        activeSurveySubmissionId = progress.submissionId
+                        activeSurveyLanguage = language
+                        activeSurveyRenderedLanguage = language
+                        activeSurveyQuestionTranslations = questionTranslations
+                        activeSurveyRenderedQuestionTranslations = questionTranslations
+                        activeSurveyCompleted = false
+                        activeSurveyResponses = progress.responses.compactMapValues { $0.response }
+                        activeSurveyResponseQuestionText = progress.questionText
+                        activeSurveyResponseLanguage = progress.language
+                        activeSurveyQuestionIndex = progress.questionIndex
+                        activeProgressWasPersisted = progressStore?.load(survey) != nil
+                    }
                 }
             }
         }
@@ -874,20 +876,24 @@
         }
 
         private func clearActiveSurvey() {
-            activeSurveyLock.withLock {
-                activeSurvey = nil
-                activeSurveySubmissionId = nil
-                activeProgressWasPersisted = false
-                activeSurveyLanguage = nil
-                activeSurveyRenderedLanguage = nil
-                activeSurveyQuestionTranslations = nil
-                activeSurveyRenderedQuestionTranslations = nil
-                activeSurveyCompleted = false
-                activeSurveyResponses = [:]
-                activeSurveyResponseQuestionText = [:]
-                activeSurveyResponseLanguage = nil
-                activeSurveyQuestionIndex = 0
-            }
+            activeSurveyLock.withLock { clearActiveSurveyLocked() }
+        }
+
+        private func clearActiveSurveyLocked() {
+            activeSurvey = nil
+            activeSurveyAttemptId = nil
+            activeSurveyGeneration = nil
+            activeSurveySubmissionId = nil
+            activeProgressWasPersisted = false
+            activeSurveyLanguage = nil
+            activeSurveyRenderedLanguage = nil
+            activeSurveyQuestionTranslations = nil
+            activeSurveyRenderedQuestionTranslations = nil
+            activeSurveyCompleted = false
+            activeSurveyResponses = [:]
+            activeSurveyResponseQuestionText = [:]
+            activeSurveyResponseLanguage = nil
+            activeSurveyQuestionIndex = 0
         }
 
         private func resolveDisplayLanguage() -> String? {
@@ -912,28 +918,26 @@
         ///   - index: The index of the question being answered
         ///   - response: The user's response to store
         ///   - nextQuestion: The next question index and completion info
-        private func setActiveSurveyResponse(
+        private func setActiveSurveyResponseLocked(
             id: String,
             index: Int,
             response: PostHogSurveyResponse,
             nextQuestion: PostHogNextSurveyQuestion
         ) -> (responses: [String: PostHogSurveyResponse], questionText: [String: String]) {
-            activeSurveyLock.withLock {
-                let displayedText = displayedQuestionTextLocked(at: index)
+            let displayedText = displayedQuestionTextLocked(at: index)
 
-                // Response is stored under both key formats for back compatibility; the snapshot only
-                // needs the single key it's read back under.
-                activeSurveyResponses[getOldResponseKey(for: index)] = response
-                if !id.isEmpty {
-                    activeSurveyResponses[getNewResponseKey(for: id)] = response
-                }
-                activeSurveyResponseQuestionText[responseKey(questionId: id, index: index)] = displayedText
-                activeSurveyResponseLanguage = activeSurveyRenderedLanguage
-                activeSurveyQuestionIndex = nextQuestion.questionIndex
-                activeSurveyCompleted = nextQuestion.isSurveyCompleted
-                persistActiveProgressLocked()
-                return (activeSurveyResponses, activeSurveyResponseQuestionText)
+            // Response is stored under both key formats for back compatibility; the snapshot only
+            // needs the single key it's read back under.
+            activeSurveyResponses[getOldResponseKey(for: index)] = response
+            if !id.isEmpty {
+                activeSurveyResponses[getNewResponseKey(for: id)] = response
             }
+            activeSurveyResponseQuestionText[responseKey(questionId: id, index: index)] = displayedText
+            activeSurveyResponseLanguage = activeSurveyRenderedLanguage
+            activeSurveyQuestionIndex = nextQuestion.questionIndex
+            activeSurveyCompleted = nextQuestion.isSurveyCompleted
+            persistActiveProgressLocked()
+            return (activeSurveyResponses, activeSurveyResponseQuestionText)
         }
 
         /// The response-property key for a question, matching the one used when storing its response.
@@ -1080,6 +1084,10 @@
                 setActiveSurvey(survey: survey, language: language, questionTranslations: questionTranslations)
             }
 
+            func testSurveyCallbacks() -> SurveyCallbacks {
+                makeSurveyCallbacks()
+            }
+
             var testActiveQuestionIndex: Int { activeSurveyLock.withLock { activeSurveyQuestionIndex } }
             var testActiveSubmissionId: String? { activeSurveyLock.withLock { activeSurveySubmissionId } }
 
@@ -1094,7 +1102,7 @@
             func getNextQuestion(index: Int, response: PostHogSurveyResponse) -> (Int, Bool)? {
                 guard let activeSurvey else { return nil }
                 activeSurveyQuestionIndex = index
-                if let next = handleSurveyResponse(survey: activeSurvey.toDisplaySurvey(), index: index, response: response) {
+                if let next = makeSurveyCallbacks().response(activeSurvey.toDisplaySurvey(), index, response) {
                     return (next.questionIndex, next.isSurveyCompleted)
                 }
                 return nil
@@ -1105,11 +1113,11 @@
             }
 
             func testHandleSurveyShown(survey: PostHogDisplaySurvey) {
-                handleSurveyShown(survey: survey)
+                makeSurveyCallbacks().shown(survey)
             }
 
             func testHandleSurveyClosed(survey: PostHogDisplaySurvey) {
-                handleSurveyClosed(survey: survey)
+                makeSurveyCallbacks().closed(survey)
             }
 
             func testSendSurveySentEvent(
@@ -1145,11 +1153,11 @@
             }
 
             func testGetBaseSurveyEventProperties(for survey: PostHogSurvey) -> [String: Any] {
-                getBaseSurveyEventProperties(for: survey)
+                survey.eventProperties
             }
 
             func testGetSurveyInteractionProperty(survey: PostHogSurvey, property: String) -> String {
-                getSurveyInteractionProperty(survey: survey, property: property)
+                survey.interactionProperty(property)
             }
 
             func testGetResponseKey(questionId: String) -> String {

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -56,6 +56,7 @@
 
         private var activeSurveyLock = NSLock()
         private var activeSurvey: PostHogSurvey?
+        private var activeSurveySubmissionId: String?
         private var activeSurveyLanguage: String?
         /// Language the survey was rendered with, frozen at show time and reused as `$survey_language` on
         /// `sent`/`dismissed`. Not touched by `refreshActiveSurveyTranslations`, so a drop stays detectable.
@@ -547,8 +548,8 @@
         ///   - response: The user's response to the current question
         /// - Returns: The next question to display based on branching logic, or nil if there was an error
         private func handleSurveyResponse(survey: PostHogDisplaySurvey, index: Int, response: PostHogSurveyResponse) -> PostHogNextSurveyQuestion? {
-            let (activeSurvey, activeSurveyQuestionIndex, shownLanguage, renderedQuestionTranslations) = activeSurveyLock.withLock {
-                (self.activeSurvey, self.activeSurveyQuestionIndex, self.activeSurveyRenderedLanguage, self.activeSurveyRenderedQuestionTranslations)
+            let (activeSurvey, activeSurveyQuestionIndex, shownLanguage, renderedQuestionTranslations, submissionId) = activeSurveyLock.withLock {
+                (self.activeSurvey, self.activeSurveyQuestionIndex, self.activeSurveyRenderedLanguage, self.activeSurveyRenderedQuestionTranslations, self.activeSurveySubmissionId)
             }
 
             guard let activeSurvey, survey.id == activeSurvey.id else {
@@ -586,11 +587,12 @@
             let stored = setActiveSurveyResponse(id: questionId, index: index, response: response, nextQuestion: nextSurveyQuestion)
 
             // send event if needed
-            // TODO: Partial responses
-            if isCompleted {
+            if activeSurvey.enablePartialResponses == true || isCompleted {
                 sendSurveySentEvent(
                     survey: activeSurvey,
                     responses: stored.responses,
+                    submissionId: submissionId,
+                    isCompleted: isCompleted,
                     language: shownLanguage,
                     questionTranslations: renderedQuestionTranslations,
                     responseQuestionText: stored.questionText
@@ -608,7 +610,8 @@
                 activeSurveyResponses,
                 shownLanguage,
                 renderedQuestionTranslations,
-                activeSurveyResponseQuestionText
+                activeSurveyResponseQuestionText,
+                submissionId
             ) = activeSurveyLock.withLock {
                 (
                     self.activeSurvey,
@@ -616,7 +619,8 @@
                     self.activeSurveyResponses,
                     self.activeSurveyRenderedLanguage,
                     self.activeSurveyRenderedQuestionTranslations,
-                    self.activeSurveyResponseQuestionText
+                    self.activeSurveyResponseQuestionText,
+                    self.activeSurveySubmissionId
                 )
             }
 
@@ -630,6 +634,7 @@
                 sendSurveyDismissedEvent(
                     survey: activeSurvey,
                     responses: activeSurveyResponses,
+                    submissionId: submissionId,
                     language: shownLanguage,
                     questionTranslations: renderedQuestionTranslations,
                     responseQuestionText: activeSurveyResponseQuestionText
@@ -665,22 +670,27 @@
         private func sendSurveySentEvent(
             survey: PostHogSurvey,
             responses: [String: PostHogSurveyResponse],
+            submissionId: String? = nil,
+            isCompleted: Bool = true,
             language: String? = nil,
             questionTranslations: [PostHogSurveyQuestionTranslation?]? = nil,
             responseQuestionText: [String: String] = [:]
         ) {
-            let additionalProperties = buildSurveyResponseProperties(
+            var additionalProperties = buildSurveyResponseProperties(
                 survey: survey,
                 responses: responses,
                 questionTranslations: questionTranslations,
                 responseQuestionText: responseQuestionText
             ).merging(
                 [
+                    "$survey_completed": isCompleted,
                     "$set": [getSurveyInteractionProperty(survey: survey, property: "responded"): true],
                 ],
                 uniquingKeysWith: { _, new in new }
             )
 
+            additionalProperties["$survey_submission_id"] = submissionId
+            setSurveySeen(survey: survey)
             sendSurveyEvent(
                 event: "survey sent",
                 survey: survey,
@@ -693,11 +703,12 @@
         private func sendSurveyDismissedEvent(
             survey: PostHogSurvey,
             responses: [String: PostHogSurveyResponse],
+            submissionId: String? = nil,
             language: String? = nil,
             questionTranslations: [PostHogSurveyQuestionTranslation?]? = nil,
             responseQuestionText: [String: String] = [:]
         ) {
-            let additionalProperties = buildSurveyResponseProperties(
+            var additionalProperties = buildSurveyResponseProperties(
                 survey: survey,
                 responses: responses,
                 questionTranslations: questionTranslations,
@@ -712,6 +723,7 @@
                 uniquingKeysWith: { _, new in new }
             )
 
+            additionalProperties["$survey_submission_id"] = submissionId
             sendSurveyEvent(
                 event: "survey dismissed",
                 survey: survey,
@@ -803,6 +815,7 @@
             activeSurveyLock.withLock {
                 if activeSurvey == nil {
                     activeSurvey = survey
+                    activeSurveySubmissionId = UUID().uuidString
                     activeSurveyLanguage = language
                     activeSurveyRenderedLanguage = language
                     activeSurveyQuestionTranslations = questionTranslations
@@ -818,6 +831,7 @@
         private func clearActiveSurvey() {
             activeSurveyLock.withLock {
                 activeSurvey = nil
+                activeSurveySubmissionId = nil
                 activeSurveyLanguage = nil
                 activeSurveyRenderedLanguage = nil
                 activeSurveyQuestionTranslations = nil

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -54,7 +54,7 @@
         private var activeSurveyLock = NSLock()
         private var activeSurvey: PostHogSurvey?
         private var activeSurveyAttemptId: UUID?
-        private var activeSurveyGeneration: Int?
+        private var activeSurveyGeneration: String?
         private var progressStore: SurveyProgressStore?
         private var activeProgressWasPersisted = false
         private var activeSurveySubmissionId: String?
@@ -383,7 +383,7 @@
         }
 
         /// Mark a survey as seen
-        private func setSurveySeen(survey: PostHogSurvey, generation: Int? = nil) {
+        private func setSurveySeen(survey: PostHogSurvey, generation: String? = nil) {
             storage?.withSurveyState { currentGeneration in
                 guard generation == nil || generation == currentGeneration else { return }
                 var seenKeys = storage?.getDictionary(forKey: .surveySeen) ?? [:]
@@ -498,7 +498,7 @@
             )
         }
 
-        private func withActiveSurveyAttempt<T>(_ attemptId: UUID?, _ operation: (Int) -> T?) -> T? {
+        private func withActiveSurveyAttempt<T>(_ attemptId: UUID?, _ operation: (String) -> T?) -> T? {
             activeSurveyLock.withLock {
                 guard let attemptId, attemptId == activeSurveyAttemptId, let storage else { return nil }
                 return storage.withSurveyState { generation in
@@ -518,7 +518,7 @@
 
         /// Handle a survey that is shown
         private func handleSurveyShown(survey: PostHogDisplaySurvey, attemptId: UUID?) {
-            let shown: (survey: PostHogSurvey, generation: Int)? = withActiveSurveyAttempt(attemptId) { generation in
+            let shown: (survey: PostHogSurvey, generation: String)? = withActiveSurveyAttempt(attemptId) { generation in
                 guard let activeSurvey, survey.id == activeSurvey.id else {
                     hedgeLog("[Surveys] Received a show event for a non-active survey")
                     return nil
@@ -678,7 +678,7 @@
         }
 
         /// Sends a `survey shown` event to PostHog instance
-        private func sendSurveyShownEvent(survey: PostHogSurvey, language: String? = nil, generation: Int? = nil) {
+        private func sendSurveyShownEvent(survey: PostHogSurvey, language: String? = nil, generation: String? = nil) {
             sendSurveyEvent(
                 event: "survey shown",
                 survey: survey,
@@ -700,7 +700,7 @@
             language: String? = nil,
             questionTranslations: [PostHogSurveyQuestionTranslation?]? = nil,
             responseQuestionText: [String: String] = [:],
-            generation: Int? = nil
+            generation: String? = nil
         ) {
             var additionalProperties = buildSurveyResponseProperties(
                 survey: survey,
@@ -734,7 +734,7 @@
             language: String? = nil,
             questionTranslations: [PostHogSurveyQuestionTranslation?]? = nil,
             responseQuestionText: [String: String] = [:],
-            generation: Int? = nil
+            generation: String? = nil
         ) {
             var additionalProperties = buildSurveyResponseProperties(
                 survey: survey,
@@ -805,7 +805,7 @@
         }
 
         private func sendSurveyEvent(
-            event: String, survey: PostHogSurvey, additionalProperties: [String: Any] = [:], language: String? = nil, generation: Int? = nil
+            event: String, survey: PostHogSurvey, additionalProperties: [String: Any] = [:], language: String? = nil, generation: String? = nil
         ) {
             guard let postHog else {
                 hedgeLog("[\(event)] event not captured, PostHog instance not found.")
@@ -818,11 +818,7 @@
                 properties["$survey_language"] = language
             }
 
-            let distinctId = storage?.withSurveyState { currentGeneration -> String? in
-                guard generation == nil || generation == currentGeneration else { return nil }
-                return postHog.getDistinctId()
-            }
-            guard let distinctId else { return }
+            guard let distinctId = postHog.surveyEventDistinctId(generation: generation) else { return }
             // Keep user hooks outside the state locks: a hook may reset or start another survey.
             postHog.capture(event, distinctId: distinctId, properties: properties)
         }
@@ -833,7 +829,7 @@
                 storage.withSurveyState { generation in
                     if activeSurvey == nil {
                         let progress = progressStore?.load(survey) ?? SurveyProgress(
-                            submissionId: UUID().uuidString,
+                            resetEpoch: generation, submissionId: UUID().uuidString,
                             questionOrder: SurveyProgress.questionOrder(for: survey)
                         )
                         guard storage.isSurveyGenerationCurrent(generation) else { return }
@@ -861,12 +857,12 @@
         }
 
         private func persistActiveProgressLocked() {
-            guard let survey = activeSurvey, let submissionId = activeSurveySubmissionId else { return }
+            guard let survey = activeSurvey, let submissionId = activeSurveySubmissionId, let resetEpoch = activeSurveyGeneration else { return }
             if activeSurveyCompleted {
                 progressStore?.remove(survey)
                 return
             }
-            var progress = SurveyProgress(submissionId: submissionId, questionOrder: SurveyProgress.questionOrder(for: survey))
+            var progress = SurveyProgress(resetEpoch: resetEpoch, submissionId: submissionId, questionOrder: SurveyProgress.questionOrder(for: survey))
             progress.questionIndex = activeSurveyQuestionIndex
             progress.responses = activeSurveyResponses.mapValues(StoredSurveyResponse.init)
             progress.questionText = activeSurveyResponseQuestionText

--- a/PostHog/Surveys/PostHogSurveysConfig.swift
+++ b/PostHog/Surveys/PostHogSurveysConfig.swift
@@ -53,6 +53,7 @@ public typealias OnPostHogSurveyClosed = (_ survey: PostHogDisplaySurvey) -> Voi
 /// Delegate used by the SDK to present surveys and receive survey lifecycle callbacks.
 @objc public protocol PostHogSurveysDelegate {
     /// Called when an activated PostHog survey needs to be rendered on the app's UI
+    /// Start at `survey.initialQuestionIndex` to resume an unfinished survey.
     ///
     /// - Parameters:
     ///   - survey: The survey to be displayed to the user

--- a/PostHog/Surveys/PostHogSurveysConfig.swift
+++ b/PostHog/Surveys/PostHogSurveysConfig.swift
@@ -43,7 +43,7 @@ public typealias OnPostHogSurveyShown = (_ survey: PostHogDisplaySurvey) -> Void
 ///   - survey: The current survey being displayed
 ///   - index: The index of the question being answered
 ///   - response: The user's response to the question
-/// - Returns: The next survey state, or `nil` to leave the displayed survey state unchanged.
+/// - Returns: The next survey state, or `nil` if the attempt is no longer valid. The built-in renderer closes an invalidated survey.
 public typealias OnPostHogSurveyResponse = (_ survey: PostHogDisplaySurvey, _ index: Int, _ response: PostHogSurveyResponse) -> PostHogNextSurveyQuestion?
 
 /// To be called when a survey is dismissed
@@ -87,4 +87,10 @@ public typealias OnPostHogSurveyClosed = (_ survey: PostHogDisplaySurvey) -> Voi
     /// Called when surveys are stopped to clean up any UI elements and reset the survey display state.
     /// This method should handle the dismissal of any active surveys and cleanup of associated resources.
     @objc func cleanupSurveys()
+}
+
+struct SurveyCallbacks {
+    let shown: OnPostHogSurveyShown
+    let response: OnPostHogSurveyResponse
+    let closed: OnPostHogSurveyClosed
 }

--- a/PostHog/Surveys/SurveyDisplayController.swift
+++ b/PostHog/Surveys/SurveyDisplayController.swift
@@ -26,12 +26,12 @@
 
             displayedSurvey = survey
             isSurveyCompleted = false
-            currentQuestionIndex = 0
+            currentQuestionIndex = survey.initialQuestionIndex
             // The intro has no default header, so an intro with no copy at all is skipped
             // instead of drawing an empty sheet with a lone button.
             let hasIntroContent = survey.appearance?.introScreenHeader?.isEmpty == false
                 || survey.appearance?.introScreenDescription?.isEmpty == false
-            showingIntroScreen = survey.appearance?.displayIntroScreen == true && hasIntroContent
+            showingIntroScreen = survey.initialQuestionIndex == 0 && survey.appearance?.displayIntroScreen == true && hasIntroContent
             onSurveyShown?(survey)
         }
 
@@ -60,7 +60,10 @@
 
         func onNextQuestion(index: Int, response: PostHogSurveyResponse) {
             guard let displayedSurvey else { return }
-            guard let next = onSurveyResponse?(displayedSurvey, index, response) else { return }
+            guard let next = onSurveyResponse?(displayedSurvey, index, response) else {
+                dismissSurvey()
+                return
+            }
 
             currentQuestionIndex = next.questionIndex
             isSurveyCompleted = next.isSurveyCompleted

--- a/PostHog/Surveys/SurveyProgressStore.swift
+++ b/PostHog/Surveys/SurveyProgressStore.swift
@@ -55,7 +55,6 @@ import Foundation
 
     final class SurveyProgressStore {
         private let storage: PostHogStorage
-        private let lock = NSLock()
 
         init(storage: PostHogStorage) {
             self.storage = storage
@@ -66,8 +65,9 @@ import Foundation
         }
 
         func load(_ survey: PostHogSurvey) -> SurveyProgress? {
-            lock.withLock {
+            storage.withSurveyState { generation in
                 let records = storage.getDictionary(forKey: .surveyProgress) ?? [:]
+                guard storage.isSurveyGenerationCurrent(generation) else { return nil }
                 guard let json = records[key(survey)] else { return nil }
                 guard let data = try? JSONSerialization.data(withJSONObject: json),
                       let progress = try? JSONDecoder().decode(SurveyProgress.self, from: data),
@@ -84,19 +84,21 @@ import Foundation
         }
 
         func save(_ progress: SurveyProgress, for survey: PostHogSurvey) {
-            lock.withLock {
+            storage.withSurveyState { generation in
                 guard let data = try? JSONEncoder().encode(progress),
                       let json = try? JSONSerialization.jsonObject(with: data) else { return }
                 var records = storage.getDictionary(forKey: .surveyProgress) ?? [:]
+                guard storage.isSurveyGenerationCurrent(generation) else { return }
                 records[key(survey)] = json
                 storage.setDictionary(forKey: .surveyProgress, contents: records)
             }
         }
 
         func reconcile(_ surveys: [PostHogSurvey]) {
-            lock.withLock {
+            storage.withSurveyState { generation in
                 let keys = Set(surveys.filter(\.isActive).map(key))
                 let records = storage.getDictionary(forKey: .surveyProgress) ?? [:]
+                guard storage.isSurveyGenerationCurrent(generation) else { return }
                 storage.setDictionary(forKey: .surveyProgress, contents: records.filter { entry in
                     (entry.key as? String).map(keys.contains) ?? false
                 })
@@ -104,11 +106,13 @@ import Foundation
         }
 
         func remove(_ survey: PostHogSurvey) {
-            lock.withLock { removeLocked(survey) }
+            storage.withSurveyState { _ in removeLocked(survey) }
         }
 
         private func removeLocked(_ survey: PostHogSurvey) {
+            let generation = storage.withSurveyState { $0 }
             var records = storage.getDictionary(forKey: .surveyProgress) ?? [:]
+            guard storage.isSurveyGenerationCurrent(generation) else { return }
             records.removeValue(forKey: key(survey))
             storage.setDictionary(forKey: .surveyProgress, contents: records)
         }

--- a/PostHog/Surveys/SurveyProgressStore.swift
+++ b/PostHog/Surveys/SurveyProgressStore.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+#if os(iOS) || TESTING
+    struct SurveyProgress: Codable {
+        var version = 1
+        let submissionId: String
+        let questionOrder: [String]
+        var questionIndex = 0
+        var responses: [String: StoredSurveyResponse] = [:]
+        var questionText: [String: String] = [:]
+        var language: String?
+
+        static func questionOrder(for survey: PostHogSurvey) -> [String] {
+            survey.questions.map { question in
+                let kind: String
+                switch question {
+                case .open: kind = "open"
+                case .link: kind = "link"
+                case .rating: kind = "rating"
+                case .singleChoice: kind = "single_choice"
+                case .multipleChoice: kind = "multiple_choice"
+                case .unknown: kind = "unknown"
+                }
+                return "\(kind):\(question.id)"
+            }
+        }
+    }
+
+    struct StoredSurveyResponse: Codable {
+        let type: Int
+        let text: String?
+        let rating: Int?
+        let choices: [String]?
+        let clicked: Bool?
+
+        init(_ response: PostHogSurveyResponse) {
+            type = response.type.rawValue
+            text = response.textValue
+            rating = response.ratingValue
+            choices = response.selectedOptions
+            clicked = response.linkClicked
+        }
+
+        var response: PostHogSurveyResponse? {
+            switch PostHogSurveyResponseType(rawValue: type) {
+            case .openEnded: return .openEnded(text)
+            case .rating: return .rating(rating)
+            case .singleChoice: return .singleChoice(choices?.first)
+            case .multipleChoice: return .multipleChoice(choices)
+            case .link: return .link(clicked ?? false)
+            case nil: return nil
+            }
+        }
+    }
+
+    final class SurveyProgressStore {
+        private let storage: PostHogStorage
+        private let lock = NSLock()
+
+        init(storage: PostHogStorage) {
+            self.storage = storage
+        }
+
+        private func key(_ survey: PostHogSurvey) -> String {
+            "\(survey.id)/\(survey.currentIteration ?? 0)"
+        }
+
+        func load(_ survey: PostHogSurvey) -> SurveyProgress? {
+            lock.withLock {
+                let records = storage.getDictionary(forKey: .surveyProgress) ?? [:]
+                guard let json = records[key(survey)] else { return nil }
+                guard let data = try? JSONSerialization.data(withJSONObject: json),
+                      let progress = try? JSONDecoder().decode(SurveyProgress.self, from: data),
+                      progress.version == 1, !progress.submissionId.isEmpty,
+                      survey.questions.indices.contains(progress.questionIndex),
+                      progress.questionOrder == SurveyProgress.questionOrder(for: survey),
+                      progress.responses.values.allSatisfy({ $0.response != nil })
+                else {
+                    removeLocked(survey)
+                    return nil
+                }
+                return progress
+            }
+        }
+
+        func save(_ progress: SurveyProgress, for survey: PostHogSurvey) {
+            lock.withLock {
+                guard let data = try? JSONEncoder().encode(progress),
+                      let json = try? JSONSerialization.jsonObject(with: data) else { return }
+                var records = storage.getDictionary(forKey: .surveyProgress) ?? [:]
+                records[key(survey)] = json
+                storage.setDictionary(forKey: .surveyProgress, contents: records)
+            }
+        }
+
+        func reconcile(_ surveys: [PostHogSurvey]) {
+            lock.withLock {
+                let keys = Set(surveys.filter(\.isActive).map(key))
+                let records = storage.getDictionary(forKey: .surveyProgress) ?? [:]
+                storage.setDictionary(forKey: .surveyProgress, contents: records.filter { entry in
+                    (entry.key as? String).map(keys.contains) ?? false
+                })
+            }
+        }
+
+        func remove(_ survey: PostHogSurvey) {
+            lock.withLock { removeLocked(survey) }
+        }
+
+        private func removeLocked(_ survey: PostHogSurvey) {
+            var records = storage.getDictionary(forKey: .surveyProgress) ?? [:]
+            records.removeValue(forKey: key(survey))
+            storage.setDictionary(forKey: .surveyProgress, contents: records)
+        }
+    }
+#endif

--- a/PostHog/Surveys/SurveyProgressStore.swift
+++ b/PostHog/Surveys/SurveyProgressStore.swift
@@ -2,7 +2,8 @@ import Foundation
 
 #if os(iOS) || TESTING
     struct SurveyProgress: Codable {
-        var version = 1
+        var version = 2
+        let resetEpoch: String
         let submissionId: String
         let questionOrder: [String]
         var questionIndex = 0
@@ -71,7 +72,7 @@ import Foundation
                 guard let json = records[key(survey)] else { return nil }
                 guard let data = try? JSONSerialization.data(withJSONObject: json),
                       let progress = try? JSONDecoder().decode(SurveyProgress.self, from: data),
-                      progress.version == 1, !progress.submissionId.isEmpty,
+                      progress.version == 2, progress.resetEpoch == generation, !progress.submissionId.isEmpty,
                       survey.questions.indices.contains(progress.questionIndex),
                       progress.questionOrder == SurveyProgress.questionOrder(for: survey),
                       progress.responses.values.allSatisfy({ $0.response != nil })
@@ -85,7 +86,8 @@ import Foundation
 
         func save(_ progress: SurveyProgress, for survey: PostHogSurvey) {
             storage.withSurveyState { generation in
-                guard let data = try? JSONEncoder().encode(progress),
+                guard progress.resetEpoch == generation,
+                      let data = try? JSONEncoder().encode(progress),
                       let json = try? JSONSerialization.jsonObject(with: data) else { return }
                 var records = storage.getDictionary(forKey: .surveyProgress) ?? [:]
                 guard storage.isSurveyGenerationCurrent(generation) else { return }

--- a/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
+++ b/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
@@ -238,6 +238,55 @@
         }
     }
 
+    /// Returns next question index based on a branching step result
+    /// - Parameters:
+    ///   - nextIndex: The next index to process
+    ///   - totalQuestions: The total number of questions in the survey
+    /// - Returns: The next question index if found, or nil if not
+    func processBranchingStep(nextIndex: Any, totalQuestions: Int) -> NextSurveyQuestion? {
+        if let nextIndex = nextIndex as? Int {
+            return .index(min(nextIndex, totalQuestions - 1))
+        }
+        if let nextIndex = nextIndex as? String, nextIndex.lowercased() == "end" {
+            return .end
+        }
+        return nil
+    }
+
+    // Gets the response bucket for a given rating response value, given the scale.
+    // For example, for a scale of 3, the buckets are "negative", "neutral" and "positive".
+    func getRatingBucketForResponseValue(scale: PostHogSurveyRatingScale, value: Int) -> String? {
+        // swiftlint:disable:previous cyclomatic_complexity
+        // Validate input ranges
+        switch scale {
+        case .threePoint where RatingBucket.threePointRange.contains(value):
+            return sentimentBucket(value, negatives: BucketThresholds.ThreePoint.negatives, neutrals: BucketThresholds.ThreePoint.neutrals)
+
+        case .fivePoint where RatingBucket.fivePointRange.contains(value):
+            return sentimentBucket(value, negatives: BucketThresholds.FivePoint.negatives, neutrals: BucketThresholds.FivePoint.neutrals)
+
+        case .sevenPoint where RatingBucket.sevenPointRange.contains(value):
+            return sentimentBucket(value, negatives: BucketThresholds.SevenPoint.negatives, neutrals: BucketThresholds.SevenPoint.neutrals)
+
+        case .tenPoint where RatingBucket.tenPointRange.contains(value):
+            switch value {
+            case BucketThresholds.TenPoint.detractors: return RatingBucket.detractors
+            case BucketThresholds.TenPoint.passives: return RatingBucket.passives
+            default: return RatingBucket.promoters
+            }
+
+        default:
+            hedgeLog("[Surveys] Cannot get rating bucket for invalid scale: \(scale). The scale must be one of: 3 (1-3), 5 (1-5), 7 (1-7), 10 (0-10).")
+            return nil
+        }
+    }
+
+    private func sentimentBucket(_ value: Int, negatives: ClosedRange<Int>, neutrals: ClosedRange<Int>) -> String {
+        if negatives.contains(value) { return RatingBucket.negative }
+        if neutrals.contains(value) { return RatingBucket.neutral }
+        return RatingBucket.positive
+    }
+
     enum RatingBucket {
         // Bucket names
         static let negative = "negative"

--- a/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
+++ b/PostHog/Surveys/Utils/PostHogSurveyMatching.swift
@@ -51,7 +51,8 @@
             beforeCacheUpdate: (([PostHogSurvey]) -> Bool)? = nil,
             callback: @escaping SurveyCallback
         ) {
-            let loadedSurveys: [PostHogSurvey] = decodeSurveys(from: remoteConfig ?? [:])
+            guard let remoteConfig else { return callback([]) }
+            let loadedSurveys: [PostHogSurvey] = decodeSurveys(from: remoteConfig)
             guard beforeCacheUpdate?(loadedSurveys) != false else { return }
 
             let eventMap = loadedSurveys.reduce(into: [String: [(surveyId: String, condition: PostHogEventCondition)]]()) { result, current in

--- a/PostHogTests/PostHogIdentityTests.swift
+++ b/PostHogTests/PostHogIdentityTests.swift
@@ -121,6 +121,11 @@ class PostHogIdentityTests {
 
         #expect(sut.getDistinctId() == "newDistinctId")
         #expect(sut.getAnonymousId() == distId)
+
+        // Finish this test's upload before the next test installs its batch recorder.
+        let events = try await getServerEvents(server)
+        #expect(events.map(\.event) == ["$identify"])
+        #expect(events.first?.distinctId == "newDistinctId")
     }
 
     @Test("captures the capture event with a custom distinctId")

--- a/PostHogTests/PostHogSurveyEventsTest.swift
+++ b/PostHogTests/PostHogSurveyEventsTest.swift
@@ -92,18 +92,17 @@ class PostHogSurveyEventsTest {
         )
     }
 
-    func getSut() -> PostHogSDK {
+    func getSut(resetStorage: Bool = true) -> PostHogSDK {
         let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9090")
         config._surveys = true
+        config.disableRemoteConfigForTesting = true
         config.flushAt = 1
         config.disableReachabilityForTesting = true
         config.disableQueueTimerForTesting = true
         config.disableFlushOnBackgroundForTesting = true
         config.captureApplicationLifecycleEvents = false
 
-        let storage = PostHogStorage(config)
-        storage.reset()
-
+        if resetStorage { PostHogStorage(config).reset() }
         return PostHogSDK.with(config)
     }
 
@@ -117,7 +116,7 @@ class PostHogSurveyEventsTest {
         return integration
     }
 
-    private func partialResponseSurvey(enabled: Bool?, branching: [String: Any]? = nil, properties: [String: Any] = [:]) throws -> PostHogSurvey {
+    func partialResponseSurvey(enabled: Bool?, branching: [String: Any]? = nil, properties: [String: Any] = [:]) throws -> PostHogSurvey {
         var first: [String: Any] = ["id": "first", "type": "open", "question": "First?", "optional": true]
         first["branching"] = branching
         var json: [String: Any] = [

--- a/PostHogTests/PostHogSurveyEventsTest.swift
+++ b/PostHogTests/PostHogSurveyEventsTest.swift
@@ -131,6 +131,244 @@ class PostHogSurveyEventsTest {
         return try decoder.decode(PostHogSurvey.self, from: JSONSerialization.data(withJSONObject: json))
     }
 
+    @Test("resumed completion and dismissal preserve seen history", arguments: [false, true])
+    func resumedSurveyPreservesSeenHistory(closeWithoutCompleting: Bool) throws {
+        let postHog = getSut()
+        defer { postHog.reset()
+            postHog.close()
+        }
+        let storage = try #require(postHog.storage)
+        storage.setDictionary(forKey: .surveySeen, contents: ["seenSurvey_previous": true])
+        postHog.config.setBeforeSend { _ in nil }
+        let survey = try partialResponseSurvey(enabled: true, properties: ["start_date": 0])
+        let first = try getSurveyIntegration(postHog)
+        first.setSurveys([survey])
+        var matching: [PostHogSurvey] = []
+        first.getActiveMatchingSurveys { matching = $0 }
+        try #require(matching.count == 1)
+        first.setShownSurvey(survey)
+        _ = first.getNextQuestion(index: 0, response: .openEnded("Saved"))
+        try #require(storage.getDictionary(forKey: .surveySeen)?["seenSurvey_previous"] as? Bool == true)
+        try #require(storage.getDictionary(forKey: .surveySeen)?["seenSurvey_partial-survey"] as? Bool == true)
+        first.uninstall(postHog)
+        let resumed = try getSurveyIntegration(postHog)
+        resumed.setSurveys([survey])
+        resumed.getActiveMatchingSurveys { matching = $0 }
+        try #require(matching.count == 1)
+        resumed.setShownSurvey(survey)
+        try #require(resumed.testActiveQuestionIndex == 1)
+        if !closeWithoutCompleting {
+            _ = resumed.getNextQuestion(index: 1, response: .openEnded("Final"))
+        }
+        resumed.testHandleSurveyClosed(survey: survey.toDisplaySurvey())
+        #expect(storage.getDictionary(forKey: .surveySeen)?["seenSurvey_previous"] as? Bool == true)
+        #expect(storage.getDictionary(forKey: .surveySeen)?["seenSurvey_partial-survey"] as? Bool == true)
+        resumed.getActiveMatchingSurveys { matching = $0 }
+        #expect(matching.isEmpty)
+        resumed.uninstall(postHog)
+    }
+
+    @Test("reset invalidates an attempt before its first answer", arguments: [false, true])
+    func resetBeforeFirstAnswer(keepAnonymousId: Bool) throws {
+        let postHog = getSut()
+        defer { postHog.reset()
+            postHog.close()
+        }
+        postHog.config.reuseAnonymousId = keepAnonymousId
+        let survey = try partialResponseSurvey(enabled: true)
+        let integration = try getSurveyIntegration(postHog)
+        var events: [PostHogEvent] = []
+        postHog.config.setBeforeSend { events.append($0)
+            return nil
+        }
+        integration.setShownSurvey(survey)
+        postHog.reset()
+        #expect(integration.getNextQuestion(index: 0, response: .openEnded("Stale")) == nil)
+        #expect(events.isEmpty)
+        #expect(SurveyProgressStore(storage: try #require(postHog.storage)).load(survey) == nil)
+        integration.uninstall(postHog)
+    }
+
+    @Test("reset in a dismissal hook preserves the new identity's attempt")
+    func resetDuringDismissalPreservesNewAttempt() throws {
+        let postHog = getSut()
+        defer { postHog.reset()
+            postHog.close()
+        }
+        let survey = try partialResponseSurvey(enabled: true)
+        let integration = try getSurveyIntegration(postHog)
+        var switchedIdentity = false
+        postHog.config.setBeforeSend { event in
+            if event.event == "survey dismissed", !switchedIdentity {
+                switchedIdentity = true
+                DispatchQueue.global().sync { postHog.reset() }
+                integration.setShownSurvey(survey)
+                _ = integration.getNextQuestion(index: 0, response: .openEnded("New identity"))
+            }
+            return nil
+        }
+        integration.setShownSurvey(survey)
+        _ = integration.getNextQuestion(index: 0, response: .openEnded("Old identity"))
+        let oldSubmission = integration.testActiveSubmissionId
+        integration.testHandleSurveyClosed(survey: survey.toDisplaySurvey())
+        try #require(switchedIdentity)
+        let storage = try #require(postHog.storage)
+        let progress = try #require(SurveyProgressStore(storage: storage).load(survey))
+        #expect(progress.submissionId != oldSubmission)
+        #expect(progress.responses["$survey_response_first"]?.text == "New identity")
+        #expect(integration.testActiveSubmissionId == progress.submissionId)
+        #expect(integration.testActiveQuestionIndex == 1)
+        integration.uninstall(postHog)
+    }
+
+    @Test("callbacks from an old render cannot mutate a new attempt", arguments: [false, true])
+    func staleRenderCallbacks(reset: Bool) throws {
+        let postHog = getSut()
+        defer { postHog.reset()
+            postHog.close()
+        }
+        let storage = try #require(postHog.storage)
+        let survey = try partialResponseSurvey(enabled: true)
+        let integration = try getSurveyIntegration(postHog)
+        var events: [PostHogEvent] = []
+        postHog.config.setBeforeSend { events.append($0)
+            return nil
+        }
+        integration.setShownSurvey(survey)
+        _ = integration.getNextQuestion(index: 0, response: .openEnded("First render"))
+        let oldCallbacks = integration.testSurveyCallbacks()
+        if reset { postHog.reset() }
+        integration.setShownSurvey(survey)
+        if reset { _ = integration.getNextQuestion(index: 0, response: .openEnded("New identity")) }
+        let submissionId = integration.testActiveSubmissionId
+        let eventCount = events.count
+        let display = survey.toDisplaySurvey()
+        oldCallbacks.shown(display)
+        #expect(oldCallbacks.response(display, 1, .openEnded("Stale response")) == nil)
+        oldCallbacks.closed(display)
+        #expect(events.count == eventCount)
+        #expect(integration.testActiveSubmissionId == submissionId)
+        let progress = try #require(SurveyProgressStore(storage: storage).load(survey))
+        #expect(progress.submissionId == submissionId)
+        #expect(progress.responses["$survey_response_first"]?.text == (reset ? "New identity" : "First render"))
+        integration.uninstall(postHog)
+    }
+
+    @Test("SDK reset waits for a survey storage transaction")
+    func resetSerializesSurveyState() throws {
+        let postHog = getSut()
+        defer { postHog.reset()
+            postHog.close()
+        }
+        let storage = try #require(postHog.storage)
+        let survey = try partialResponseSurvey(enabled: true, properties: ["start_date": 0])
+        let integration = try getSurveyIntegration(postHog)
+        postHog.config.setBeforeSend { _ in nil }
+        integration.setShownSurvey(survey)
+        _ = integration.getNextQuestion(index: 0, response: .openEnded("Old identity"))
+        postHog.identify("identity-before-reset")
+        let oldDistinctId = postHog.getDistinctId()
+        let oldAnonymousId = postHog.getAnonymousId()
+        let resetStarted = DispatchSemaphore(value: 0)
+        let resetFinished = DispatchSemaphore(value: 0)
+        let oldGeneration = storage.withSurveyState { generation in
+            DispatchQueue.global().async {
+                resetStarted.signal()
+                postHog.reset()
+                resetFinished.signal()
+            }
+            #expect(resetStarted.wait(timeout: .now() + 5) == .success)
+            // Reset must not delete identities or progress halfway through a read-modify-write.
+            #expect(resetFinished.wait(timeout: .now() + 0.05) == .timedOut)
+            #expect(postHog.getDistinctId() == oldDistinctId)
+            #expect(storage.getString(forKey: .distinctId) == oldDistinctId)
+            #expect(postHog.getAnonymousId() == oldAnonymousId)
+            #expect(storage.getString(forKey: .anonymousId) == oldAnonymousId)
+            integration.updateSurveyCache([survey], events: [:])
+            return generation
+        }
+        try #require(resetFinished.wait(timeout: .now() + 5) == .success)
+        #expect(storage.withSurveyState { $0 } != oldGeneration)
+        #expect(postHog.getDistinctId() != oldDistinctId)
+        #expect(postHog.getAnonymousId() != oldAnonymousId)
+        #expect(storage.getString(forKey: .distinctId) == nil)
+        #expect(postHog.getDistinctId() == postHog.getAnonymousId())
+        #expect(storage.getString(forKey: .anonymousId) == postHog.getAnonymousId())
+        #expect(SurveyProgressStore(storage: storage).load(survey) == nil)
+        #expect(integration.getNextQuestion(index: 1, response: .openEnded("Stale response")) == nil)
+        integration.setShownSurvey(survey)
+        _ = integration.getNextQuestion(index: 0, response: .openEnded("New identity"))
+        integration.updateSurveyCache([survey], events: [:])
+        #expect(SurveyProgressStore(storage: storage).load(survey)?.responses["$survey_response_first"]?.text == "New identity")
+        integration.uninstall(postHog)
+    }
+
+    @Test("reset during a progress read cannot restore or remove another identity's state", arguments: ["load", "save", "remove", "reconcile"], [false, true])
+    func resetDuringProgressRead(operation: String, startNewAttempt: Bool) throws {
+        let postHog = getSut()
+        defer { postHog.reset()
+            postHog.close()
+        }
+        let storage = try #require(postHog.storage)
+        let store = SurveyProgressStore(storage: storage)
+        let survey = try partialResponseSurvey(enabled: true, properties: ["start_date": 0])
+        let integration = try getSurveyIntegration(postHog)
+        postHog.config.setBeforeSend { _ in nil }
+        integration.setShownSurvey(survey)
+        _ = integration.getNextQuestion(index: 0, response: .openEnded("Old identity"))
+        let oldProgress = try #require(store.load(survey))
+        storage.testOnSurveyProgressRead = {
+            storage.testOnSurveyProgressRead = nil
+            postHog.reset()
+            if startNewAttempt {
+                integration.setShownSurvey(survey)
+                _ = integration.getNextQuestion(index: 0, response: .openEnded("New identity"))
+            }
+        }
+        switch operation {
+        case "load": #expect(store.load(survey) == nil)
+        case "save": store.save(oldProgress, for: survey)
+        case "remove": store.remove(survey)
+        default: integration.updateSurveyCache([survey], events: [:])
+        }
+        #expect(storage.testOnSurveyProgressRead == nil)
+        let progress = store.load(survey)
+        if startNewAttempt {
+            let progress = try #require(progress)
+            #expect(progress.submissionId != oldProgress.submissionId)
+            #expect(progress.responses["$survey_response_first"]?.text == "New identity")
+        } else {
+            #expect(progress == nil)
+        }
+        integration.uninstall(postHog)
+    }
+
+    @Test("reset during response validation invalidates the pending answer")
+    func resetDuringResponseValidation() throws {
+        let postHog = getSut()
+        defer { postHog.reset()
+            postHog.close()
+        }
+        let storage = try #require(postHog.storage)
+        let survey = try partialResponseSurvey(enabled: true)
+        let integration = try getSurveyIntegration(postHog)
+        var events: [PostHogEvent] = []
+        postHog.config.setBeforeSend { events.append($0)
+            return nil
+        }
+        integration.setShownSurvey(survey)
+        _ = integration.getNextQuestion(index: 0, response: .openEnded("Old identity"))
+        storage.testOnSurveyProgressRead = {
+            storage.testOnSurveyProgressRead = nil
+            postHog.reset()
+        }
+        #expect(integration.getNextQuestion(index: 1, response: .openEnded("Stale response")) == nil)
+        #expect(events.count == 1)
+        #expect(integration.testActiveSubmissionId == nil)
+        #expect(SurveyProgressStore(storage: storage).load(survey) == nil)
+        integration.uninstall(postHog)
+    }
+
     @Test("unfinished responses survive integration restart", arguments: [true, false, nil] as [Bool?])
     func resumeAfterRestart(enabled: Bool?) throws {
         let postHog = getSut()

--- a/PostHogTests/PostHogSurveyEventsTest.swift
+++ b/PostHogTests/PostHogSurveyEventsTest.swift
@@ -92,15 +92,16 @@ class PostHogSurveyEventsTest {
         )
     }
 
-    func getSut(resetStorage: Bool = true) -> PostHogSDK {
+    func getSut(resetStorage: Bool = true, installSurveys: Bool = true) -> PostHogSDK {
         let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9090")
-        config._surveys = true
+        config._surveys = installSurveys
         config.disableRemoteConfigForTesting = true
         config.flushAt = 1
         config.disableReachabilityForTesting = true
         config.disableQueueTimerForTesting = true
         config.disableFlushOnBackgroundForTesting = true
         config.captureApplicationLifecycleEvents = false
+        config.captureScreenViews = false
 
         if resetStorage { PostHogStorage(config).reset() }
         return PostHogSDK.with(config)
@@ -368,39 +369,6 @@ class PostHogSurveyEventsTest {
         integration.uninstall(postHog)
     }
 
-    @Test("unfinished responses survive integration restart", arguments: [true, false, nil] as [Bool?])
-    func resumeAfterRestart(enabled: Bool?) throws {
-        let postHog = getSut()
-        defer { postHog.close()
-            postHog.reset()
-        }
-        let survey = try partialResponseSurvey(enabled: enabled)
-        var events: [PostHogEvent] = []
-        postHog.config.setBeforeSend { events.append($0)
-            return nil
-        }
-        let first = try getSurveyIntegration(postHog)
-        first.setShownSurvey(survey)
-        _ = first.getNextQuestion(index: 0, response: .openEnded("Saved answer"))
-        let submissionId = first.testActiveSubmissionId
-        first.uninstall(postHog)
-
-        let resumed = try getSurveyIntegration(postHog)
-        resumed.setShownSurvey(survey)
-        #expect(resumed.testActiveQuestionIndex == 1)
-        #expect(resumed.testActiveSubmissionId == submissionId)
-        _ = resumed.getNextQuestion(index: 1, response: .openEnded("Final answer"))
-        let event = try #require(events.last)
-        #expect(event.properties["$survey_response_first"] as? String == "Saved answer")
-        #expect(event.properties["$survey_submission_id"] as? String == submissionId)
-        #expect(event.properties["$survey_completed"] as? Bool == true)
-        resumed.uninstall(postHog)
-        let completed = try getSurveyIntegration(postHog)
-        completed.setShownSurvey(survey)
-        #expect(completed.testActiveQuestionIndex == 0)
-        #expect(completed.testActiveSubmissionId != submissionId)
-    }
-
     @Test("dismissal and reset remove saved progress", arguments: [false, true])
     func clearSavedProgress(reset: Bool) throws {
         let postHog = getSut()
@@ -449,29 +417,7 @@ class PostHogSurveyEventsTest {
         #expect(storage.getDictionary(forKey: .surveyProgress)?["partial-survey/0"] == nil)
     }
 
-    @Test("response values survive disk round-trip", arguments: [
-        PostHogSurveyResponse.rating(nil), .rating(5), .openEnded("hello"), .openEnded(nil),
-        .singleChoice("A"), .multipleChoice(["A", "B"]), .multipleChoice(nil), .link(true), .link(false),
-    ])
-    func storedResponseRoundTrip(response: PostHogSurveyResponse) throws {
-        let restored = try #require(JSONDecoder().decode(StoredSurveyResponse.self, from: JSONEncoder().encode(StoredSurveyResponse(response))).response)
-        #expect(restored.type == response.type)
-        #expect(restored.textValue == response.textValue)
-        #expect(restored.ratingValue == response.ratingValue)
-        #expect(restored.selectedOptions == response.selectedOptions)
-        #expect(restored.linkClicked == response.linkClicked)
-    }
-
     #if os(iOS)
-        @Test("display controller starts at the restored question")
-        @MainActor
-        func restoredDisplayQuestion() throws {
-            let survey = try partialResponseSurvey(enabled: true).toDisplaySurvey(initialQuestionIndex: 1)
-            let controller = SurveyDisplayController()
-            controller.showSurvey(survey)
-            #expect(controller.currentQuestionIndex == 1)
-            #expect(!controller.showingIntroScreen)
-        }
         @Test("an invalidated attempt closes the displayed survey")
         @MainActor
         func invalidatedDisplayQuestion() throws {
@@ -512,8 +458,8 @@ class PostHogSurveyEventsTest {
         #expect(matching.isEmpty)
     }
 
-    @Test("new iterations and ended surveys do not reuse old progress")
-    func staleSurveyProgress() throws {
+    @Test("new iterations and ended or removed surveys discard old progress", arguments: [false, true])
+    func staleSurveyProgress(ended: Bool) throws {
         let postHog = getSut()
         defer { postHog.close()
             postHog.reset()
@@ -531,36 +477,45 @@ class PostHogSurveyEventsTest {
         #expect(store.load(survey) == nil)
         integration.setShownSurvey(nextIteration)
         _ = integration.getNextQuestion(index: 0, response: .openEnded("Saved"))
-        store.reconcile([])
+        let endedSurvey = try partialResponseSurvey(enabled: true, properties: ["start_date": 0, "end_date": 1, "current_iteration": 2])
+        store.reconcile(ended ? [endedSurvey] : [])
         #expect(store.load(nextIteration) == nil)
     }
 
-    @Test("restart restores the branching destination and omits skipped answers")
-    func resumeBranching() throws {
+    @Test("unavailable config preserves progress while an authoritative empty list removes it")
+    func unavailableConfigPreservesProgress() throws {
         let postHog = getSut()
         defer { postHog.close()
             postHog.reset()
         }
-        var events: [PostHogEvent] = []
-        postHog.config.setBeforeSend { events.append($0)
-            return nil
+        postHog.config.setBeforeSend { _ in nil }
+        let integration = try getSurveyIntegration(postHog)
+        let survey = try partialResponseSurvey(enabled: true, properties: ["start_date": 0])
+        integration.setSurveys([survey])
+        integration.setShownSurvey(survey)
+        _ = integration.getNextQuestion(index: 0, response: .openEnded("Saved before going offline"))
+        let store = SurveyProgressStore(storage: try #require(postHog.storage))
+        let saved = try #require(store.load(survey))
+        var callbacks = 0
+        integration.decodeAndSetSurveys(remoteConfig: nil) {
+            callbacks += 1
+            #expect($0.isEmpty)
         }
-        let survey = try partialResponseSurvey(enabled: true, properties: ["questions": [
-            ["id": "first", "type": "open", "question": "First?", "branching": ["type": "specific_question", "index": 2]],
-            ["id": "skipped", "type": "open", "question": "Skipped?"],
-            ["id": "last", "type": "open", "question": "Last?"],
-        ]])
-        let first = try getSurveyIntegration(postHog)
-        first.setShownSurvey(survey)
-        _ = first.getNextQuestion(index: 0, response: .openEnded("Saved"))
-        first.uninstall(postHog)
-        let resumed = try getSurveyIntegration(postHog)
-        resumed.setShownSurvey(survey)
-        #expect(resumed.testActiveQuestionIndex == 2)
-        _ = resumed.getNextQuestion(index: 2, response: .openEnded("Final"))
-        let event = try #require(events.last)
-        #expect(event.properties["$survey_response_first"] as? String == "Saved")
-        #expect(event.properties["$survey_response_skipped"] == nil)
+        #expect(callbacks == 1)
+        #expect(store.load(survey)?.submissionId == saved.submissionId)
+        #expect(store.load(survey)?.responses["$survey_response_first"]?.text == "Saved before going offline")
+        var matching: [PostHogSurvey] = []
+        integration.getActiveMatchingSurveys { matching = $0 }
+        #expect(matching.map(\.id) == [survey.id])
+
+        integration.decodeAndSetSurveys(remoteConfig: ["surveys": []]) {
+            callbacks += 1
+            #expect($0.isEmpty)
+        }
+        #expect(callbacks == 2)
+        #expect(store.load(survey) == nil)
+        integration.getActiveMatchingSurveys { matching = $0 }
+        #expect(matching.isEmpty)
     }
 
     @Test("showing a survey alone does not create resumable progress")

--- a/PostHogTests/PostHogSurveyEventsTest.swift
+++ b/PostHogTests/PostHogSurveyEventsTest.swift
@@ -115,6 +115,114 @@ class PostHogSurveyEventsTest {
         return integration
     }
 
+    private func partialResponseSurvey(enabled: Bool?, branching: [String: Any]? = nil) throws -> PostHogSurvey {
+        var first: [String: Any] = ["id": "first", "type": "open", "question": "First?", "optional": true]
+        first["branching"] = branching
+        var json: [String: Any] = [
+            "id": "partial-survey", "name": "Partial survey", "type": "popover",
+            "questions": [first, ["id": "second", "type": "open", "question": "Second?"]],
+        ]
+        json["enable_partial_responses"] = enabled
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(PostHogSurvey.self, from: JSONSerialization.data(withJSONObject: json))
+    }
+
+    @Test("partial responses emit cumulative answers with one submission id", arguments: [true, false, nil] as [Bool?])
+    func partialResponses(enabled: Bool?) throws {
+        let postHog = getSut()
+        defer { postHog.close()
+            postHog.reset()
+        }
+        let integration = try getSurveyIntegration(postHog)
+        let survey = try partialResponseSurvey(enabled: enabled)
+        var events: [PostHogEvent] = []
+        postHog.config.setBeforeSend { event in
+            events.append(event)
+            return nil
+        }
+
+        integration.setShownSurvey(survey)
+        let first = try #require(integration.getNextQuestion(index: 0, response: .openEnded("First answer")))
+        #expect(!first.1)
+        #expect(!integration.canShowNextSurvey())
+        #expect(events.count == (enabled == true ? 1 : 0))
+        if enabled == true {
+            let partial = try #require(events.first)
+            #expect(partial.event == "survey sent")
+            #expect(partial.properties["$survey_completed"] as? Bool == false)
+            #expect(partial.properties["$survey_response_first"] as? String == "First answer")
+            #expect(partial.properties["$survey_response_second"] == nil)
+        }
+
+        _ = integration.getNextQuestion(index: 1, response: .openEnded("Second answer"))
+        #expect(events.count == (enabled == true ? 2 : 1))
+        let completed = try #require(events.last)
+        #expect(completed.event == "survey sent")
+        #expect(completed.properties["$survey_completed"] as? Bool == true)
+        #expect(completed.properties["$survey_response_first"] as? String == "First answer")
+        #expect(completed.properties["$survey_response_second"] as? String == "Second answer")
+        let submissionId = try #require(completed.properties["$survey_submission_id"] as? String)
+        #expect(UUID(uuidString: submissionId) != nil)
+        #expect(events.allSatisfy { $0.properties["$survey_submission_id"] as? String == submissionId })
+        integration.testHandleSurveyClosed(survey: survey.toDisplaySurvey())
+        #expect(events.count == (enabled == true ? 2 : 1))
+    }
+
+    @Test("dismissed partial response keeps submission id and next attempt gets a new id")
+    func partialResponseDismissal() throws {
+        let postHog = getSut()
+        defer { postHog.close()
+            postHog.reset()
+        }
+        let integration = try getSurveyIntegration(postHog)
+        let survey = try partialResponseSurvey(enabled: true)
+        var events: [PostHogEvent] = []
+        postHog.config.setBeforeSend { event in
+            events.append(event)
+            return nil
+        }
+
+        integration.setShownSurvey(survey)
+        _ = integration.getNextQuestion(index: 0, response: .openEnded("Saved"))
+        let sent = try #require(events.last)
+        #expect(sent.event == "survey sent")
+        let submissionId = try #require(sent.properties["$survey_submission_id"] as? String)
+        integration.testHandleSurveyClosed(survey: survey.toDisplaySurvey())
+        let dismissed = try #require(events.last)
+        #expect(dismissed.event == "survey dismissed")
+        #expect(dismissed.properties["$survey_submission_id"] as? String == submissionId)
+        #expect(dismissed.properties["$survey_partially_completed"] as? Bool == true)
+        #expect(dismissed.properties["$survey_response_first"] as? String == "Saved")
+
+        integration.setShownSurvey(survey)
+        _ = integration.getNextQuestion(index: 0, response: .openEnded("New answer"))
+        let nextId = try #require(events.last?.properties["$survey_submission_id"] as? String)
+        #expect(nextId != submissionId)
+        #expect(events.count == 3)
+    }
+
+    @Test("branching to end marks a partial-enabled survey complete")
+    func partialResponseBranching() throws {
+        let postHog = getSut()
+        defer { postHog.close()
+            postHog.reset()
+        }
+        let integration = try getSurveyIntegration(postHog)
+        let survey = try partialResponseSurvey(enabled: true, branching: ["type": "end"])
+        var events: [PostHogEvent] = []
+        postHog.config.setBeforeSend { event in
+            events.append(event)
+            return nil
+        }
+        integration.setShownSurvey(survey)
+        let next = try #require(integration.getNextQuestion(index: 0, response: .openEnded(nil)))
+        #expect(next.1)
+        #expect(events.count == 1)
+        #expect(events.first?.properties["$survey_completed"] as? Bool == true)
+        #expect(events.first?.properties["$survey_response_second"] == nil)
+    }
+
     // MARK: - Survey Shown Event Tests
 
     @Test("survey shown event has correct event name and properties")

--- a/PostHogTests/PostHogSurveyEventsTest.swift
+++ b/PostHogTests/PostHogSurveyEventsTest.swift
@@ -112,10 +112,12 @@ class PostHogSurveyEventsTest {
         let integration = PostHogSurveyIntegration()
         let installResult = integration.install(postHog)
         try #require(installResult == .installed)
+        // These tests drive callbacks directly; remote refreshes must not replace their fixture surveys.
+        integration.stop()
         return integration
     }
 
-    private func partialResponseSurvey(enabled: Bool?, branching: [String: Any]? = nil) throws -> PostHogSurvey {
+    private func partialResponseSurvey(enabled: Bool?, branching: [String: Any]? = nil, properties: [String: Any] = [:]) throws -> PostHogSurvey {
         var first: [String: Any] = ["id": "first", "type": "open", "question": "First?", "optional": true]
         first["branching"] = branching
         var json: [String: Any] = [
@@ -123,9 +125,217 @@ class PostHogSurveyEventsTest {
             "questions": [first, ["id": "second", "type": "open", "question": "Second?"]],
         ]
         json["enable_partial_responses"] = enabled
+        json.merge(properties) { _, new in new }
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         return try decoder.decode(PostHogSurvey.self, from: JSONSerialization.data(withJSONObject: json))
+    }
+
+    @Test("unfinished responses survive integration restart", arguments: [true, false, nil] as [Bool?])
+    func resumeAfterRestart(enabled: Bool?) throws {
+        let postHog = getSut()
+        defer { postHog.close()
+            postHog.reset()
+        }
+        let survey = try partialResponseSurvey(enabled: enabled)
+        var events: [PostHogEvent] = []
+        postHog.config.setBeforeSend { events.append($0)
+            return nil
+        }
+        let first = try getSurveyIntegration(postHog)
+        first.setShownSurvey(survey)
+        _ = first.getNextQuestion(index: 0, response: .openEnded("Saved answer"))
+        let submissionId = first.testActiveSubmissionId
+        first.uninstall(postHog)
+
+        let resumed = try getSurveyIntegration(postHog)
+        resumed.setShownSurvey(survey)
+        #expect(resumed.testActiveQuestionIndex == 1)
+        #expect(resumed.testActiveSubmissionId == submissionId)
+        _ = resumed.getNextQuestion(index: 1, response: .openEnded("Final answer"))
+        let event = try #require(events.last)
+        #expect(event.properties["$survey_response_first"] as? String == "Saved answer")
+        #expect(event.properties["$survey_submission_id"] as? String == submissionId)
+        #expect(event.properties["$survey_completed"] as? Bool == true)
+        resumed.uninstall(postHog)
+        let completed = try getSurveyIntegration(postHog)
+        completed.setShownSurvey(survey)
+        #expect(completed.testActiveQuestionIndex == 0)
+        #expect(completed.testActiveSubmissionId != submissionId)
+    }
+
+    @Test("dismissal and reset remove saved progress", arguments: [false, true])
+    func clearSavedProgress(reset: Bool) throws {
+        let postHog = getSut()
+        defer { postHog.close()
+            postHog.reset()
+        }
+        let integration = try getSurveyIntegration(postHog)
+        let survey = try partialResponseSurvey(enabled: true)
+        let store = SurveyProgressStore(storage: try #require(postHog.storage))
+        postHog.config.setBeforeSend { _ in nil }
+        integration.setShownSurvey(survey)
+        _ = integration.getNextQuestion(index: 0, response: .openEnded("Saved"))
+        #expect(store.load(survey)?.questionIndex == 1)
+        if reset {
+            postHog.reset()
+            #expect(integration.getNextQuestion(index: 1, response: .openEnded("Stale callback")) == nil)
+        } else {
+            integration.testHandleSurveyClosed(survey: survey.toDisplaySurvey())
+        }
+        #expect(store.load(survey) == nil)
+    }
+
+    @Test("invalid persisted progress is discarded", arguments: ["version", "questionIndex", "questionOrder", "responses"])
+    func invalidSavedProgress(field: String) throws {
+        let postHog = getSut()
+        defer { postHog.close()
+            postHog.reset()
+        }
+        let integration = try getSurveyIntegration(postHog)
+        let survey = try partialResponseSurvey(enabled: true)
+        let storage = try #require(postHog.storage)
+        postHog.config.setBeforeSend { _ in nil }
+        integration.setShownSurvey(survey)
+        _ = integration.getNextQuestion(index: 0, response: .openEnded("Saved"))
+        var records = try #require(storage.getDictionary(forKey: .surveyProgress))
+        var record = try #require(records["partial-survey/0"] as? [String: Any])
+        let invalidValues: [String: Any] = [
+            "version": 99, "questionIndex": 9,
+            "questionOrder": ["open:second", "open:first"],
+            "responses": ["first": ["type": 99]],
+        ]
+        record[field] = invalidValues[field]
+        records["partial-survey/0"] = record
+        storage.setDictionary(forKey: .surveyProgress, contents: records)
+        #expect(SurveyProgressStore(storage: storage).load(survey) == nil)
+        #expect(storage.getDictionary(forKey: .surveyProgress)?["partial-survey/0"] == nil)
+    }
+
+    @Test("response values survive disk round-trip", arguments: [
+        PostHogSurveyResponse.rating(nil), .rating(5), .openEnded("hello"), .openEnded(nil),
+        .singleChoice("A"), .multipleChoice(["A", "B"]), .multipleChoice(nil), .link(true), .link(false),
+    ])
+    func storedResponseRoundTrip(response: PostHogSurveyResponse) throws {
+        let restored = try #require(JSONDecoder().decode(StoredSurveyResponse.self, from: JSONEncoder().encode(StoredSurveyResponse(response))).response)
+        #expect(restored.type == response.type)
+        #expect(restored.textValue == response.textValue)
+        #expect(restored.ratingValue == response.ratingValue)
+        #expect(restored.selectedOptions == response.selectedOptions)
+        #expect(restored.linkClicked == response.linkClicked)
+    }
+
+    #if os(iOS)
+        @Test("display controller starts at the restored question")
+        @MainActor
+        func restoredDisplayQuestion() throws {
+            let survey = try partialResponseSurvey(enabled: true).toDisplaySurvey(initialQuestionIndex: 1)
+            let controller = SurveyDisplayController()
+            controller.showSurvey(survey)
+            #expect(controller.currentQuestionIndex == 1)
+            #expect(!controller.showingIntroScreen)
+        }
+        @Test("an invalidated attempt closes the displayed survey")
+        @MainActor
+        func invalidatedDisplayQuestion() throws {
+            let survey = try partialResponseSurvey(enabled: true).toDisplaySurvey(initialQuestionIndex: 1)
+            let controller = SurveyDisplayController()
+            controller.onSurveyResponse = { _, _, _ in nil }
+            controller.showSurvey(survey)
+            controller.onNextQuestion(index: 1, response: .openEnded("Stale"))
+            #expect(controller.displayedSurvey == nil)
+        }
+    #endif
+
+    @Test("unfinished surveys remain eligible after partial answers mark them seen")
+    func resumeEligibility() throws {
+        let postHog = getSut()
+        defer { postHog.close()
+            postHog.reset()
+        }
+        postHog.config.setBeforeSend { _ in nil }
+        let survey = try partialResponseSurvey(enabled: true, properties: ["start_date": 0])
+        let integration = try getSurveyIntegration(postHog)
+        integration.setSurveys([survey])
+        var matching: [PostHogSurvey] = []
+        integration.getActiveMatchingSurveys { matching = $0 }
+        #expect(matching.count == 1)
+        integration.setShownSurvey(survey)
+        _ = integration.getNextQuestion(index: 0, response: .openEnded("Saved"))
+        #expect(postHog.storage?.getDictionary(forKey: .surveySeen)?["seenSurvey_partial-survey"] as? Bool == true)
+        integration.uninstall(postHog)
+        let resumed = try getSurveyIntegration(postHog)
+        let withInternalFlag = try partialResponseSurvey(enabled: true, properties: ["start_date": 0, "internal_targeting_flag_key": "already-answered"])
+        resumed.setSurveys([withInternalFlag])
+        resumed.getActiveMatchingSurveys { matching = $0 }
+        #expect(matching.count == 1)
+        let gated = try partialResponseSurvey(enabled: true, properties: ["start_date": 0, "linked_flag_key": "disabled-product-flag"])
+        resumed.setSurveys([gated])
+        resumed.getActiveMatchingSurveys { matching = $0 }
+        #expect(matching.isEmpty)
+    }
+
+    @Test("new iterations and ended surveys do not reuse old progress")
+    func staleSurveyProgress() throws {
+        let postHog = getSut()
+        defer { postHog.close()
+            postHog.reset()
+        }
+        let survey = try partialResponseSurvey(enabled: true, properties: ["start_date": 0, "current_iteration": 1])
+        let nextIteration = try partialResponseSurvey(enabled: true, properties: ["start_date": 0, "current_iteration": 2])
+        let integration = try getSurveyIntegration(postHog)
+        postHog.config.setBeforeSend { _ in nil }
+        integration.setShownSurvey(survey)
+        _ = integration.getNextQuestion(index: 0, response: .openEnded("Saved"))
+        let store = SurveyProgressStore(storage: try #require(postHog.storage))
+        #expect(store.load(survey) != nil)
+        #expect(store.load(nextIteration) == nil)
+        store.reconcile([nextIteration])
+        #expect(store.load(survey) == nil)
+        integration.setShownSurvey(nextIteration)
+        _ = integration.getNextQuestion(index: 0, response: .openEnded("Saved"))
+        store.reconcile([])
+        #expect(store.load(nextIteration) == nil)
+    }
+
+    @Test("restart restores the branching destination and omits skipped answers")
+    func resumeBranching() throws {
+        let postHog = getSut()
+        defer { postHog.close()
+            postHog.reset()
+        }
+        var events: [PostHogEvent] = []
+        postHog.config.setBeforeSend { events.append($0)
+            return nil
+        }
+        let survey = try partialResponseSurvey(enabled: true, properties: ["questions": [
+            ["id": "first", "type": "open", "question": "First?", "branching": ["type": "specific_question", "index": 2]],
+            ["id": "skipped", "type": "open", "question": "Skipped?"],
+            ["id": "last", "type": "open", "question": "Last?"],
+        ]])
+        let first = try getSurveyIntegration(postHog)
+        first.setShownSurvey(survey)
+        _ = first.getNextQuestion(index: 0, response: .openEnded("Saved"))
+        first.uninstall(postHog)
+        let resumed = try getSurveyIntegration(postHog)
+        resumed.setShownSurvey(survey)
+        #expect(resumed.testActiveQuestionIndex == 2)
+        _ = resumed.getNextQuestion(index: 2, response: .openEnded("Final"))
+        let event = try #require(events.last)
+        #expect(event.properties["$survey_response_first"] as? String == "Saved")
+        #expect(event.properties["$survey_response_skipped"] == nil)
+    }
+
+    @Test("showing a survey alone does not create resumable progress")
+    func noProgressBeforeAnswer() throws {
+        let postHog = getSut()
+        defer { postHog.close()
+            postHog.reset()
+        }
+        let integration = try getSurveyIntegration(postHog)
+        let survey = try partialResponseSurvey(enabled: true)
+        integration.setShownSurvey(survey)
+        #expect(SurveyProgressStore(storage: try #require(postHog.storage)).load(survey) == nil)
     }
 
     @Test("partial responses emit cumulative answers with one submission id", arguments: [true, false, nil] as [Bool?])

--- a/PostHogTests/PostHogSurveyResumeTest.swift
+++ b/PostHogTests/PostHogSurveyResumeTest.swift
@@ -1,0 +1,130 @@
+import Foundation
+@testable import PostHog
+import Testing
+
+#if os(iOS)
+    extension PostHogSurveyEventsTest {
+        @MainActor
+        private func renderingSDK(resetStorage: Bool, language: String) -> (PostHogSDK, PostHogSurveyIntegration, SurveyDisplayController) {
+            let postHog = getSut(resetStorage: resetStorage, installSurveys: false)
+            postHog.config._surveys = true
+            postHog.config._surveysConfig.overrideDisplayLanguage = language
+            let integration = PostHogSurveyIntegration()
+            postHog.addIntegration(integration)
+            // Fixture surveys are supplied directly; background refresh must not replace them.
+            integration.stop()
+            integration.hasActiveSurveyWindow = { true }
+            let controller = SurveyDisplayController()
+            let delegate = PostHogSurveysDefaultDelegate()
+            delegate.setDisplayControllerForTesting(controller)
+            postHog.config._surveysConfig.surveysDelegate = delegate
+            return (postHog, integration, controller)
+        }
+
+        private func branchingResumeSurvey(enabled: Bool?) throws -> PostHogSurvey {
+            try partialResponseSurvey(enabled: enabled, properties: [
+                "start_date": 0,
+                "questions": [
+                    ["id": "first", "type": "open", "question": "Original first?", "branching": ["type": "specific_question", "index": 2], "translations": ["fr": ["question": "Premiere question?"]]],
+                    ["id": "skipped", "type": "open", "question": "Skipped?"],
+                    ["id": "last", "type": "open", "question": "Last?", "translations": ["fr": ["question": "Derniere question?"]]],
+                ],
+                "translations": ["en": ["name": "English survey"], "fr": ["name": "French survey"]],
+                "appearance": ["displayIntroScreen": true, "introScreenHeader": "Welcome", "displayThankYouMessage": false],
+            ])
+        }
+
+        private func expectResumedCompletion(_ completed: PostHogEvent, submissionId: String) throws {
+            #expect(completed.properties["$survey_response_first"] as? String == "Saved answer")
+            #expect(completed.properties["$survey_response_last"] as? String == "New answer")
+            #expect(completed.properties["$survey_response_skipped"] == nil)
+            #expect(completed.properties["$survey_submission_id"] as? String == submissionId)
+            #expect(completed.properties["$survey_completed"] as? Bool == true)
+            #expect(completed.properties["$survey_language"] as? String == "fr")
+            let questions = try #require(completed.properties["$survey_questions"] as? [[String: Any]])
+            #expect(questions.count == 3)
+            #expect(questions[0]["question"] as? String == "Original first?")
+            #expect(questions[2]["question"] as? String == "Derniere question?")
+        }
+
+        private func expectResumedDismissal(_ dismissed: PostHogEvent, submissionId: String) throws {
+            #expect(dismissed.properties["$survey_submission_id"] as? String == submissionId)
+            #expect(dismissed.properties["$survey_language"] as? String == "en")
+            #expect(dismissed.properties["$survey_response_first"] as? String == "Saved answer")
+            #expect(dismissed.properties["$survey_response_last"] == nil)
+            let questions = try #require(dismissed.properties["$survey_questions"] as? [[String: Any]])
+            #expect(questions[0]["question"] as? String == "Original first?")
+        }
+
+        @MainActor
+        @Test("a fresh SDK renders the saved branch and preserves answer attribution", arguments: [(true, false), (false, false), (nil, false), (true, true)] as [(Bool?, Bool)])
+        func resumeAfterRestart(enabled: Bool?, dismiss: Bool) async throws {
+            let survey = try branchingResumeSurvey(enabled: enabled)
+            let (firstSDK, first, firstController) = renderingSDK(resetStorage: true, language: "en")
+            defer { firstSDK.close() }
+            let firstStorage = try #require(firstSDK.storage)
+            let firstShown = AsyncLatch()
+            var firstEvents: [PostHogEvent] = []
+            firstSDK.config.setBeforeSend {
+                firstEvents.append($0)
+                if $0.event == "survey shown" { firstShown.signal() }
+                return nil
+            }
+            first.setSurveys([survey])
+            first.showNextSurvey()
+            await firstShown.wait(timeout: 2)
+            try #require(firstController.displayedSurvey != nil)
+            #expect(firstController.currentQuestionIndex == 0)
+            #expect(firstController.showingIntroScreen)
+            firstController.dismissIntroScreen()
+            firstController.onNextQuestion(index: firstController.currentQuestionIndex, response: .openEnded("Saved answer"))
+            #expect(firstController.currentQuestionIndex == 2)
+            let saved = try #require(SurveyProgressStore(storage: firstStorage).load(survey))
+            #expect(firstEvents.map(\.event) == (enabled == true ? ["survey shown", "survey sent"] : ["survey shown"]))
+            #expect(firstEvents.last?.properties["$survey_language"] as? String == "en")
+            firstSDK.close()
+            #expect(first.testActiveSubmissionId == nil)
+            #expect(firstController.displayedSurvey == nil)
+
+            let (secondSDK, resumed, controller) = renderingSDK(resetStorage: false, language: "fr")
+            defer { secondSDK.close()
+                secondSDK.reset()
+            }
+            let secondStorage = try #require(secondSDK.storage)
+            #expect(secondStorage !== firstStorage)
+            #expect(secondStorage.appFolderUrl == firstStorage.appFolderUrl)
+            let shown = AsyncLatch()
+            var events: [PostHogEvent] = []
+            secondSDK.config.setBeforeSend {
+                events.append($0)
+                if $0.event == "survey shown" { shown.signal() }
+                return nil
+            }
+            resumed.setSurveys([survey])
+            resumed.showNextSurvey()
+            await shown.wait(timeout: 2)
+            let display = try #require(controller.displayedSurvey)
+            #expect(display.name == "French survey")
+            #expect(display.questions[0].question == "Premiere question?")
+            #expect(controller.currentQuestionIndex == 2)
+            #expect(display.questions[controller.currentQuestionIndex].id == "last")
+            #expect(!controller.showingIntroScreen)
+            #expect(events.map(\.event) == ["survey shown"])
+            if dismiss {
+                controller.dismissSurvey()
+                #expect(events.map(\.event) == ["survey shown", "survey dismissed"])
+                let dismissed = try #require(events.last)
+                try expectResumedDismissal(dismissed, submissionId: saved.submissionId)
+                #expect(SurveyProgressStore(storage: secondStorage).load(survey) == nil)
+                return
+            }
+            controller.onNextQuestion(index: controller.currentQuestionIndex, response: .openEnded("New answer"))
+            #expect(controller.isSurveyCompleted)
+            #expect(controller.displayedSurvey == nil)
+            #expect(events.map(\.event) == ["survey shown", "survey sent"])
+            let completed = try #require(events.last)
+            try expectResumedCompletion(completed, submissionId: saved.submissionId)
+            #expect(SurveyProgressStore(storage: secondStorage).load(survey) == nil)
+        }
+    }
+#endif

--- a/PostHogTests/PostHogSurveySharedStorageTest.swift
+++ b/PostHogTests/PostHogSurveySharedStorageTest.swift
@@ -115,6 +115,14 @@ extension PostHogSurveyEventsTest {
         postHog.reset()
         #expect(storage.getString(forKey: .surveyResetEpoch) != oldEpoch)
         #expect(storage.isSurveyGenerationCurrent(oldEpoch) == false)
+        postHog.config.setBeforeSend { _ in nil }
+        let survey = try partialResponseSurvey(enabled: true)
+        let integration = try getSurveyIntegration(postHog)
+        integration.setShownSurvey(survey)
+        _ = integration.getNextQuestion(index: 0, response: .openEnded("New identity answer"))
+        let progress = try #require(SurveyProgressStore(storage: PostHogStorage(postHog.config)).load(survey))
+        #expect(progress.questionIndex == 1)
+        #expect(progress.responses["$survey_response_first"]?.text == "New identity answer")
     }
 
     @Test("progress without a reset epoch is discarded")

--- a/PostHogTests/PostHogSurveySharedStorageTest.swift
+++ b/PostHogTests/PostHogSurveySharedStorageTest.swift
@@ -1,0 +1,264 @@
+import Foundation
+@testable import PostHog
+import Testing
+
+extension PostHogSurveyEventsTest {
+    @Test("a failed epoch rotation revokes progress for every storage instance")
+    func immutableEpochRevokesSharedProgress() throws {
+        let first = getSut()
+        defer { first.close() }
+        let second = getSut(resetStorage: false)
+        defer { second.close() }
+        second.config.setBeforeSend { _ in nil }
+        let storage = try #require(first.storage)
+        let epochFile = storage.url(forKey: .surveyResetEpoch)
+        let survey = try partialResponseSurvey(enabled: true)
+        let integration = try getSurveyIntegration(first)
+        integration.setShownSurvey(survey)
+        var events: [PostHogEvent] = []
+        first.config.setBeforeSend { events.append($0)
+            return nil
+        }
+        try FileManager.default.setAttributes([.immutable: true], ofItemAtPath: epochFile.path)
+        defer { try? FileManager.default.setAttributes([.immutable: false], ofItemAtPath: epochFile.path)
+            second.reset()
+        }
+        second.reset()
+        #expect(integration.getNextQuestion(index: 0, response: .openEnded("Old process")) == nil)
+        #expect(events.isEmpty)
+        #expect(SurveyProgressStore(storage: storage).load(survey) == nil)
+        try FileManager.default.setAttributes([.immutable: false], ofItemAtPath: epochFile.path)
+        first.reset()
+        let recovered = try getSurveyIntegration(second)
+        recovered.setShownSurvey(survey)
+        _ = recovered.getNextQuestion(index: 0, response: .openEnded("Recovered"))
+        #expect(SurveyProgressStore(storage: storage).load(survey)?.responses["$survey_response_first"]?.text == "Recovered")
+    }
+
+    @Test("a new shared-storage attempt captures events before resetting SDK warms its identity")
+    func surveyEventsDuringResetIdentityGap() throws {
+        let first = getSut()
+        defer { first.close() }
+        let storage = try #require(first.storage)
+        var generateDuringReset: (() -> Void)?
+        let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9090")
+        config._surveys = true
+        config.disableRemoteConfigForTesting = true
+        config.captureApplicationLifecycleEvents = false
+        config.disableQueueTimerForTesting = true
+        config.getAnonymousId = { uuid in
+            generateDuringReset?()
+            // Preserve the identity created by the other process during this callback.
+            return storage.getString(forKey: .anonymousId).flatMap(UUID.init(uuidString:)) ?? uuid
+        }
+        let second = PostHogSDK.with(config)
+        defer { second.close() }
+        let survey = try partialResponseSurvey(enabled: true)
+        let integration = try getSurveyIntegration(first)
+        var events: [PostHogEvent] = []
+        first.config.setBeforeSend { events.append($0)
+            return nil
+        }
+        var enteredGap = false
+        generateDuringReset = {
+            enteredGap = true
+            #expect(storage.getString(forKey: .anonymousId) == nil)
+            #expect(storage.getString(forKey: .distinctId) == nil)
+            integration.setShownSurvey(survey)
+            integration.testHandleSurveyShown(survey: survey.toDisplaySurvey())
+            _ = integration.getNextQuestion(index: 0, response: .openEnded("First"))
+            _ = integration.getNextQuestion(index: 1, response: .openEnded("Final"))
+        }
+        defer { generateDuringReset = nil }
+        second.reset()
+        try #require(enteredGap)
+        #expect(events.map(\.event) == ["survey shown", "survey sent", "survey sent"])
+        #expect(events.allSatisfy { $0.distinctId == second.getDistinctId() })
+        #expect(events.last?.properties["$survey_response_first"] as? String == "First")
+    }
+
+    @Test("fresh SDK shown events use the newly persisted anonymous identity")
+    func freshSurveyEventIdentity() throws {
+        let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9090")
+        config._surveys = true
+        config.disableRemoteConfigForTesting = true
+        config.captureApplicationLifecycleEvents = false
+        config.disableQueueTimerForTesting = true
+        let storage = PostHogStorage(config)
+        storage.reset()
+        try #require(storage.getString(forKey: .anonymousId) == nil)
+        try #require(storage.getString(forKey: .distinctId) == nil)
+        let postHog = PostHogSDK.with(config)
+        defer { postHog.close() }
+        var captured: PostHogEvent?
+        config.setBeforeSend { captured = $0
+            return nil
+        }
+        let survey = try partialResponseSurvey(enabled: true)
+        let integration = try getSurveyIntegration(postHog)
+        integration.setShownSurvey(survey)
+        integration.testHandleSurveyShown(survey: survey.toDisplaySurvey())
+        let event = try #require(captured)
+        #expect(event.event == "survey shown")
+        #expect(event.distinctId == storage.getString(forKey: .anonymousId))
+    }
+
+    @Test("reset atomically replaces a read-only epoch file")
+    func resetReplacesReadOnlyEpoch() throws {
+        let postHog = getSut()
+        defer { postHog.close() }
+        let storage = try #require(postHog.storage)
+        let oldEpoch = storage.withSurveyState { $0 }
+        let epochFile = storage.url(forKey: .surveyResetEpoch)
+        try FileManager.default.setAttributes([.posixPermissions: 0o400], ofItemAtPath: epochFile.path)
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: epochFile.path) }
+        postHog.reset()
+        #expect(storage.getString(forKey: .surveyResetEpoch) != oldEpoch)
+        #expect(storage.isSurveyGenerationCurrent(oldEpoch) == false)
+    }
+
+    @Test("progress without a reset epoch is discarded")
+    func ownerlessProgressIsDiscarded() throws {
+        let postHog = getSut()
+        defer { postHog.close() }
+        postHog.config.setBeforeSend { _ in nil }
+        let storage = try #require(postHog.storage)
+        let survey = try partialResponseSurvey(enabled: true)
+        let integration = try getSurveyIntegration(postHog)
+        integration.setShownSurvey(survey)
+        _ = integration.getNextQuestion(index: 0, response: .openEnded("Ownerless"))
+        var records = try #require(storage.getDictionary(forKey: .surveyProgress))
+        let key = try #require(records.keys.first)
+        var record = try #require(records[key] as? [String: Any])
+        record.removeValue(forKey: "resetEpoch")
+        record["version"] = 1
+        records[key] = record
+        storage.setDictionary(forKey: .surveyProgress, contents: records)
+        #expect(SurveyProgressStore(storage: storage).load(survey) == nil)
+        #expect(storage.getDictionary(forKey: .surveyProgress)?.isEmpty == true)
+    }
+
+    @Test("survey progress fails closed when the shared lock cannot be opened")
+    func unavailableSurveyCoordination() throws {
+        let postHog = getSut()
+        defer { postHog.close() }
+        postHog.config.setBeforeSend { _ in nil }
+        let storage = try #require(postHog.storage)
+        let survey = try partialResponseSurvey(enabled: true)
+        let integration = try getSurveyIntegration(postHog)
+        integration.setShownSurvey(survey)
+        _ = integration.getNextQuestion(index: 0, response: .openEnded("Saved"))
+        let store = SurveyProgressStore(storage: storage)
+        let progress = try #require(store.load(survey))
+        let lockFile = storage.appFolderUrl.appendingPathComponent("posthog.surveyState.lock")
+        try FileManager.default.removeItem(at: lockFile)
+        try FileManager.default.createDirectory(at: lockFile, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: lockFile) }
+        #expect(store.load(survey) == nil)
+        store.save(progress, for: survey)
+        #expect(integration.getNextQuestion(index: 1, response: .openEnded("Rejected")) == nil)
+    }
+
+    @Test("independent storage instances initialize one durable survey epoch")
+    func sharedSurveyEpochInitialization() async throws {
+        let postHog = getSut()
+        defer { postHog.close() }
+        let storage = try #require(postHog.storage)
+        storage.remove(key: .surveyResetEpoch)
+        let instances = (0 ..< 8).map { _ in PostHogStorage(postHog.config) }
+        let epochs = await withTaskGroup(of: String.self, returning: [String].self) { group in
+            for instance in instances {
+                group.addTask { instance.withSurveyState { $0 } }
+            }
+            var epochs: [String] = []
+            for await epoch in group {
+                epochs.append(epoch)
+            }
+            return epochs
+        }
+        #expect(Set(epochs).count == 1)
+        #expect(epochs.first == storage.getString(forKey: .surveyResetEpoch))
+    }
+
+    @Test("shared storage rejects an old process's progress after reset", arguments: [false, true])
+    func sharedStorageResetRejectsStaleProgress(keepAnonymousId: Bool) throws {
+        let first = getSut()
+        defer { first.close() }
+        first.config.setBeforeSend { _ in nil }
+        if !keepAnonymousId { first.identify("old-process-user") }
+        let second = getSut(resetStorage: false)
+        defer { second.reset()
+            second.close()
+        }
+        second.config.reuseAnonymousId = keepAnonymousId
+        second.config.setBeforeSend { _ in nil }
+        let firstStorage = try #require(first.storage)
+        let secondStorage = try #require(second.storage)
+        try #require(firstStorage !== secondStorage)
+        try #require(firstStorage.appFolderUrl == secondStorage.appFolderUrl)
+        let oldIdentity = first.getDistinctId()
+        try #require(second.getDistinctId() == oldIdentity)
+        let survey = try partialResponseSurvey(enabled: true)
+        let oldIntegration = try getSurveyIntegration(first)
+        oldIntegration.setShownSurvey(survey)
+        _ = oldIntegration.getNextQuestion(index: 0, response: .openEnded("Old process"))
+        let firstStore = SurveyProgressStore(storage: firstStorage)
+        let oldProgress = try #require(firstStore.load(survey))
+        second.reset()
+        #expect((second.getDistinctId() == oldIdentity) == keepAnonymousId)
+        firstStore.save(oldProgress, for: survey)
+        #expect(SurveyProgressStore(storage: secondStorage).load(survey) == nil)
+        let freshIntegration = try getSurveyIntegration(second)
+        freshIntegration.setShownSurvey(survey)
+        _ = freshIntegration.getNextQuestion(index: 0, response: .openEnded("New process"))
+        let freshSubmission = freshIntegration.testActiveSubmissionId
+        firstStore.save(oldProgress, for: survey)
+        #expect(firstStore.load(survey)?.submissionId == freshSubmission)
+        #expect(oldIntegration.getNextQuestion(index: 1, response: .openEnded("Stale callback")) == nil)
+        let resumed = try getSurveyIntegration(first)
+        resumed.setShownSurvey(survey)
+        #expect(resumed.testActiveSubmissionId == freshSubmission)
+        var captured: PostHogEvent?
+        first.config.setBeforeSend { captured = $0
+            return nil
+        }
+        _ = resumed.getNextQuestion(index: 1, response: .openEnded("Fresh response"))
+        let event = try #require(captured)
+        #expect(event.distinctId == second.getDistinctId())
+        #expect(event.properties["$survey_response_first"] as? String == "New process")
+    }
+
+    @Test("reset in another storage instance waits for an in-flight progress write")
+    func sharedStorageResetWaitsForWrite() throws {
+        let first = getSut()
+        defer { first.close() }
+        first.config.setBeforeSend { _ in nil }
+        let second = getSut(resetStorage: false)
+        defer { second.reset()
+            second.close()
+        }
+        let storage = try #require(first.storage)
+        let secondStorage = try #require(second.storage)
+        let survey = try partialResponseSurvey(enabled: true)
+        let integration = try getSurveyIntegration(first)
+        integration.setShownSurvey(survey)
+        _ = integration.getNextQuestion(index: 0, response: .openEnded("Old process"))
+        let store = SurveyProgressStore(storage: storage)
+        let progress = try #require(store.load(survey))
+        let resetStarted = DispatchSemaphore(value: 0)
+        let resetFinished = DispatchSemaphore(value: 0)
+        storage.testOnSurveyProgressRead = {
+            storage.testOnSurveyProgressRead = nil
+            DispatchQueue.global().async {
+                resetStarted.signal()
+                second.reset()
+                resetFinished.signal()
+            }
+            #expect(resetStarted.wait(timeout: .now() + 5) == .success)
+            #expect(resetFinished.wait(timeout: .now() + 0.05) == .timedOut)
+        }
+        store.save(progress, for: survey)
+        try #require(resetFinished.wait(timeout: .now() + 5) == .success)
+        #expect(SurveyProgressStore(storage: secondStorage).load(survey) == nil)
+    }
+}

--- a/PostHogTests/PostHogSurveysTest.swift
+++ b/PostHogTests/PostHogSurveysTest.swift
@@ -1607,11 +1607,20 @@ enum PostHogSurveysTest {
         }
 
         @Test("returns surveys that match internal targeting flags")
-        func returnsSurveysThatMatchInternalTargetingFlags() async {
+        func returnsSurveysThatMatchInternalTargetingFlags() async throws {
             let sut = getSut(surveys: [surveyWithEnabledInternalTargetingFlag])
+            let surveys = sut.decodeSurveys(from: [
+                "surveys": try parseSurveys(surveyWithEnabledInternalTargetingFlag),
+            ])
+            sut.updateSurveyCache(surveys, events: [:])
+            await withCheckedContinuation { continuation in
+                postHog.remoteConfig?.reloadFeatureFlags { _ in
+                    continuation.resume()
+                }
+            }
 
             let matchedSurveys: [PostHogSurvey] = await withCheckedContinuation { continuation in
-                sut.getActiveMatchingSurveys(forceReload: true) {
+                sut.getActiveMatchingSurveys {
                     continuation.resume(with: .success($0))
                 }
             }

--- a/PostHogTests/PostHogSurveysTest.swift
+++ b/PostHogTests/PostHogSurveysTest.swift
@@ -1788,9 +1788,39 @@ enum PostHogSurveysTest {
 
     @Suite("Test conditional branching", .serialized)
     class TestConfitionalBranchingLogic {
+        let postHog: PostHogSDK
+        let server = MockPostHogServer()
+
+        init() {
+            server.start()
+            let config = PostHogConfig(projectToken: "test_survey_branching", host: "http://localhost:9090")
+            config._surveys = true
+            config.enableSwizzling = false
+            config.disableRemoteConfigForTesting = true
+            config.disableQueueTimerForTesting = true
+            config.disableFlushOnBackgroundForTesting = true
+            config.captureApplicationLifecycleEvents = false
+            config.setBeforeSend { _ in nil }
+            PostHogStorage(config).reset()
+            postHog = PostHogSDK.with(config)
+        }
+
+        deinit {
+            postHog.close()
+            server.stop()
+        }
+
+        private func getSut() -> PostHogSurveyIntegration {
+            let sut = PostHogSurveyIntegration()
+            PostHogSurveyIntegration.clearInstalls()
+            #expect(sut.install(postHog) == .installed)
+            sut.stop()
+            return sut
+        }
+
         @Test("returns next question index when no branching")
         func returnsNextQuestionIndexWhenNoBranching() throws {
-            let sut = PostHogSurveyIntegration()
+            let sut = getSut()
 
             let survey = PostHogSurvey.testInstance(
                 name: "test survey",
@@ -1827,7 +1857,7 @@ enum PostHogSurveysTest {
 
         @Test("completes survey with single question")
         func completesSurveyWithSingleQuestion() throws {
-            let sut = PostHogSurveyIntegration()
+            let sut = getSut()
 
             let survey = PostHogSurvey.testInstance(
                 name: "test survey",
@@ -1848,7 +1878,7 @@ enum PostHogSurveysTest {
 
         @Test("ends survey when branching is end")
         func endsSurveyWhenBranchingIsEnd() throws {
-            let sut = PostHogSurveyIntegration()
+            let sut = getSut()
 
             let survey = PostHogSurvey.testInstance(
                 name: "test survey",
@@ -1870,7 +1900,7 @@ enum PostHogSurveysTest {
 
         @Test("jumps to specific question when branching to specific question")
         func jumpsToSpecificQuestionWhenBranchingToSpecificQuestion() throws {
-            let sut = PostHogSurveyIntegration()
+            let sut = getSut()
 
             let survey = PostHogSurvey.testInstance(
                 name: "test survey",
@@ -1913,7 +1943,7 @@ enum PostHogSurveysTest {
 
         @Test("jumps to last question when branching is out of bounds")
         func jumpsToLastQuestionWhenBranchingOutOfBounds() throws {
-            let sut = PostHogSurveyIntegration()
+            let sut = getSut()
 
             let survey = PostHogSurvey.testInstance(
                 name: "test survey",
@@ -1943,7 +1973,7 @@ enum PostHogSurveysTest {
 
         @Test("handles single choice response based branching")
         func handlesSingleChoiceResponseBasedBranching() throws {
-            let sut = PostHogSurveyIntegration()
+            let sut = getSut()
 
             let survey = PostHogSurvey.testInstance(
                 name: "test survey",
@@ -2022,7 +2052,7 @@ enum PostHogSurveysTest {
 
         @Test("handles rating response based branching for scale 3")
         func handlesRatingResponseBasedBranchingForScale3() {
-            let sut = PostHogSurveyIntegration()
+            let sut = getSut()
 
             let survey = PostHogSurvey.testInstance(
                 name: "test survey",
@@ -2064,7 +2094,7 @@ enum PostHogSurveysTest {
 
         @Test("handles rating response based branching for scale 5")
         func handlesRatingResponseBasedBranchingForScale5() {
-            let sut = PostHogSurveyIntegration()
+            let sut = getSut()
 
             let survey = PostHogSurvey.testInstance(
                 name: "test survey",
@@ -2109,7 +2139,7 @@ enum PostHogSurveysTest {
 
         @Test("handles rating response based branching for scale 7")
         func handlesRatingResponseBasedBranchingForScale7() {
-            let sut = PostHogSurveyIntegration()
+            let sut = getSut()
 
             let survey = PostHogSurvey.testInstance(
                 name: "test survey",
@@ -2156,7 +2186,7 @@ enum PostHogSurveysTest {
 
         @Test("handles NPS rating response based branching for scale 10")
         func handlesNPSRatingResponseBasedBranchingForScale10() {
-            let sut = PostHogSurveyIntegration()
+            let sut = getSut()
 
             let survey = PostHogSurvey.testInstance(
                 name: "test survey",

--- a/PostHogTests/StoredSurveyResponseTest.swift
+++ b/PostHogTests/StoredSurveyResponseTest.swift
@@ -1,0 +1,18 @@
+import Foundation
+@testable import PostHog
+import Testing
+
+struct StoredSurveyResponseTest {
+    @Test("stored response values survive JSON encoding and decoding", arguments: [
+        PostHogSurveyResponse.rating(nil), .rating(5), .openEnded("hello"), .openEnded(nil),
+        .singleChoice("A"), .multipleChoice(["A", "B"]), .multipleChoice(nil), .link(true), .link(false),
+    ])
+    func storedResponseRoundTrip(response: PostHogSurveyResponse) throws {
+        let restored = try #require(JSONDecoder().decode(StoredSurveyResponse.self, from: JSONEncoder().encode(StoredSurveyResponse(response))).response)
+        #expect(restored.type == response.type)
+        #expect(restored.textValue == response.textValue)
+        #expect(restored.ratingValue == response.ratingValue)
+        #expect(restored.selectedOptions == response.selectedOptions)
+        #expect(restored.linkClicked == response.linkClicked)
+    }
+}

--- a/api/posthog-ios.public-api.txt
+++ b/api/posthog-ios.public-api.txt
@@ -124,6 +124,7 @@ PostHog | PostHogDisplaySurvey | class | @objc class PostHogDisplaySurvey | c:@M
 PostHog | PostHogDisplaySurvey.appearance | property | let appearance: PostHogDisplaySurveyAppearance? | s:7PostHog0aB13DisplaySurveyC10appearanceAA0abcD10AppearanceCSgvp
 PostHog | PostHogDisplaySurvey.endDate | property | let endDate: Date? | s:7PostHog0aB13DisplaySurveyC7endDate10Foundation0F0VSgvp
 PostHog | PostHogDisplaySurvey.id | property | let id: String | s:7PostHog0aB13DisplaySurveyC2idSSvp
+PostHog | PostHogDisplaySurvey.initialQuestionIndex | property | let initialQuestionIndex: Int | s:7PostHog0aB13DisplaySurveyC20initialQuestionIndexSivp
 PostHog | PostHogDisplaySurvey.name | property | let name: String | s:7PostHog0aB13DisplaySurveyC4nameSSvp
 PostHog | PostHogDisplaySurvey.questions | property | let questions: [PostHogDisplaySurveyQuestion] | s:7PostHog0aB13DisplaySurveyC9questionsSayAA0abcD8QuestionCGvp
 PostHog | PostHogDisplaySurvey.startDate | property | let startDate: Date? | s:7PostHog0aB13DisplaySurveyC9startDate10Foundation0F0VSgvp


### PR DESCRIPTION
## :bulb: Motivation and Context

Add partial responses and persistent resume to iOS surveys, moving toward **survey feature parity across all PostHog SDKs**, with [posthog-js](https://github.com/PostHog/posthog-js/blob/f1395b6ce91af909ae0fdf095886f251f569a891/packages/browser/src/extensions/surveys.tsx) as the reference. Closes #447. Auto-submit is separate in #808.

After submitting an answer, users can restart and resume at the next branching destination with saved answers and the same `$survey_submission_id`. With `enable_partial_responses=true`, each answer emits a cumulative `survey sent` event; false/absent emits only on completion. Resume works in both modes.

Key behavior:

- Completion, dismissal, reset, removed/ended surveys and incompatible questions clear progress. Unavailable configuration preserves it; a confirmed empty list clears it.
- Reset invalidates saved answers and stale callbacks across app-group processes, including when the anonymous ID is reused. Old attempts cannot overwrite newer ones.
- Historical question wording is retained. Completion uses the current answer language; dismissal uses the last saved answer language.
- Resuming bypasses seen/internal targeting checks; other targeting still applies. Custom renderers opt in with `supportsSurveyResume = true` and must then honor `initialQuestionIndex`; others start fresh without restored answers or submission IDs.

### Review path

1. [Resume test](https://github.com/PostHog/posthog-ios/blob/49ecdc180/PostHogTests/PostHogSurveyResumeTest.swift): fresh SDK, restored branch, cumulative answers and language attribution.
2. [Progress store](https://github.com/PostHog/posthog-ios/blob/49ecdc180/PostHog/Surveys/SurveyProgressStore.swift) and [integration](https://github.com/PostHog/posthog-ios/blob/49ecdc180/PostHog/Surveys/PostHogSurveyIntegration.swift): persistence, eligibility and event lifecycle.
3. [Storage](https://github.com/PostHog/posthog-ios/blob/49ecdc180/PostHog/PostHogStorage.swift) and [SDK](https://github.com/PostHog/posthog-ios/blob/49ecdc180/PostHog/PostHogSDK.swift): cross-process reset coordination and configured-delegate cleanup on close.

## :green_heart: How did you test it?

`make test` passes: 873 Swift Testing tests and 172 XCTest cases. Formatting, lint and the CodeScene check pass. A regression that failed before the opt-in fix now covers legacy, opted-out and opted-in delegates, including eligibility, fresh IDs and response payloads.

The public API snapshot and SwiftLint checks pass in CI. Local iOS platform builds are blocked by mismatched Xcode/CoreDevice components; platform build verification runs in CI.

Regression tests cover restart, branching, payloads, reset and stale callbacks. Restart tests recreate SDKs through the real delegate/controller; OS process death was not exercised.

## :pencil: Checklist

- [x] Regression tests and independent review completed.
- [x] Delegate documentation and changeset included.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Codex implemented the changes with independent QA agents; human review is required.
