### PR TITLE
fix(replay): preserve masks across siblings and collapse animations

### DIFF
--- a/.changeset/replay-inherited-mask-and-rendered-bounds.md
+++ b/.changeset/replay-inherited-mask-and-rendered-bounds.md
@@ -1,0 +1,6 @@
+---
+"posthog-ios": patch
+---
+
+- Preserve inherited session replay masking across siblings inside full-window `ph-no-capture` views.
+- Keep collecting masks inside clipping views whose model frame reaches zero while their presentation bounds remain visible during an animation.

--- a/PostHog/Replay/PostHogReplayIntegration.swift
+++ b/PostHog/Replay/PostHogReplayIntegration.swift
@@ -858,7 +858,7 @@
             return (hasText, hasGraphic)
         }
 
-        private func findMaskableWidgets(_ view: UIView, _ window: UIWindow, _ maskableWidgets: inout [MaskedRegion], _ maskChildren: inout Bool) {
+        private func findMaskableWidgets(_ view: UIView, _ window: UIWindow, _ maskableWidgets: inout [MaskedRegion], _ maskChildren: Bool) {
             // Checked first so an explicit unmask wins over the sensitive-type early-returns
             // below, matching the modifier's precedence.
             if view.isNoMask() {
@@ -1018,6 +1018,7 @@
 
             // on RN, lots get converted to RCTRootContentView, RCTRootView, RCTView and sometimes its just the whole screen, we dont want to mask
             // in such cases
+            var maskDescendants = maskChildren
             if view.isNoCapture() || maskChildren {
                 let viewRect = view.toAbsoluteRect(window)
                 let windowRect = window.frame
@@ -1026,7 +1027,7 @@
                 if !viewRect.equalTo(windowRect) {
                     maskableWidgets.append(.init(view, in: window))
                 } else {
-                    maskChildren = true
+                    maskDescendants = true
                 }
             }
 
@@ -1036,10 +1037,9 @@
                         continue
                     }
 
-                    findMaskableWidgets(child, window, &maskableWidgets, &maskChildren)
+                    findMaskableWidgets(child, window, &maskableWidgets, maskDescendants)
                 }
             }
-            maskChildren = false
         }
 
         /// Recursively iterate through layer hierarchy to find maskable layers (iOS 26+)
@@ -1119,8 +1119,7 @@
             }
 
             var maskableWidgets: [MaskedRegion] = []
-            var maskChildren = false
-            findMaskableWidgets(window, window, &maskableWidgets, &maskChildren)
+            findMaskableWidgets(window, window, &maskableWidgets, false)
             maskableWidgets.append(contentsOf: masked.regions)
             return maskableWidgets
         }

--- a/PostHog/Replay/UIView+Util.swift
+++ b/PostHog/Replay/UIView+Util.swift
@@ -28,7 +28,7 @@
             if isHidden || !hasRenderedOpacity {
                 return false
             }
-            if frame == .zero, clipsToBounds {
+            if frame == .zero, clipsToBounds, (layer.presentation()?.bounds ?? bounds).isEmpty {
                 return false
             }
             return true

--- a/PostHogTests/PostHogMaskFailClosedTest.swift
+++ b/PostHogTests/PostHogMaskFailClosedTest.swift
@@ -34,6 +34,28 @@
         override class var layerClass: AnyClass { FadingOutLayer.self }
     }
 
+    private final class CustomDrawnSecretView: UIView {
+        override func draw(_ rect: CGRect) {
+            ("Sensitive content" as NSString).draw(in: rect, withAttributes: [.foregroundColor: UIColor.black])
+        }
+    }
+
+    private final class CollapsingLayer: CALayer {
+        var renderedBounds: CGRect = .zero
+
+        override func presentation() -> Self? {
+            let presentation = CollapsingLayer()
+            presentation.bounds = renderedBounds
+            presentation.position = position
+            presentation.opacity = opacity
+            return presentation as? Self
+        }
+    }
+
+    private final class CollapsingView: UIView {
+        override class var layerClass: AnyClass { CollapsingLayer.self }
+    }
+
     @Suite("Replay masking fails closed", .serialized)
     @MainActor
     struct PostHogMaskFailClosedTest {
@@ -233,6 +255,59 @@
             let window = makeWindow(containing: wrapper)
 
             #expect(sut.integration.collectMaskableRects(in: window) == [])
+        }
+
+        @Test("a preceding sibling cannot clear an inherited no-capture mask", arguments: [true, false])
+        func inheritedMaskSurvivesSiblingTraversal(zeroSizeFirstChild: Bool) throws {
+            let sut = makeSut()
+            defer { teardown(sut) }
+
+            let parent = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+            parent.accessibilityIdentifier = "ph-no-capture"
+            let firstChild = UIView(frame: zeroSizeFirstChild ? .zero : CGRect(x: 0, y: 0, width: 20, height: 20))
+            firstChild.clipsToBounds = false
+            parent.addSubview(firstChild)
+            let secret = CustomDrawnSecretView(frame: CGRect(x: 24, y: 120, width: 200, height: 32))
+            parent.addSubview(secret)
+            let window = makeWindow(containing: parent)
+
+            let rects = try #require(sut.integration.collectMaskableRects(in: window))
+            #expect(rects.contains(secret.frame))
+        }
+
+        @Test("inherited masking respects explicit no-mask and stays within the marked subtree")
+        func inheritedMaskRespectsScopeAndNoMask() {
+            let sut = makeSut()
+            defer { teardown(sut) }
+
+            let parent = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+            parent.accessibilityIdentifier = "ph-no-capture"
+            let unmaskedChild = CustomDrawnSecretView(frame: CGRect(x: 24, y: 80, width: 200, height: 32))
+            unmaskedChild.accessibilityIdentifier = "ph-no-mask"
+            parent.addSubview(unmaskedChild)
+            let secret = CustomDrawnSecretView(frame: CGRect(x: 24, y: 120, width: 200, height: 32))
+            parent.addSubview(secret)
+            let window = makeWindow(containing: parent)
+            window.addSubview(CustomDrawnSecretView(frame: CGRect(x: 24, y: 160, width: 200, height: 32)))
+
+            #expect(sut.integration.collectMaskableRects(in: window) == [secret.frame])
+        }
+
+        @Test("a collapsed clipping parent is walked while its presentation bounds remain visible", arguments: [true, false])
+        func collapsingClippingParentUsesRenderedBounds(presentationIsVisible: Bool) throws {
+            let sut = makeSut()
+            defer { teardown(sut) }
+
+            let wrapper = CollapsingView(frame: .zero)
+            wrapper.clipsToBounds = true
+            let layer = try #require(wrapper.layer as? CollapsingLayer)
+            layer.renderedBounds = presentationIsVisible ? CGRect(x: 0, y: 0, width: 320, height: 640) : .zero
+            let label = makeSecretLabel(frame: CGRect(x: 24, y: 120, width: 200, height: 32))
+            wrapper.addSubview(label)
+            let window = makeWindow(containing: wrapper)
+
+            #expect(wrapper.frame == .zero)
+            #expect(sut.integration.collectMaskableRects(in: window) == (presentationIsVisible ? [label.frame] : []))
         }
 
         // MARK: - Fading views


### PR DESCRIPTION
## :bulb: Motivation and Context

Follow-up to two review findings on the merged #822: [inherited masking across siblings](https://github.com/PostHog/posthog-ios/pull/822#discussion_r3989418863) and [presentation bounds during collapse animations](https://github.com/PostHog/posthog-ios/pull/822#discussion_r3989418871).

Inside a full-window `ph-no-capture` view, visiting one child could clear the shared masking flag for later siblings. This could leave custom-drawn content unmasked. The walk now passes the inherited flag by value so each sibling receives the same parent state.

A clipping view could also be skipped when its model frame reached zero, even though its presentation bounds were still visible during an animation. The existing zero-frame/clipping check now consults presentation bounds before skipping the subtree. Other views do not pay for an extra presentation-layer read.

The synchronous Flutter bridge API is unchanged. Includes a patch changeset.

## :green_heart: How did you test it?

Both concerns were reproduced with failing regression tests on `main` before changing production code. The sibling test failed with both zero-size and normal-size preceding children. The collapse test failed when the model frame was zero but presentation bounds were nonempty. These tests now pass, along with controls for empty presentation bounds, explicit `ph-no-mask`, and masking scope.

- All 101 tests across nine relevant iOS Simulator suites passed on iPhone 17 Pro, iOS 26.5. They passed again after runtime validation and removal of the temporary harness.
- A separate real UIKit simulator run compared the base SDK with this PR, including a real collapse animation. All 52 uploaded frames across both runs were decoded and checked. Both leaks reproduced on the baseline and were masked with the fix. Explicit unmasking, subtree scope, fade-out, zero-size containers, injected render failure, and recovery controls passed. [Runtime results and limitations](https://github.com/PostHog/posthog-ios/pull/826#issuecomment-5638744953).
- `make test` passed with 172 XCTest tests and 799 Swift Testing tests.
- `make format`, `make lint`, and `make apiCheck` passed.
- `make build` passed all SDK platforms and platform examples. XCFramework creation passed, but its client failed dependency resolution because it expects package identity `posthog-ios` rather than the worktree directory name. CocoaPods targets were not reached.
- Autoreview of `e76b246d1` against `origin/main` reported no actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed. No public API documentation changes are needed.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Added a patch changeset directly in `.changeset/`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi used `read`, `edit`, `write`, and `bash` tools to implement and validate this follow-up in a fresh worktree from `main`. XcodeBuildMCP and AXe were used for the simulator runtime checks. An isolated Pi autoreview checked the committed diff. No public session link is available.

The fixes keep mask state local to each subtree and retain the existing fast path for visible model geometry. They do not change the deferred Flutter capture-result behavior. Human review is required.
