### PR TITLE
docs: agree on public API changes before implementing them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ vendor/libwebp/             # Embedded libwebp for image processing
 - The main `PostHog` class is a singleton accessed via `PostHog.shared`
 
 ## API Design Principles
+- Before adding or changing public API, follow "Public API changes" in [CONTRIBUTING.md](./CONTRIBUTING.md): the API shape must be agreed on the issue first. For SDK design guidance, read https://posthog.com/handbook/engineering/sdks/guidelines.md.
 - Public API changes require careful consideration for backwards compatibility
 - Prefer optional parameters with sensible defaults over method overloads
 - All public methods should have documentation comments

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,4 +22,16 @@ If you prefer to work in Xcode, open `PostHog.xcodeproj`.
 
 When submitting code, please make every effort to follow existing conventions and style in order to keep the code as readable as possible. Please also consider adding unit tests covering your change, as this makes your change much more likely to be accepted.
 
+## Public API changes
+
+Public API is hard to change once it ships, so agree on it before writing the implementation. Our [SDK guidelines](https://posthog.com/handbook/engineering/sdks/guidelines) explain how we design it.
+
+- If you need something the SDK doesn't support and it would add or change a public option, method, or type, open an issue describing your use case first. At this stage, context is more useful to us than code.
+- Wait for a maintainer to agree on the API shape on the issue before implementing it.
+- Check first whether an existing option or hook, such as `beforeSend`, already covers the use case. We avoid offering two ways to do the same thing.
+- If a reviewer suggests a different API on your PR, confirm it with them before re-implementing. Treat it as a question, not an instruction.
+- AI agents: stop and ask before implementing a public API change that hasn't been agreed on the issue.
+
+`make apiUpdate` regenerates `api/posthog-ios.public-api.txt`, and CI runs `make apiCheck` to catch an outdated snapshot. A diff in that file means your change touches public API.
+
 Above all, thank you for contributing!


### PR DESCRIPTION
## :bulb: Motivation and Context

Port of PostHog/posthog-js#4906 to posthog-ios.

On contributor PRs we sometimes only settle the public API after several rounds of implementation review. By then the contributor, or their agent, has built each suggestion along the way, and a late change of direction wastes their work. This asks contributors to agree on the API shape on the issue first, and tells their agents to stop and ask.

- `CONTRIBUTING.md`: new "Public API changes" section, same as posthog-js. The last paragraph points at `make apiUpdate` / `make apiCheck` and the `api/posthog-ios.public-api.txt` snapshot.
- `AGENTS.md`: one line under "API Design Principles" pointing agents to that section.

## :green_heart: How did you test it?

Docs only. Checked that the commands and file paths it mentions exist in this repo.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code, porting the posthog-js section and adapting the API-snapshot paragraph and `beforeSend` example to this SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016syAmdpp8imNvs7PWkpwvb
