### PR TITLE
feat(surveys): target linked feature flag variants

### DIFF
--- a/.changeset/wet-bags-remain.md
+++ b/.changeset/wet-bags-remain.md
@@ -1,0 +1,5 @@
+---
+"posthog-ios": minor
+---
+
+Support survey targeting by a specific linked feature flag variant.

--- a/PostHog/Models/Surveys/PostHogSurveyConditions.swift
+++ b/PostHog/Models/Surveys/PostHogSurveyConditions.swift
@@ -23,6 +23,8 @@ struct PostHogSurveyConditions: Decodable {
     let seenSurveyWaitPeriodInDays: Int?
     /// Event-based conditions for displaying the survey (optional)
     let events: PostHogSurveyEventConditions?
+    /// Required variant of the linked flag; "any" accepts any enabled value.
+    let linkedFlagVariant: String?
     /// Action-based conditions for displaying the survey (optional)
     let actions: PostHogSurveyActionsConditions?
 }

--- a/PostHog/Surveys/PostHogSurveyIntegration.swift
+++ b/PostHog/Surveys/PostHogSurveyIntegration.swift
@@ -161,7 +161,7 @@
 
                         // all keys must be enabled
                         return Set(allKeys)
-                            .allSatisfy(self.isSurveyFeatureFlagEnabled)
+                            .allSatisfy(self.isSurveyFeatureFlagEnabled) && self.matchesLinkedFlagVariant(survey)
                     }
                     .filter { survey in // 5. and if event-based, have been activated by that event
                         survey.hasEvents ? self.isSurveyEventActivated(survey: survey) : true
@@ -271,6 +271,15 @@
             }
 
             return postHog.isFeatureEnabled(flagKey)
+        }
+
+        private func matchesLinkedFlagVariant(_ survey: PostHogSurvey) -> Bool {
+            guard let variant = survey.conditions?.linkedFlagVariant, !variant.isEmpty, variant != "any",
+                  let key = survey.linkedFlagKey, !key.isEmpty
+            else {
+                return true
+            }
+            return postHog?.getFeatureFlag(key, sendFeatureFlagEvent: false) as? String == variant
         }
 
         /// Shows next survey in queue. No-op if a survey is already being shown

--- a/PostHogTests/PostHogSurveysTest.swift
+++ b/PostHogTests/PostHogSurveysTest.swift
@@ -675,6 +675,7 @@ enum PostHogSurveysTest {
                         repeatedActivation: repeatedActivation,
                         values: values
                     ),
+                    linkedFlagVariant: nil,
                     actions: nil
                 ),
                 appearance: nil,
@@ -1568,6 +1569,43 @@ enum PostHogSurveysTest {
             #expect(matchedSurveys.map(\.id).contains("survey-with-flags"))
             #expect(matchedSurveys.map(\.id).contains("survey-without-flags"))
             #expect(!matchedSurveys.map(\.id).contains("survey-with-disabled-flags"))
+        }
+
+        @Test("matches the linked flag variant without bypassing other targeting", arguments: [
+            ("linked-blue", "blue", true),
+            ("linked-blue", "red", false),
+            ("linked-blue", "Blue", false),
+            ("linked-flag-enabled", "blue", false),
+            ("linked-flag-disabled", "blue", false),
+            ("missing-flag", "blue", false),
+            ("linked-blue", "any", true),
+            ("linked-flag-enabled", "any", true),
+            ("linked-flag-disabled", "any", false),
+            ("missing-flag", "any", false),
+            ("linked-blue", nil, true),
+            ("linked-blue", "", true),
+            (nil, "blue", true),
+            ("", "blue", true),
+        ] as [(String?, String?, Bool)])
+        func matchesLinkedFlagVariant(linkedKey: String?, variant: String?, matches: Bool) async throws {
+            server.featureFlags?["linked-blue"] = "blue"
+            var survey = try #require(try parseSurveys(activeSurvey).first)
+            survey["linked_flag_key"] = linkedKey
+            survey["conditions"] = variant.map { ["linkedFlagVariant": $0] } ?? [:]
+            var blockedSurvey = survey
+            blockedSurvey["id"] = "blocked"
+            blockedSurvey["targeting_flag_key"] = "survey-targeting-flag-disabled"
+
+            let sut = getSut(surveys: [])
+            let surveys = sut.decodeSurveys(from: ["surveys": [survey, blockedSurvey]])
+            sut.updateSurveyCache(surveys, events: [:])
+            await withCheckedContinuation { continuation in
+                postHog.remoteConfig?.reloadFeatureFlags { _ in continuation.resume() }
+            }
+            let matched: [PostHogSurvey] = await withCheckedContinuation { continuation in
+                sut.getActiveMatchingSurveys { continuation.resume(returning: $0) }
+            }
+            #expect(matched.map(\.id) == (matches ? ["active_id"] : []))
         }
 
         @Test("Should not return surveys when any feature flag is disabled")


### PR DESCRIPTION
## :bulb: Motivation and Context

A survey linked to the `blue` feature flag variant currently also matches users in `red`. Decode `conditions.linkedFlagVariant` and require an exact, case-sensitive match, moving surveys toward feature parity across SDKs.

`any` still requires an enabled linked flag. Missing/empty variant conditions preserve existing behavior, and other targeting conditions still apply. This PR is independent of partial-response/resume work.

Closes #445.

## :green_heart: How did you test it?

- 14 parameterized cases exercise decoded surveys through the real SDK matcher; mismatching variants failed before the change.
- All 78 survey-matching tests pass. Formatting, lint, public API checks, and CodeScene pass.
- iOS, macOS, and Mac Catalyst SDK builds pass. `make build` stops at tvOS because its platform SDK is not installed; watchOS/visionOS are also unavailable.
- Full `make test` has event/session assertion failures outside the matcher. The survey-event failures also reproduce on untouched `main` (`make test filter=PostHogSurveyEventsTest`).

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed. Update the support matrix after release.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Codex used the GitHub CLI and CodeScene. Matching follows web/RN semantics; no UI changes or manual device testing.
