### PR TITLE
fix: warn about off-main view layout in debug mode

### DIFF
--- a/.changeset/quiet-layout-warning.md
+++ b/.changeset/quiet-layout-warning.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": patch
+---
+
+Log a one-time debug warning when the layout observation hook receives an off-main UIKit layout call, without changing the original layout behavior.

--- a/PostHog/ApplicationViewLayoutPublisher.swift
+++ b/PostHog/ApplicationViewLayoutPublisher.swift
@@ -26,6 +26,20 @@
         }
 
         private var hasSwizzled: Bool = false
+        private let backgroundLayoutWarningLock = NSLock()
+        private var hasWarnedAboutBackgroundLayout = false
+
+        fileprivate func warnAboutBackgroundLayout() {
+            guard hedgeLogEnabled else { return }
+            let shouldWarn = backgroundLayoutWarningLock.withLock {
+                guard !hasWarnedAboutBackgroundLayout else { return false }
+                hasWarnedAboutBackgroundLayout = true
+                return true
+            }
+            if shouldWarn {
+                hedgeLog("Warning: UIView.layoutSublayers(of:) was called off the main thread. UIKit layout may crash in this situation. Use Main Thread Checker to investigate off-main view or layer access. PostHog is forwarding the original call unchanged.")
+            }
+        }
 
         private func swizzleLayoutSubviews() {
             guard !hasSwizzled else { return }
@@ -59,16 +73,24 @@
             func simulateLayoutSubviews() {
                 layoutSubviews()
             }
+
+            func resetBackgroundLayoutWarning() {
+                backgroundLayoutWarningLock.withLock {
+                    hasWarnedAboutBackgroundLayout = false
+                }
+            }
         #endif
     }
 
     extension UIView {
         @objc func ph_swizzled_layoutSublayers(of layer: CALayer) {
+            let isMainThread = Thread.isMainThread
+            if !isMainThread {
+                // UIKit can throw inside the original call, before our notification is reached.
+                ApplicationViewLayoutPublisher.shared.warnAboutBackgroundLayout()
+            }
             ph_swizzled_layoutSublayers(of: layer) // call original, not altering execution logic
-            // Only notify on main thread - layoutSublayers can be called on background threads
-            // during thread cleanup (CA::Transaction::release_thread), which can cause crashes
-            // in the Auto Layout engine (NSISEngine) since it's not thread-safe.
-            if Thread.isMainThread {
+            if isMainThread {
                 ApplicationViewLayoutPublisher.shared.layoutSubviews()
             } else {
                 DispatchQueue.main.async {

--- a/PostHogTests/ApplicationViewLayoutPublisherTest.swift
+++ b/PostHogTests/ApplicationViewLayoutPublisherTest.swift
@@ -9,12 +9,159 @@
     import Foundation
     @testable import PostHog
     import Testing
+    import UIKit
+
+    private final class StubbedLayoutView: UIView {}
+
+    // Only used off-main while this view's original layout forwarding is replaced by a test stub.
+    private struct StubbedLayoutCall: @unchecked Sendable {
+        let view: UIView
+        let layer: CALayer
+    }
 
     @Suite("Application View Publisher Test", .serialized, .resetsGlobalState)
     final class ApplicationViewLayoutPublisherTest {
         var registrationToken: RegistrationToken?
 
+        @MainActor
+        private func withOriginalLayoutStub(
+            _ original: @escaping (UIView, CALayer) -> Void,
+            perform body: (UIView, CALayer) async throws -> Void
+        ) async throws {
+            try #require(ApplicationViewLayoutPublisher.shared.onViewLayout.subscriberCount == 0)
+            let view = StubbedLayoutView()
+            let layer = view.layer
+            let method = try #require(class_getInstanceMethod(UIView.self, #selector(UIView.layoutSublayers(of:))))
+            let selector = #selector(UIView.ph_swizzled_layoutSublayers(of:))
+            let block: @convention(block) (UIView, CALayer) -> Void = original
+            let stub = imp_implementationWithBlock(block)
+            let implementation = method_getImplementation(method)
+            // Replace only this test view's call-through; other UIView instances keep their UIKit layout.
+            class_replaceMethod(StubbedLayoutView.self, selector, stub, method_getTypeEncoding(method))
+            defer {
+                registrationToken = nil
+                class_replaceMethod(StubbedLayoutView.self, selector, implementation, method_getTypeEncoding(method))
+                imp_removeBlock(stub)
+            }
+            try await body(view, layer)
+            // Drain off-main layout notifications before another test subscribes to the shared publisher.
+            await withCheckedContinuation { continuation in
+                DispatchQueue.main.async { continuation.resume() }
+            }
+        }
+
+        private func runOffMain(_ body: @escaping () -> Void) throws {
+            let finished = DispatchSemaphore(value: 0)
+            DispatchQueue.global().async {
+                body()
+                finished.signal()
+            }
+            try #require(finished.wait(timeout: .now() + 5) == .success)
+        }
+
+        private func captureStdout(_ body: () throws -> Void) throws -> String {
+            let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            FileManager.default.createFile(atPath: url.path, contents: nil)
+            defer { try? FileManager.default.removeItem(at: url) }
+            let file = try FileHandle(forWritingTo: url)
+            defer { file.closeFile() }
+            fflush(stdout)
+            let saved = dup(STDOUT_FILENO)
+            try #require(saved >= 0)
+            defer { close(saved) }
+            try #require(dup2(file.fileDescriptor, STDOUT_FILENO) >= 0)
+            defer {
+                fflush(stdout)
+                dup2(saved, STDOUT_FILENO)
+            }
+            try body()
+            fflush(stdout)
+            return try String(contentsOf: url, encoding: .utf8)
+        }
+
+        @MainActor
+        @Test("forwards layout synchronously on the calling thread and notifies on main", arguments: [false, true])
+        func forwardsLayout(background: Bool) async throws {
+            let wasLogging = hedgeLogEnabled
+            hedgeLogEnabled = false
+            defer { hedgeLogEnabled = wasLogging }
+            var originalCalls: [(UIView, CALayer, Bool)] = []
+            var notifications = 0
+            try await withOriginalLayoutStub({ view, layer in
+                originalCalls.append((view, layer, Thread.isMainThread))
+            }) { view, layer in
+                registrationToken = ApplicationViewLayoutPublisher.shared.onViewLayout.subscribe(throttle: 0, trailing: true) {
+                    #expect(Thread.isMainThread)
+                    #expect(originalCalls.count == 1)
+                    notifications += 1
+                }
+                if background {
+                    try runOffMain { view.layoutSublayers(of: layer) }
+                } else {
+                    view.layoutSublayers(of: layer)
+                }
+                try #require(originalCalls.count == 1)
+                #expect(originalCalls[0].0 === view)
+                #expect(originalCalls[0].1 === layer)
+                #expect(originalCalls[0].2 == !background)
+                await waitUntil { notifications == 1 }
+                #expect(notifications == 1)
+            }
+        }
+
+        @MainActor
+        @Test("warns before forwarding off-main layout only once while debug logging is enabled", arguments: [1, 32])
+        func warnsAboutBackgroundLayout(calls: Int) async throws {
+            let wasLogging = hedgeLogEnabled
+            defer { hedgeLogEnabled = wasLogging }
+            let warning = "UIView.layoutSublayers(of:) was called off the main thread"
+            let marker = "original-layout-called"
+            try await withOriginalLayoutStub({ _, _ in print(marker) }) { view, layer in
+                let publisher = ApplicationViewLayoutPublisher.shared
+                publisher.resetBackgroundLayoutWarning()
+                defer { publisher.resetBackgroundLayoutWarning() }
+                registrationToken = publisher.onViewLayout.subscribe(throttle: 0, trailing: true) {}
+
+                hedgeLogEnabled = false
+                let disabled = try captureStdout {
+                    try runOffMain { view.layoutSublayers(of: layer) }
+                }
+                #expect(!disabled.contains(warning))
+                #expect(disabled.contains(marker))
+
+                hedgeLogEnabled = true
+                let main = try captureStdout { view.layoutSublayers(of: layer) }
+                #expect(!main.contains(warning))
+                #expect(main.contains(marker))
+
+                let call = StubbedLayoutCall(view: view, layer: layer)
+                let concurrent = try captureStdout {
+                    try runOffMain {
+                        DispatchQueue.concurrentPerform(iterations: calls) { _ in
+                            call.view.layoutSublayers(of: call.layer)
+                        }
+                    }
+                }
+                #expect(concurrent.components(separatedBy: warning).count - 1 == 1)
+                #expect(concurrent.components(separatedBy: marker).count - 1 == calls)
+                if calls == 1 {
+                    let warningRange = try #require(concurrent.range(of: warning))
+                    let originalRange = try #require(concurrent.range(of: marker))
+                    #expect(warningRange.lowerBound < originalRange.lowerBound)
+                }
+
+                registrationToken = nil
+                registrationToken = publisher.onViewLayout.subscribe(throttle: 0, trailing: true) {}
+                let restarted = try captureStdout {
+                    try runOffMain { view.layoutSublayers(of: layer) }
+                }
+                #expect(!restarted.contains(warning))
+                #expect(restarted.contains(marker))
+            }
+        }
+
         // invoke() hops to a background throttle queue then back to main, so effects are async.
+        @MainActor
         private func waitUntil(timeoutNanoseconds: UInt64 = 1_000_000_000,
                                pollNanoseconds: UInt64 = 5_000_000,
                                _ condition: () -> Bool) async


### PR DESCRIPTION
## :bulb: Motivation and Context

Related to #806. The layout hook forwards to UIKit before notifying PostHog, so an exception in UIKit can occur before the existing notification thread check. The investigation reproduced the crash path with and without the hook. The customer's production trigger remains unproven.

This adds a debug-gated warning before forwarding an off-main layout call. A dedicated lock makes the warning once per process. Calls while debug logging is disabled do not consume it, and restarting the layout subscription does not reset it.

UIKit forwarding remains synchronous on the calling thread. PostHog notifications still run on main. There is no layout suppression, new public option, or scheduler redesign. The lifecycle reproductions in #814 and the architecture proposal in #813 remain separate work.

## :green_heart: How did you test it?

- Added regression tests for main/background forwarding, view and layer identity, main-thread callback delivery, debug gating, warning order, concurrent once-only logging, and subscription restarts. The tests replace only a test view's call-through, not UIKit layout for other views.
- Verified the warning test failed against the original SDK because no warning was emitted.
- The focused iOS suite passes under Thread Sanitizer with three repetitions on iOS 26.5. The new subscriptions use replay's trailing delivery. The polling helper now runs on main to avoid reading callback counters concurrently.
- `make test`, `make format`, and `make lint` pass after syncing with main.
- `make build` passes all SDK platforms and platform examples, then fails in the external-SDK client example because its package reference assumes the checkout directory is named `posthog-ios`. The worktree is named `posthog-ios-issue-806`. CocoaPods examples were not reached.
- Isolated autoreview against `origin/main` passed for `88a4f5d0cfd80df9bf3d1c2bf9333aea8338d58f` with no actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed. No public API change.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file. A patch changeset was added directly.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Manoel directed the scope. Pi used file read/edit tools, shell commands, GitHub CLI, make-based validation, and isolated Pi autoreview. Investigation details are in #806.

The chosen change is diagnostic only. We explicitly rejected changing UIKit layout timing, adding a suppression flag, or claiming that the SDK's presence in the crash stack proves causation. A separate draft contains the lifecycle reproductions. Human review is required.
