### PR TITLE
fix: make layout observation lifecycle thread-safe

### DIFF
--- a/.changeset/stable-layout-lifecycle.md
+++ b/.changeset/stable-layout-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Fix layout observation lifecycle races during concurrent subscriptions and preserve safe forwarding for in-flight layout calls when recording stops.

--- a/.changeset/stable-layout-lifecycle.md
+++ b/.changeset/stable-layout-lifecycle.md
@@ -2,4 +2,4 @@
 "posthog-ios": patch
 ---
 
-Fix layout observation lifecycle races during concurrent subscriptions and preserve safe forwarding for in-flight layout calls when recording stops.
+Fix layout observation lifecycle races during concurrent subscriptions and preserve safe forwarding for in-flight layout calls when recording stops. Recover layout observation on subscription changes when another swizzler removes or bypasses the PostHog hook.

--- a/PostHog/ApplicationViewLayoutPublisher.swift
+++ b/PostHog/ApplicationViewLayoutPublisher.swift
@@ -17,64 +17,94 @@
     final class ApplicationViewLayoutPublisher: ViewLayoutPublishing {
         static let shared = ApplicationViewLayoutPublisher()
 
-        private(set) lazy var onViewLayout = PostHogThrottledMulticastCallback<Void> { [weak self] subscriberCount in
-            if subscriberCount > 0 {
-                self?.swizzleLayoutSubviews()
-            } else {
-                self?.unswizzleLayoutSubviews()
+        var onViewLayout: PostHogThrottledMulticastCallback<Void> { callbacks }
+        private var callbacks: PostHogThrottledMulticastCallback<Void>!
+        private let viewClass: UIView.Type
+
+        private struct LayoutHook {
+            let original: IMP
+            let replacement: IMP
+            let token: NSObject
+        }
+
+        // Only accessed by the multicast's serialized subscriber-count callbacks.
+        private var installedLayout: LayoutHook?
+        private var layoutHooks: [UInt: LayoutHook] = [:]
+        private let activeLayoutLock = NSLock()
+        private var activeLayoutToken: NSObject?
+        private typealias LayoutImplementation = @convention(c) (UIView, Selector, CALayer) -> Void
+
+        init(viewClass: UIView.Type = UIView.self) {
+            self.viewClass = viewClass
+            // Initialize before publication; Swift lazy properties are not safe on concurrent first access.
+            callbacks = PostHogThrottledMulticastCallback<Void> { [weak self] subscriberCount in
+                if subscriberCount > 0 {
+                    self?.swizzleLayoutSubviews()
+                } else {
+                    self?.unswizzleLayoutSubviews()
+                }
             }
         }
 
-        private var hasSwizzled: Bool = false
-
         private func swizzleLayoutSubviews() {
-            guard !hasSwizzled else { return }
-            hasSwizzled = true
+            guard installedLayout == nil,
+                  let method = class_getInstanceMethod(viewClass, #selector(UIView.layoutSublayers(of:)))
+            else { return }
 
-            swizzle(
-                forClass: UIView.self,
-                original: #selector(UIView.layoutSublayers(of:)),
-                new: #selector(UIView.ph_swizzled_layoutSublayers(of:))
-            )
+            let hook = layoutHook(for: method_getImplementation(method))
+            activeLayoutLock.withLock { activeLayoutToken = hook.token }
+            method_setImplementation(method, hook.replacement)
+            installedLayout = hook
         }
 
         private func unswizzleLayoutSubviews() {
-            guard hasSwizzled else { return }
-            hasSwizzled = false
+            guard let installedLayout,
+                  let method = class_getInstanceMethod(viewClass, #selector(UIView.layoutSublayers(of:)))
+            else { return }
 
-            // swizzling twice will exchange implementations back to original
-            swizzle(
-                forClass: UIView.self,
-                original: #selector(UIView.layoutSublayers(of:)),
-                new: #selector(UIView.ph_swizzled_layoutSublayers(of:))
-            )
+            // A newer swizzler may still forward through our IMP. Do not overwrite its hook or wrap it again.
+            guard method_getImplementation(method) == installedLayout.replacement else { return }
+            method_setImplementation(method, installedLayout.original)
+            activeLayoutLock.withLock { activeLayoutToken = nil }
+            self.installedLayout = nil
         }
 
-        // Called from swizzled `UIView.layoutSubviews`
-        fileprivate func layoutSubviews() {
+        private func layoutHook(for original: IMP) -> LayoutHook {
+            let key = unsafeBitCast(original, to: UInt.self)
+            if let hook = layoutHooks[key] {
+                return hook
+            }
+
+            let forward = unsafeBitCast(original, to: LayoutImplementation.self)
+            let selector = #selector(UIView.layoutSublayers(of:))
+            let token = NSObject()
+            let block: @convention(block) (UIView, CALayer) -> Void = { [weak self] view, layer in
+                forward(view, selector, layer)
+                if Thread.isMainThread {
+                    self?.layoutSubviews(token: token)
+                } else {
+                    DispatchQueue.main.async { [weak self] in
+                        self?.layoutSubviews(token: token)
+                    }
+                }
+            }
+            let hook = LayoutHook(original: original, replacement: imp_implementationWithBlock(block), token: token)
+            // In-flight dispatches and other swizzlers can retain the IMP after unsubscribe.
+            // Keep it valid and reuse it rather than allocating a new block on every restart.
+            layoutHooks[key] = hook
+            return hook
+        }
+
+        private func layoutSubviews(token: NSObject) {
+            // An older hook may still be in another swizzler's call chain.
+            guard activeLayoutLock.withLock({ activeLayoutToken === token }) else { return }
             onViewLayout.invoke(())
         }
 
         #if TESTING
             func simulateLayoutSubviews() {
-                layoutSubviews()
+                onViewLayout.invoke(())
             }
         #endif
-    }
-
-    extension UIView {
-        @objc func ph_swizzled_layoutSublayers(of layer: CALayer) {
-            ph_swizzled_layoutSublayers(of: layer) // call original, not altering execution logic
-            // Only notify on main thread - layoutSublayers can be called on background threads
-            // during thread cleanup (CA::Transaction::release_thread), which can cause crashes
-            // in the Auto Layout engine (NSISEngine) since it's not thread-safe.
-            if Thread.isMainThread {
-                ApplicationViewLayoutPublisher.shared.layoutSubviews()
-            } else {
-                DispatchQueue.main.async {
-                    ApplicationViewLayoutPublisher.shared.layoutSubviews()
-                }
-            }
-        }
     }
 #endif

--- a/PostHog/ApplicationViewLayoutPublisher.swift
+++ b/PostHog/ApplicationViewLayoutPublisher.swift
@@ -62,11 +62,12 @@
         }
 
         private func swizzleLayoutSubviews() {
-            guard installedLayout == nil,
-                  let method = class_getInstanceMethod(viewClass, #selector(UIView.layoutSublayers(of:)))
-            else { return }
+            guard let method = class_getInstanceMethod(viewClass, #selector(UIView.layoutSublayers(of:))) else { return }
+            let current = method_getImplementation(method)
+            if let installedLayout, current == installedLayout.replacement { return }
 
-            let hook = layoutHook(for: method_getImplementation(method))
+            // Another swizzler may restore one of our cached IMPs. Reactivate it instead of wrapping ourselves.
+            let hook = layoutHooks.values.first { $0.replacement == current } ?? layoutHook(for: current)
             activeLayoutLock.withLock { activeLayoutToken = hook.token }
             method_setImplementation(method, hook.replacement)
             installedLayout = hook
@@ -77,9 +78,12 @@
                   let method = class_getInstanceMethod(viewClass, #selector(UIView.layoutSublayers(of:)))
             else { return }
 
-            // A newer swizzler may still forward through our IMP. Do not overwrite its hook or wrap it again.
-            guard method_getImplementation(method) == installedLayout.replacement else { return }
-            method_setImplementation(method, installedLayout.original)
+            // Never overwrite another swizzler's replacement.
+            if method_getImplementation(method) == installedLayout.replacement {
+                method_setImplementation(method, installedLayout.original)
+            }
+            // An opaque replacement may retain or bypass our hook. Retire ownership in either case
+            // so the next subscription reconciles the current chain instead of trusting stale state.
             activeLayoutLock.withLock { activeLayoutToken = nil }
             self.installedLayout = nil
         }

--- a/PostHog/Utils/PostHogMulticastCallback.swift
+++ b/PostHog/Utils/PostHogMulticastCallback.swift
@@ -102,6 +102,9 @@ final class PostHogThrottledMulticastCallback<T> {
     private let lock = NSLock()
     private let onSubscriberCountChanged: ((Int) -> Void)?
 
+    // Heuristic budget: keep small bursts synchronous, but yield under sustained churn instead
+    // of letting an unbounded drain monopolize the caller. This is not a measured threshold.
+    private let subscriberCountBatchLimit = 32
     private var isNotifyingSubscriberCount = false
     private var needsSubscriberCountNotification = false
     private let subscriberCountQueue = DispatchQueue(label: "com.posthog.SubscriberCount")
@@ -124,7 +127,7 @@ final class PostHogThrottledMulticastCallback<T> {
     /// Creates a new throttled multicast callback.
     /// - Parameter onSubscriberCountChanged: Optional closure called when subscriber count changes.
     ///   Concurrent and reentrant changes are coalesced, and count callbacks never overlap.
-    ///   After 32 observer calls, pending changes are reconciled asynchronously in bounded batches.
+    ///   After a bounded synchronous batch, pending changes are reconciled asynchronously in bounded batches.
     init(onSubscriberCountChanged: ((Int) -> Void)? = nil) {
         self.onSubscriberCountChanged = onSubscriberCountChanged
     }
@@ -168,7 +171,7 @@ final class PostHogThrottledMulticastCallback<T> {
 
     private func drainSubscriberCountNotifications() {
         guard let onSubscriberCountChanged else { return }
-        for _ in 0 ..< 32 {
+        for _ in 0 ..< subscriberCountBatchLimit {
             let count = lock.withLock { () -> Int? in
                 guard needsSubscriberCountNotification else {
                     isNotifyingSubscriberCount = false

--- a/PostHog/Utils/PostHogMulticastCallback.swift
+++ b/PostHog/Utils/PostHogMulticastCallback.swift
@@ -102,6 +102,9 @@ final class PostHogThrottledMulticastCallback<T> {
     private let lock = NSLock()
     private let onSubscriberCountChanged: ((Int) -> Void)?
 
+    private var isNotifyingSubscriberCount = false
+    private var needsSubscriberCountNotification = false
+
     /// Serial queue that drains throttled callbacks. Stored per instance: generic types
     /// cannot have stored static properties, and a computed static would allocate a fresh
     /// queue on every `invoke()` — besides the allocation cost, separate queues would also
@@ -119,6 +122,7 @@ final class PostHogThrottledMulticastCallback<T> {
 
     /// Creates a new throttled multicast callback.
     /// - Parameter onSubscriberCountChanged: Optional closure called when subscriber count changes.
+    ///   Concurrent and reentrant changes are coalesced, and count callbacks never overlap.
     init(onSubscriberCountChanged: ((Int) -> Void)? = nil) {
         self.onSubscriberCountChanged = onSubscriberCountChanged
     }
@@ -132,21 +136,45 @@ final class PostHogThrottledMulticastCallback<T> {
     /// - Returns: A `RegistrationToken` that unsubscribes when deallocated.
     func subscribe(throttle interval: TimeInterval, trailing: Bool = false, _ callback: @escaping (T) -> Void) -> RegistrationToken {
         let id = UUID()
-        let newCount = lock.withLock {
+        lock.withLock {
             callbacks[id] = ThrottledCallback(handler: callback, interval: interval, trailing: trailing)
             // A new subscriber is immediately eligible; without this reset the invoke()
             // gate could suppress its first fire until the other subscribers' windows open.
             nextEligibleFire = .distantPast
-            return callbacks.count
         }
-        onSubscriberCountChanged?(newCount)
+        notifySubscriberCountChanged()
         return RegistrationToken { [weak self] in
             guard let self else { return }
-            let newCount = self.lock.withLock {
+            self.lock.withLock {
                 self.callbacks[id] = nil
-                return self.callbacks.count
             }
-            self.onSubscriberCountChanged?(newCount)
+            self.notifySubscriberCountChanged()
+        }
+    }
+
+    private func notifySubscriberCountChanged() {
+        guard let onSubscriberCountChanged else { return }
+        let shouldNotify = lock.withLock { () -> Bool in
+            needsSubscriberCountNotification = true
+            guard !isNotifyingSubscriberCount else { return false }
+            isNotifyingSubscriberCount = true
+            return true
+        }
+        guard shouldNotify else { return }
+
+        while true {
+            let count = lock.withLock { () -> Int? in
+                guard needsSubscriberCountNotification else {
+                    isNotifyingSubscriberCount = false
+                    return nil
+                }
+                needsSubscriberCountNotification = false
+                return callbacks.count
+            }
+            guard let count else { return }
+            // Observers may subscribe or unsubscribe. Reconcile those changes after they return,
+            // without holding the state lock or delivering a captured, out-of-order count.
+            onSubscriberCountChanged(count)
         }
     }
 

--- a/PostHog/Utils/PostHogMulticastCallback.swift
+++ b/PostHog/Utils/PostHogMulticastCallback.swift
@@ -104,6 +104,7 @@ final class PostHogThrottledMulticastCallback<T> {
 
     private var isNotifyingSubscriberCount = false
     private var needsSubscriberCountNotification = false
+    private let subscriberCountQueue = DispatchQueue(label: "com.posthog.SubscriberCount")
 
     /// Serial queue that drains throttled callbacks. Stored per instance: generic types
     /// cannot have stored static properties, and a computed static would allocate a fresh
@@ -123,6 +124,7 @@ final class PostHogThrottledMulticastCallback<T> {
     /// Creates a new throttled multicast callback.
     /// - Parameter onSubscriberCountChanged: Optional closure called when subscriber count changes.
     ///   Concurrent and reentrant changes are coalesced, and count callbacks never overlap.
+    ///   After 32 observer calls, pending changes are reconciled asynchronously in bounded batches.
     init(onSubscriberCountChanged: ((Int) -> Void)? = nil) {
         self.onSubscriberCountChanged = onSubscriberCountChanged
     }
@@ -153,7 +155,7 @@ final class PostHogThrottledMulticastCallback<T> {
     }
 
     private func notifySubscriberCountChanged() {
-        guard let onSubscriberCountChanged else { return }
+        guard onSubscriberCountChanged != nil else { return }
         let shouldNotify = lock.withLock { () -> Bool in
             needsSubscriberCountNotification = true
             guard !isNotifyingSubscriberCount else { return false }
@@ -161,8 +163,12 @@ final class PostHogThrottledMulticastCallback<T> {
             return true
         }
         guard shouldNotify else { return }
+        drainSubscriberCountNotifications()
+    }
 
-        while true {
+    private func drainSubscriberCountNotifications() {
+        guard let onSubscriberCountChanged else { return }
+        for _ in 0 ..< 32 {
             let count = lock.withLock { () -> Int? in
                 guard needsSubscriberCountNotification else {
                     isNotifyingSubscriberCount = false
@@ -175,6 +181,19 @@ final class PostHogThrottledMulticastCallback<T> {
             // Observers may subscribe or unsubscribe. Reconcile those changes after they return,
             // without holding the state lock or delivering a captured, out-of-order count.
             onSubscriberCountChanged(count)
+        }
+
+        let shouldContinue = lock.withLock { () -> Bool in
+            guard needsSubscriberCountNotification else {
+                isNotifyingSubscriberCount = false
+                return false
+            }
+            return true
+        }
+        guard shouldContinue else { return }
+        // Retain notification ownership across the queue hop so mutators only mark pending work.
+        subscriberCountQueue.async { [weak self] in
+            self?.drainSubscriberCountNotifications()
         }
     }
 

--- a/PostHogTests/ApplicationViewLayoutPublisherTest.swift
+++ b/PostHogTests/ApplicationViewLayoutPublisherTest.swift
@@ -11,11 +11,16 @@
     import Testing
     import UIKit
 
+    // Keep runtime replacements local to this suite, even when another suite has an active recording.
+    private final class LifecycleLayoutView: UIView {
+        override dynamic func layoutSublayers(of _: CALayer) {}
+    }
+
     @Suite("Application View Publisher Test", .serialized, .resetsGlobalState)
     final class ApplicationViewLayoutPublisherTest {
         var registrationToken: RegistrationToken?
 
-        @Test("lifecycle reproduction: subscriber-count callbacks can arrive out of order")
+        @Test("coalesces concurrent subscriber-count changes to the current count")
         func lifecycleStaleCount() throws {
             let zeroPending = DispatchSemaphore(value: 0)
             let releaseZero = DispatchSemaphore(value: 0)
@@ -53,19 +58,20 @@
         }
 
         @MainActor
-        @Test("lifecycle reproduction: concurrent subscriptions preserve the real swizzle state")
+        @Test("concurrent subscriptions preserve installed and restored layout implementations")
         func lifecycleConcurrentSubscriptions() throws {
-            let publisher = ApplicationViewLayoutPublisher.shared
+            let publisher = ApplicationViewLayoutPublisher(viewClass: LifecycleLayoutView.self)
+            defer { withExtendedLifetime(publisher) {} }
             let callback = publisher.onViewLayout
             try #require(callback.subscriberCount == 0)
-            let method = try #require(class_getInstanceMethod(UIView.self, #selector(UIView.layoutSublayers(of:))))
-            let alias = try #require(class_getInstanceMethod(UIView.self, #selector(UIView.ph_swizzled_layoutSublayers(of:))))
+            let method = try #require(class_getInstanceMethod(LifecycleLayoutView.self, #selector(UIView.layoutSublayers(of:))))
             let original = method_getImplementation(method)
-            let replacement = method_getImplementation(alias)
-            defer {
-                method_setImplementation(method, original)
-                method_setImplementation(alias, replacement)
-            }
+            var initialToken: RegistrationToken? = callback.subscribe(throttle: 0) {}
+            let replacement = method_getImplementation(method)
+            try #require(replacement != original)
+            #expect(initialToken != nil)
+            initialToken = nil
+            try #require(method_getImplementation(method) == original)
             for attempt in 0 ..< 5000 {
                 let lock = NSLock()
                 var tokens: [RegistrationToken] = []
@@ -87,7 +93,159 @@
             print("LIFECYCLE no method-state mismatch observed in 5000 rounds")
         }
 
+        @Test("concurrent first access returns the same layout publisher callbacks")
+        func concurrentFirstAccess() {
+            let publisher = ApplicationViewLayoutPublisher()
+            let lock = NSLock()
+            var callbacks: [PostHogThrottledMulticastCallback<Void>] = []
+            DispatchQueue.concurrentPerform(iterations: 32) { _ in
+                let callback = publisher.onViewLayout
+                lock.withLock { callbacks.append(callback) }
+            }
+            #expect(Set(callbacks.map(ObjectIdentifier.init)).count == 1)
+        }
+
+        @MainActor
+        @Test("a captured layout implementation still forwards after unsubscribe", arguments: [false, true])
+        func forwardsCapturedLayoutAfterUnsubscribe(background: Bool) throws {
+            let publisher = ApplicationViewLayoutPublisher(viewClass: LifecycleLayoutView.self)
+            defer { withExtendedLifetime(publisher) {} }
+            try #require(publisher.onViewLayout.subscriberCount == 0)
+            let view = LifecycleLayoutView()
+            let layer = view.layer
+            let selector = #selector(UIView.layoutSublayers(of:))
+            let method = try #require(class_getInstanceMethod(LifecycleLayoutView.self, selector))
+            var forwardedCalls = 0
+            var forwardedOnMain = false
+            let block: @convention(block) (UIView, CALayer) -> Void = { receivedView, receivedLayer in
+                #expect(receivedView === view)
+                #expect(receivedLayer === layer)
+                forwardedCalls += 1
+                forwardedOnMain = Thread.isMainThread
+            }
+            let stub = imp_implementationWithBlock(block)
+            let original = method_setImplementation(method, stub)
+            defer {
+                method_setImplementation(method, original)
+                imp_removeBlock(stub)
+            }
+            var token: RegistrationToken? = publisher.onViewLayout.subscribe(throttle: 0, trailing: true) {}
+            #expect(token != nil)
+            let captured = unsafeBitCast(method_getImplementation(method), to: LayoutImplementation.self)
+            token = nil
+            try #require(method_getImplementation(method) == stub)
+
+            // objc_msgSend may have already selected an IMP when another thread uninstalls the hook.
+            if background {
+                let finished = DispatchSemaphore(value: 0)
+                DispatchQueue.global().async {
+                    captured(view, selector, layer)
+                    finished.signal()
+                }
+                try #require(finished.wait(timeout: .now() + 5) == .success)
+            } else {
+                captured(view, selector, layer)
+            }
+            #expect(forwardedCalls == 1)
+            #expect(forwardedOnMain == !background)
+        }
+
+        @MainActor
+        @Test("unsubscribe preserves a newer swizzler and resubscribe does not wrap it again")
+        func preservesNewerSwizzler() throws {
+            let publisher = ApplicationViewLayoutPublisher(viewClass: LifecycleLayoutView.self)
+            defer { withExtendedLifetime(publisher) {} }
+            try #require(publisher.onViewLayout.subscriberCount == 0)
+            let view = LifecycleLayoutView()
+            let layer = view.layer
+            let selector = #selector(UIView.layoutSublayers(of:))
+            let method = try #require(class_getInstanceMethod(LifecycleLayoutView.self, selector))
+            var originalCalls = 0
+            var otherCalls = 0
+            let originalBlock: @convention(block) (UIView, CALayer) -> Void = { _, _ in originalCalls += 1 }
+            let stub = imp_implementationWithBlock(originalBlock)
+            let original = method_setImplementation(method, stub)
+            defer {
+                method_setImplementation(method, original)
+                imp_removeBlock(stub)
+            }
+            var token: RegistrationToken? = publisher.onViewLayout.subscribe(throttle: 0, trailing: true) {}
+            defer { token = nil }
+            #expect(token != nil)
+            let installed = method_getImplementation(method)
+            let forward = unsafeBitCast(installed, to: LayoutImplementation.self)
+            let otherBlock: @convention(block) (UIView, CALayer) -> Void = { view, layer in
+                otherCalls += 1
+                forward(view, selector, layer)
+            }
+            let other = imp_implementationWithBlock(otherBlock)
+            defer { imp_removeBlock(other) }
+            method_setImplementation(method, other)
+            token = nil
+            try #require(method_getImplementation(method) == other)
+
+            token = publisher.onViewLayout.subscribe(throttle: 0, trailing: true) {}
+            #expect(method_getImplementation(method) == other)
+            view.layoutSublayers(of: layer)
+            #expect(originalCalls == 1)
+            #expect(otherCalls == 1)
+            token = nil
+            #expect(method_getImplementation(method) == other)
+
+            // The newer swizzler restores the implementation it originally replaced.
+            method_setImplementation(method, installed)
+            token = publisher.onViewLayout.subscribe(throttle: 0, trailing: true) {}
+            token = nil
+            #expect(method_getImplementation(method) == stub)
+        }
+
+        @MainActor
+        @Test("a retired hook in a newer swizzler's chain does not duplicate notifications")
+        func retiredHookDoesNotDuplicateNotifications() async throws {
+            let publisher = ApplicationViewLayoutPublisher(viewClass: LifecycleLayoutView.self)
+            defer { withExtendedLifetime(publisher) {} }
+            try #require(publisher.onViewLayout.subscriberCount == 0)
+            let view = LifecycleLayoutView()
+            let layer = view.layer
+            let selector = #selector(UIView.layoutSublayers(of:))
+            let method = try #require(class_getInstanceMethod(LifecycleLayoutView.self, selector))
+            var originalCalls = 0
+            let originalBlock: @convention(block) (UIView, CALayer) -> Void = { _, _ in originalCalls += 1 }
+            let stub = imp_implementationWithBlock(originalBlock)
+            let original = method_setImplementation(method, stub)
+            defer {
+                method_setImplementation(method, original)
+                imp_removeBlock(stub)
+            }
+            var token: RegistrationToken? = publisher.onViewLayout.subscribe(throttle: 0, trailing: true) {}
+            #expect(token != nil)
+            let retired = unsafeBitCast(method_getImplementation(method), to: LayoutImplementation.self)
+            token = nil
+            let otherBlock: @convention(block) (UIView, CALayer) -> Void = { view, layer in
+                retired(view, selector, layer)
+            }
+            let other = imp_implementationWithBlock(otherBlock)
+            defer { imp_removeBlock(other) }
+            method_setImplementation(method, other)
+
+            var notifications = 0
+            token = publisher.onViewLayout.subscribe(throttle: 0, trailing: true) {
+                #expect(Thread.isMainThread)
+                notifications += 1
+            }
+            defer { token = nil }
+            view.layoutSublayers(of: layer)
+            await withCheckedContinuation { continuation in
+                DispatchQueue.main.async { continuation.resume() }
+            }
+            #expect(originalCalls == 1)
+            #expect(notifications == 1)
+        }
+
+        private typealias LayoutImplementation = @convention(c) (UIView, Selector, CALayer) -> Void
+
         // invoke() hops to a background throttle queue then back to main, so effects are async.
+        @MainActor
         private func waitUntil(timeoutNanoseconds: UInt64 = 1_000_000_000,
                                pollNanoseconds: UInt64 = 5_000_000,
                                _ condition: () -> Bool) async
@@ -108,7 +266,8 @@
             var timesCalled = 0
             var lastCallTime: Date?
 
-            let sut = ApplicationViewLayoutPublisher.shared
+            let sut = ApplicationViewLayoutPublisher(viewClass: LifecycleLayoutView.self)
+            defer { withExtendedLifetime(sut) {} }
             registrationToken = sut.onViewLayout.subscribe(throttle: 2) {
                 timesCalled += 1
                 lastCallTime = mockNow.date

--- a/PostHogTests/ApplicationViewLayoutPublisherTest.swift
+++ b/PostHogTests/ApplicationViewLayoutPublisherTest.swift
@@ -157,8 +157,8 @@
         }
 
         @MainActor
-        @Test("unsubscribe preserves a newer swizzler and resubscribe does not wrap it again")
-        func preservesNewerSwizzler() throws {
+        @Test("restarts preserve newer forwarding, notify once, and reuse a bounded hook chain")
+        func preservesNewerSwizzler() async throws {
             let publisher = ApplicationViewLayoutPublisher(viewClass: LifecycleLayoutView.self)
             defer { withExtendedLifetime(publisher) {} }
             try #require(publisher.onViewLayout.subscriberCount == 0)
@@ -168,6 +168,7 @@
             let method = try #require(class_getInstanceMethod(LifecycleLayoutView.self, selector))
             var originalCalls = 0
             var otherCalls = 0
+            var notifications = 0
             let originalBlock: @convention(block) (UIView, CALayer) -> Void = { _, _ in originalCalls += 1 }
             let stub = imp_implementationWithBlock(originalBlock)
             let original = method_setImplementation(method, stub)
@@ -190,17 +191,42 @@
             token = nil
             try #require(method_getImplementation(method) == other)
 
-            token = publisher.onViewLayout.subscribe(throttle: 0, trailing: true) {}
-            #expect(method_getImplementation(method) == other)
-            view.layoutSublayers(of: layer)
-            #expect(originalCalls == 1)
-            #expect(otherCalls == 1)
-            token = nil
-            #expect(method_getImplementation(method) == other)
+            var resumed: IMP?
+            for restart in 1 ... 100 {
+                token = publisher.onViewLayout.subscribe(throttle: 0, trailing: true) {
+                    #expect(Thread.isMainThread)
+                    notifications += 1
+                }
+                let current = method_getImplementation(method)
+                if let resumed {
+                    #expect(current == resumed)
+                } else {
+                    resumed = current
+                }
+                view.layoutSublayers(of: layer)
+                await withCheckedContinuation { continuation in
+                    DispatchQueue.main.async { continuation.resume() }
+                }
+                #expect(originalCalls == restart)
+                #expect(otherCalls == restart)
+                #expect(notifications == restart)
+                token = nil
+                #expect(method_getImplementation(method) == other)
+            }
 
             // The newer swizzler restores the implementation it originally replaced.
             method_setImplementation(method, installed)
-            token = publisher.onViewLayout.subscribe(throttle: 0, trailing: true) {}
+            token = publisher.onViewLayout.subscribe(throttle: 0, trailing: true) {
+                notifications += 1
+            }
+            #expect(method_getImplementation(method) == installed)
+            view.layoutSublayers(of: layer)
+            await withCheckedContinuation { continuation in
+                DispatchQueue.main.async { continuation.resume() }
+            }
+            #expect(originalCalls == 101)
+            #expect(otherCalls == 100)
+            #expect(notifications == 101)
             token = nil
             #expect(method_getImplementation(method) == stub)
         }
@@ -245,6 +271,75 @@
                 DispatchQueue.main.async { continuation.resume() }
             }
             #expect(originalCalls == 1)
+            #expect(notifications == 1)
+        }
+
+        @MainActor
+        @Test("resubscription recovers after another swizzler detaches the PostHog hook", arguments: [false, true], [false, true])
+        func externallyDetachedHook(removeEarlierSwizzler: Bool, retainOtherSubscriber: Bool) async throws {
+            let publisher = ApplicationViewLayoutPublisher(viewClass: LifecycleLayoutView.self)
+            defer { withExtendedLifetime(publisher) {} }
+            let view = LifecycleLayoutView()
+            let layer = view.layer
+            let selector = #selector(UIView.layoutSublayers(of:))
+            let method = try #require(class_getInstanceMethod(LifecycleLayoutView.self, selector))
+            var originalCalls = 0
+            var otherCalls = 0
+            var notifications = 0
+            let originalBlock: @convention(block) (UIView, CALayer) -> Void = { _, _ in originalCalls += 1 }
+            let stub = imp_implementationWithBlock(originalBlock)
+            let original = method_setImplementation(method, stub)
+            let forward = unsafeBitCast(stub, to: LayoutImplementation.self)
+            let otherBlock: @convention(block) (UIView, CALayer) -> Void = { view, layer in
+                otherCalls += 1
+                forward(view, selector, layer)
+            }
+            let other = imp_implementationWithBlock(otherBlock)
+            defer {
+                method_setImplementation(method, original)
+                imp_removeBlock(other)
+                imp_removeBlock(stub)
+            }
+            if removeEarlierSwizzler {
+                method_setImplementation(method, other)
+            }
+            // Surveys may keep observing layout while replay stops and restarts.
+            var retainedToken = retainOtherSubscriber ? publisher.onViewLayout.subscribe(throttle: 0, trailing: true) {} : nil
+            #expect((retainedToken != nil) == retainOtherSubscriber)
+            var token: RegistrationToken? = publisher.onViewLayout.subscribe(throttle: 0, trailing: true) {
+                notifications += 1
+            }
+            defer {
+                token = nil
+                retainedToken = nil
+            }
+            #expect(token != nil)
+            view.layoutSublayers(of: layer)
+            await withCheckedContinuation { continuation in
+                DispatchQueue.main.async { continuation.resume() }
+            }
+            try #require(originalCalls == 1)
+            try #require(notifications == 1)
+            originalCalls = 0
+            otherCalls = 0
+            notifications = 0
+
+            // Either an older swizzler restores UIKit directly, or a newer one bypasses our IMP.
+            let detached = removeEarlierSwizzler ? stub : other
+            method_setImplementation(method, detached)
+            token = nil
+            try #require(publisher.onViewLayout.subscriberCount == (retainOtherSubscriber ? 1 : 0))
+            token = publisher.onViewLayout.subscribe(throttle: 0, trailing: true) {
+                notifications += 1
+            }
+            view.layoutSublayers(of: layer)
+            await withCheckedContinuation { continuation in
+                DispatchQueue.main.async { continuation.resume() }
+            }
+            #expect(publisher.onViewLayout.subscriberCount == (retainOtherSubscriber ? 2 : 1))
+            #expect(originalCalls == 1)
+            #expect(otherCalls == (removeEarlierSwizzler ? 0 : 1))
+            print("HOOK_DETACH olderUninstall=\(removeEarlierSwizzler), retainedSubscriber=\(retainOtherSubscriber), rootUnchanged=\(method_getImplementation(method) == detached), originalCalls=\(originalCalls), notifications=\(notifications)")
             #expect(notifications == 1)
         }
 

--- a/PostHogTests/ApplicationViewLayoutPublisherTest.swift
+++ b/PostHogTests/ApplicationViewLayoutPublisherTest.swift
@@ -9,10 +9,83 @@
     import Foundation
     @testable import PostHog
     import Testing
+    import UIKit
 
     @Suite("Application View Publisher Test", .serialized, .resetsGlobalState)
     final class ApplicationViewLayoutPublisherTest {
         var registrationToken: RegistrationToken?
+
+        @Test("lifecycle reproduction: subscriber-count callbacks can arrive out of order")
+        func lifecycleStaleCount() throws {
+            let zeroPending = DispatchSemaphore(value: 0)
+            let releaseZero = DispatchSemaphore(value: 0)
+            let finished = DispatchSemaphore(value: 0)
+            let lock = NSLock()
+            var blockFirstZero = true
+            var observedCounts: [Int] = []
+            let callback = PostHogThrottledMulticastCallback<Void> { count in
+                let shouldBlock = lock.withLock { () -> Bool in
+                    guard count == 0, blockFirstZero else { return false }
+                    blockFirstZero = false
+                    return true
+                }
+                if shouldBlock {
+                    zeroPending.signal()
+                    _ = releaseZero.wait(timeout: .now() + 5)
+                }
+                lock.withLock { observedCounts.append(count) }
+            }
+            var first: RegistrationToken? = callback.subscribe(throttle: 0) {}
+            #expect(first != nil)
+            DispatchQueue.global().async {
+                first = nil
+                finished.signal()
+            }
+            defer { releaseZero.signal() }
+            try #require(zeroPending.wait(timeout: .now() + 5) == .success)
+            let second = callback.subscribe(throttle: 0) {}
+            defer { withExtendedLifetime(second) {} }
+            releaseZero.signal()
+            try #require(finished.wait(timeout: .now() + 5) == .success)
+            let counts = lock.withLock { observedCounts }
+            print("LIFECYCLE observed counts=\(counts), actual subscribers=\(callback.subscriberCount)")
+            #expect(counts.last == callback.subscriberCount)
+        }
+
+        @MainActor
+        @Test("lifecycle reproduction: concurrent subscriptions preserve the real swizzle state")
+        func lifecycleConcurrentSubscriptions() throws {
+            let publisher = ApplicationViewLayoutPublisher.shared
+            let callback = publisher.onViewLayout
+            try #require(callback.subscriberCount == 0)
+            let method = try #require(class_getInstanceMethod(UIView.self, #selector(UIView.layoutSublayers(of:))))
+            let alias = try #require(class_getInstanceMethod(UIView.self, #selector(UIView.ph_swizzled_layoutSublayers(of:))))
+            let original = method_getImplementation(method)
+            let replacement = method_getImplementation(alias)
+            defer {
+                method_setImplementation(method, original)
+                method_setImplementation(alias, replacement)
+            }
+            for attempt in 0 ..< 5000 {
+                let lock = NSLock()
+                var tokens: [RegistrationToken] = []
+                DispatchQueue.concurrentPerform(iterations: 8) { _ in
+                    let token = callback.subscribe(throttle: 0) {}
+                    lock.withLock { tokens.append(token) }
+                }
+                let subscribed = callback.subscriberCount
+                let installed = method_getImplementation(method) == replacement
+                tokens.removeAll()
+                let removed = method_getImplementation(method) == original
+                if !installed || !removed {
+                    print("LIFECYCLE attempt=\(attempt), subscribed=\(subscribed), installed=\(installed), removed=\(removed), remaining=\(callback.subscriberCount)")
+                    #expect(installed)
+                    #expect(removed)
+                    return
+                }
+            }
+            print("LIFECYCLE no method-state mismatch observed in 5000 rounds")
+        }
 
         // invoke() hops to a background throttle queue then back to main, so effects are async.
         private func waitUntil(timeoutNanoseconds: UInt64 = 1_000_000_000,

--- a/PostHogTests/PostHogMulticastCallbackTest.swift
+++ b/PostHogTests/PostHogMulticastCallbackTest.swift
@@ -128,6 +128,98 @@ class PostHogThrottledMulticastCallbackTests {
         #expect(publisher.subscriberCount == 0)
     }
 
+    @MainActor
+    @Test("Subscriber-count delivery yields and reconciles changes made during deferred delivery", arguments: [0, 2])
+    func subscriberCountDeliveryYields(finalCount: Int) throws {
+        let deferredStarted = DispatchSemaphore(value: 0)
+        let releaseDeferred = DispatchSemaphore(value: 0)
+        let reconciled = DispatchSemaphore(value: 0)
+        let lock = NSLock()
+        weak var callback: PostHogThrottledMulticastCallback<Void>?
+        var mainDeliveries = 0
+        var deferredDeliveries = 0
+        var depth = 0
+        var churn = true
+        var counts: [Int] = []
+        let publisher = PostHogThrottledMulticastCallback<Void> { count in
+            let (shouldChurn, shouldBlock) = lock.withLock { () -> (Bool, Bool) in
+                depth += 1
+                #expect(depth == 1)
+                if Thread.isMainThread {
+                    mainDeliveries += 1
+                    return (churn && mainDeliveries < 128, false)
+                }
+                deferredDeliveries += 1
+                return (false, deferredDeliveries == 1)
+            }
+            defer { lock.withLock { depth -= 1 } }
+            if shouldChurn {
+                withExtendedLifetime(callback?.subscribe(throttle: 0) {}) {}
+            }
+            if shouldBlock {
+                deferredStarted.signal()
+                #expect(releaseDeferred.wait(timeout: .now() + 5) == .success)
+            }
+            lock.withLock { counts.append(count) }
+            if !Thread.isMainThread, count == finalCount {
+                reconciled.signal()
+            }
+        }
+        callback = publisher
+        var first: RegistrationToken? = publisher.subscribe(throttle: 0) {}
+        defer { releaseDeferred.signal() }
+        #expect(first != nil)
+        lock.withLock {
+            #expect(mainDeliveries == 32)
+            churn = false
+        }
+        try #require(deferredStarted.wait(timeout: .now() + 5) == .success)
+
+        let additionalTokens = (0 ..< finalCount).map { _ in publisher.subscribe(throttle: 0) {} }
+        defer { withExtendedLifetime((publisher, additionalTokens)) {} }
+        first = nil
+        releaseDeferred.signal()
+        try #require(reconciled.wait(timeout: .now() + 5) == .success)
+        #expect(publisher.subscriberCount == finalCount)
+        #expect(lock.withLock { counts.last } == finalCount)
+    }
+
+    @MainActor
+    @Test("Subscriber-count delivery drains reentrant changes across multiple bounded batches")
+    func subscriberCountDeliveryDrainsMultipleBatches() throws {
+        let finished = DispatchSemaphore(value: 0)
+        let lock = NSLock()
+        weak var callback: PostHogThrottledMulticastCallback<Void>?
+        var deliveries = 0
+        var deferredDeliveries = 0
+        var depth = 0
+        let publisher = PostHogThrottledMulticastCallback<Void> { count in
+            let delivery = lock.withLock { () -> Int in
+                depth += 1
+                #expect(depth == 1)
+                deliveries += 1
+                if !Thread.isMainThread { deferredDeliveries += 1 }
+                return deliveries
+            }
+            defer { lock.withLock { depth -= 1 } }
+            #expect(callback?.subscriberCount == count)
+            if delivery < 257 {
+                withExtendedLifetime(callback?.subscribe(throttle: 0) {}) {}
+            } else if delivery == 257 {
+                finished.signal()
+            }
+        }
+        callback = publisher
+        let token = publisher.subscribe(throttle: 0) {}
+        defer { withExtendedLifetime((publisher, token)) {} }
+        try #require(finished.wait(timeout: .now() + 5) == .success)
+        lock.withLock {
+            #expect(deliveries == 257)
+            #expect(deferredDeliveries == 225)
+        }
+        #expect(publisher.subscriberCount == 1)
+    }
+
     @Test("Single subscriber receives value with throttle")
     func singleSubscriber() async {
         let callback = PostHogThrottledMulticastCallback<Int>()

--- a/PostHogTests/PostHogMulticastCallbackTest.swift
+++ b/PostHogTests/PostHogMulticastCallbackTest.swift
@@ -99,6 +99,35 @@ class PostHogMulticastCallbackTests {
 
 @Suite("PostHogThrottledMulticastCallback Tests", .resetsGlobalState)
 class PostHogThrottledMulticastCallbackTests {
+    @Test("Subscriber-count callbacks can reenter without overlapping or reporting stale state")
+    func reentrantSubscriberCountChanges() {
+        weak var callback: PostHogThrottledMulticastCallback<Void>?
+        var nestedToken: RegistrationToken?
+        var addedNested = false
+        var depth = 0
+        var counts: [Int] = []
+        let publisher = PostHogThrottledMulticastCallback<Void> { count in
+            depth += 1
+            defer { depth -= 1 }
+            #expect(depth == 1)
+            #expect(callback?.subscriberCount == count)
+            counts.append(count)
+            if count == 1, !addedNested {
+                addedNested = true
+                nestedToken = callback?.subscribe(throttle: 0) {}
+            }
+        }
+        callback = publisher
+        var token: RegistrationToken? = publisher.subscribe(throttle: 0) {}
+        #expect(token != nil)
+        #expect(nestedToken != nil)
+        #expect(counts == [1, 2])
+        nestedToken = nil
+        token = nil
+        #expect(counts == [1, 2, 1, 0])
+        #expect(publisher.subscriberCount == 0)
+    }
+
     @Test("Single subscriber receives value with throttle")
     func singleSubscriber() async {
         let callback = PostHogThrottledMulticastCallback<Int>()


### PR DESCRIPTION
## :bulb: Motivation and Context

Converts this reproduction-only PR into a production lifecycle fix. The reproductions are now passing regression tests; no intentionally failing tests remain.

Related to #806, but these confirmed lifecycle defects do **not** establish the cause of the customer's production `NSISEngine` crash. The diagnostic warning from merged #815 is preserved in the new hook. The run-loop proposal in #813 remains separate work. This preserves synchronous UIKit forwarding on its original calling thread; it does not suppress background layout.

### Changes

- Eagerly initialize the callback publisher instead of racing Swift's lazy initialization.
- Serialize and coalesce subscriber-count observer delivery, reconciling the latest count without holding callback-state locks during observer execution. Concurrent and reentrant observers cannot overlap or apply an older count after the final current count.
- Bound subscriber-count delivery to 32 observer calls per batch. Queue pending reconciliation on a private serial queue while retaining notification ownership, so sustained churn cannot keep the initiating thread in an unbounded drain. This bounds call count, not the duration of arbitrary observer code.
- Replace exchange-based forwarding with hooks that capture immutable original IMPs. A layout dispatch that retained a hook before unsubscribe can still forward safely after uninstall, without recursive alias lookup.
- Cache hooks per original IMP and retain their block implementations for process lifetime, since in-flight dispatches and other swizzlers may retain those function pointers. Ordinary restarts reuse the same hook.
- Preserve an observed newer swizzler during teardown, but retire our ownership when the last subscriber leaves. On positive subscriber-count changes, check the actual current IMP and recover if another library removed or bypassed our hook. This also works when another subscriber, such as Surveys, remains active.
- Reactivate a restored cached PostHog IMP rather than wrapping ourselves. An opaque external hook may retain our old hook, so recovery can add one cached outer wrapper. The active token prevents duplicate notifications, and repeated restarts reuse a stable chain.
- Use dedicated test view classes so runtime regression fixtures do not interfere with the shared publisher or other suites.

An older library restoring UIKit can remove PostHog from the chain. Recovery now handles that sequence on the next subscriber-count notification rather than trusting stale installation state. It does not continuously monitor runtime replacement or coordinate arbitrary concurrent third-party writes. Forwarding implementations retained by other libraries must remain valid.

## :green_heart: How did you test it?

Reproduction-first validation confirmed stale count delivery, a `hasSwizzled` TSan race, multiple callback objects from concurrent first access, stack-overflowing forwarding after unsubscribe, and clobbering a newer swizzler before the fixes. A retained-old-hook regression also caught duplicate notifications during implementation.

| Validation | Result |
| --- | --- |
| Focused lifecycle suite with Thread Sanitizer | Pass, three repetitions/relaunches; includes 5,000 rounds of eight concurrent retained subscriptions |
| Reentrant and bounded-delivery regressions | Pass: 32 synchronous calls, deferred reconciliation to zero/nonzero counts, 257 calls across multiple batches, no overlapping observers |
| `make test` | Pass on `6f31b314c`: 799 Swift Testing tests, plus XCTest |
| `make testOniOSSimulator` | Pass on `6f31b314c`: 193 XCTest tests and 926 Swift Testing tests |
| Detached-hook recovery | Pass: older uninstall and newer bypass, each with/without another retained subscriber; 100 restart cycles verify exactly-once forwarding/notifications and stable cached IMP reuse |
| SDK targets via `make build` | Pass: iOS, macOS, Mac Catalyst, tvOS, watchOS, visionOS |
| `make format`, `make lint`, `git diff --check` | Pass |
| `make build` | SDK and platform examples passed; external-client example blocked by checkout/package identity mismatch described below |

Full build stops at `ExternalSDK-iOS`: the example expects package identity `posthog-ios`, while the isolated checkout is named `posthog-ios-issue-806-lifecycle`. Subsequent CocoaPods examples were not reached. No unrelated build configuration was changed.

Autoreview command: `$HOME/.pi/agent/skills/autoreview/scripts/autoreview --mode branch --base origin/main --prompt-file autoreview-scope.md`. One test-ordering finding was rejected after checking the actual code: this test uses only zero-interval **trailing** subscriptions, whose `invokeTrailing` directly enqueues on main before the continuation barrier. It does not traverse the background leading-throttle queue. The bundle-only reviewer could not see that unchanged implementation. No accepted review blockers remain.

The bounded-delivery follow-up (`5826de1b0`) passed isolated autoreview with no findings: `$HOME/.pi/agent/skills/autoreview/scripts/autoreview --mode commit --commit HEAD --prompt-file autoreview-bounded-scope.md`. Its tests first failed against the unbounded loop, then passed along with the existing lifecycle tests under Thread Sanitizer across three repetitions/relaunches.

### Latest main merge validation (`a4be3e52c`)

All 47 CI checks passed for this exact commit, including SDK/example builds, tests, replay masking snapshots, and compliance. The combined warning/lifecycle tests passed locally under TSan across three repetitions, and the full iOS suite passed (190 XCTest tests and 921 Swift Testing tests). Format and lint passed. Local macOS full-suite attempts had varying failures in unchanged feature-flag/event/queue timing tests; the queue test passed in isolation, and the full macOS CI job passed. No tests were weakened or disabled. The existing local external-client package-identity build limitation remains; its CI build passed.

### Current head (`6f31b314c`)

Recovery fix `7e043c190` addresses [the clarified review sequence](https://github.com/PostHog/posthog-ios/pull/814#discussion_r3981315753). Both detach sequences first failed with zero notifications. The retained-subscriber variants also failed on the partial zero-only fix before runtime reconciliation was added. No intentionally failing tests remain.

Merged latest `main` (`05bbc8d6e`, including v3.73.0) without conflicts in `6f31b314c`. The table above reflects this head: full SPM/iOS suites passed, combined layout and bounded/reentrant tests passed under TSan across three repetitions/relaunches, and format/lint passed. The local external-client build limitation is unchanged. CI is running for this exact head.

Final autoreview: `$HOME/.pi/agent/skills/autoreview/scripts/autoreview --mode branch --base origin/main --prompt-file autoreview-final-lifecycle-scope.md`. Clean, no actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed. Internal lifecycle behavior is documented above and in code.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Added a patch changeset: `.changeset/stable-layout-lifecycle.md`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Manoel requested implementing the lifecycle fixes in this existing PR worktree and pushing to this PR. Pi used reproduction-first tests, file edits, make-based validation, Thread Sanitizer, GitHub CLI, and isolated Pi autoreview. Changes remain within layout-hook lifecycle and throttled subscriber-count delivery; no run-loop architecture or public API changes are included. Human review is required.

