### PR TITLE
feat(push): capture each PostHog push open once across automatic and manual paths

### DIFF
--- a/.changeset/push-open-dedupe.md
+++ b/.changeset/push-open-dedupe.md
@@ -2,4 +2,4 @@
 'posthog-ios': minor
 ---
 
-Change `capturePushNotificationOpened` to skip a repeat open of a PostHog-sent notification (same `invocation_id` and `action_id`) captured in the last 5 minutes, so an automatic capture plus a manual call for one tap counts once.
+Change `capturePushNotificationOpened` to skip a repeat open of a PostHog-sent notification (same `invocation_id` and `action_id`) captured in the last 5 minutes, so an automatic capture plus a manual call for one tap counts once, while a resend of that notification (a new `UNNotificationRequest` identifier) still counts.

--- a/.changeset/push-open-dedupe.md
+++ b/.changeset/push-open-dedupe.md
@@ -2,4 +2,4 @@
 'posthog-ios': minor
 ---
 
-Change `capturePushNotificationOpened` to skip a repeat open of a PostHog-sent notification (same `invocation_id` and `action_id`) captured in the last 5 minutes, so an automatic capture plus a manual call for one tap counts once, while a resend of that notification (a new `UNNotificationRequest` identifier) still counts.
+Change `capturePushNotificationOpened` to skip a PostHog-sent notification open already captured in the last 5 minutes (same `invocation_id` and `action_id`), unless the notification's request identifier differs.

--- a/.changeset/push-open-dedupe.md
+++ b/.changeset/push-open-dedupe.md
@@ -1,0 +1,5 @@
+---
+'posthog-ios': minor
+---
+
+Change `capturePushNotificationOpened` to skip a repeat open of a PostHog-sent notification (same `invocation_id` and `action_id`) captured in the last 5 minutes, so an automatic capture plus a manual call for one tap counts once.

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -187,6 +187,10 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
         /// notification, by swizzling `UNUserNotificationCenterDelegate`. Locally-scheduled notifications
         /// are ignored — call `capturePushNotificationOpened(response:)` yourself to capture those.
         ///
+        /// A notification sent by PostHog is captured once: a manual `capturePushNotificationOpened`
+        /// call for a tap this already captured (same `posthog.invocation_id` and `action_id`, within
+        /// 5 minutes) is skipped, and so is the reverse.
+        ///
         /// - Note: Requires `enableSwizzling` to be `true`. To capture opens without swizzling, call
         ///   `PostHogSDK.capturePushNotificationOpened(response:)` from your own
         ///   `userNotificationCenter(_:didReceive:withCompletionHandler:)` implementation.

--- a/PostHog/PostHogConfig.swift
+++ b/PostHog/PostHogConfig.swift
@@ -185,11 +185,16 @@ public typealias BeforeSendBlock = (PostHogEvent) -> PostHogEvent?
 
         /// Automatically capture a `$push_notification_opened` event when the user taps a **remote** push
         /// notification, by swizzling `UNUserNotificationCenterDelegate`. Locally-scheduled notifications
-        /// are ignored — call `capturePushNotificationOpened(response:)` yourself to capture those.
+        /// are ignored — capture those yourself with
+        /// `PostHogSDK.capturePushNotificationOpened(title:subtitle:body:payload:action:)`, passing the
+        /// content you scheduled. `capturePushNotificationOpened(response:)` reads title/subtitle/body
+        /// only from notifications PostHog sent (a `posthog` key in `userInfo`), so for a local one it
+        /// captures the open with no content.
         ///
         /// A notification sent by PostHog is captured once: a manual `capturePushNotificationOpened`
         /// call for a tap this already captured (same `posthog.invocation_id` and `action_id`, within
-        /// 5 minutes) is skipped, and so is the reverse.
+        /// 5 minutes) is skipped, and so is the reverse. A resend of that notification is a separate
+        /// tap and is captured.
         ///
         /// - Note: Requires `enableSwizzling` to be `true`. To capture opens without swizzling, call
         ///   `PostHogSDK.capturePushNotificationOpened(response:)` from your own

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -3326,20 +3326,18 @@ let maxRetryDelay = 30.0
         }
 
         /// A duplicate report of one tap arrives within the same launch: milliseconds after a warm tap,
-        /// seconds after a cold start while the host's JS/Dart handlers register. The window stays finite
-        /// because a workflow that loops back to a push step re-sends the same `invocation_id`/`action_id`
-        /// pair as a new notification, and that later open must still count.
+        /// seconds after a cold start while the host's JS/Dart handlers register. Finite so that a re-send
+        /// carrying no delivery id to tell it apart still counts once the window has passed.
         private static let pushOpenDedupeWindow: TimeInterval = 5 * 60
 
         /// Only the opens of the last few minutes matter; the cap bounds memory for a host that calls the
         /// API in bulk.
         private static let maxRecentPushOpens = 20
 
-        /// Captured PostHog push opens in insertion order — each capture is appended to the back, and the
-        /// cap evicts from the front — as `invocation_id/action_id`, the wall clock at capture, and the id
-        /// of the delivery that was captured. Notification callbacks and manual calls arrive on different
-        /// threads, so the buffer is only touched under its lock. In memory only: both reports of one tap
-        /// happen in the same launch.
+        /// Recently captured PostHog push opens, keyed by `invocation_id/action_id`, oldest first —
+        /// appended at the back, evicted from the front. Notification callbacks and manual calls arrive on
+        /// different threads, so the buffer is only touched under its lock. In memory only: both reports
+        /// of one tap happen in the same launch.
         private var recentPushOpens: [RecentPushOpen] = []
         private let recentPushOpensLock = NSLock()
 
@@ -3361,11 +3359,15 @@ let maxRetryDelay = 30.0
 
             return recentPushOpensLock.withLock {
                 if let index = recentPushOpens.firstIndex(where: { $0.key == key }) {
-                    let elapsed = capturedAt.timeIntervalSince(recentPushOpens[index].capturedAt)
+                    let previous = recentPushOpens[index]
                     // A negative gap means the wall clock moved back; capture rather than risk dropping an open.
-                    if elapsed >= 0, elapsed < Self.pushOpenDedupeWindow,
-                       !Self.isNewDelivery(recentPushOpens[index].deliveryId, deliveryId)
-                    {
+                    let elapsed = capturedAt.timeIntervalSince(previous.capturedAt)
+                    let insideWindow = elapsed >= 0 && elapsed < Self.pushOpenDedupeWindow
+                    // A re-send of the same workflow step reuses the key, so only delivery ids that are
+                    // present on both reports and disagree prove a second notification rather than a second
+                    // report of one tap.
+                    let resent = previous.deliveryId != nil && deliveryId != nil && previous.deliveryId != deliveryId
+                    if insideWindow, !resent {
                         hedgeLog("Skipped $push_notification_opened: notification \(key) was already captured.")
                         return false
                     }
@@ -3377,16 +3379,6 @@ let maxRetryDelay = 30.0
                 }
                 return true
             }
-        }
-
-        /// Whether this report is a second notification rather than a second report of one tap. A rerun of
-        /// a workflow, or a loop back to its push step, re-sends the same `invocation_id`/`action_id` pair,
-        /// and only the delivery id tells that apart from the manual repeat the dedupe exists for — so the
-        /// two ids have to disagree, not merely be absent. A report without one (the field-based overload
-        /// never has one), or a first capture that had none, stays deduped.
-        private static func isNewDelivery(_ previous: String?, _ reported: String?) -> Bool {
-            guard let previous, let reported else { return false }
-            return previous != reported
         }
     #endif
 }

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -3193,6 +3193,10 @@ let maxRetryDelay = 30.0
         /// method, from the field-based overload, or from the SDK's automatic capture. Notifications
         /// without a `posthog.invocation_id` are always captured.
         ///
+        /// A rerun of that workflow, or a loop back to its push step, sends the pair again as a new
+        /// notification, and its open counts separately: two responses whose
+        /// `notification.request.identifier` differ are two taps, not one reported twice.
+        ///
         /// - Parameter response: The `UNNotificationResponse` received from the system.
         @available(iOS 14.0, macOS 11.0, *)
         @objc public func capturePushNotificationOpened(response: UNNotificationResponse) {
@@ -3207,7 +3211,8 @@ let maxRetryDelay = 30.0
                 subtitle: isPostHogNotification ? content.subtitle : nil,
                 body: isPostHogNotification ? content.body : nil,
                 payload: content.userInfo,
-                action: response.actionIdentifier
+                action: response.actionIdentifier,
+                deliveryId: response.notification.request.identifier
             )
         }
 
@@ -3221,7 +3226,9 @@ let maxRetryDelay = 30.0
         /// `invocation_id`, a repeat with the same `invocation_id` and `action_id` within 5 minutes
         /// of the first capture is skipped, whether that first capture came from this method or from
         /// the SDK's automatic capture. Payloads without a `posthog.invocation_id` are always
-        /// captured.
+        /// captured. This overload carries no notification identifier, so a rerun of that workflow
+        /// reported through it inside the window reads as the same tap and is skipped; report a rerun
+        /// through `capturePushNotificationOpened(response:)`, which can tell the deliveries apart.
         ///
         /// - Parameters:
         ///   - title: The notification title; omitted from the event when `nil` or empty.
@@ -3239,6 +3246,30 @@ let maxRetryDelay = 30.0
             payload: [AnyHashable: Any]? = nil,
             action: String? = nil
         ) {
+            capturePushNotificationOpened(
+                title: title,
+                subtitle: subtitle,
+                body: body,
+                payload: payload,
+                action: action,
+                deliveryId: nil
+            )
+        }
+
+        /// - Parameter deliveryId: The system's id for the delivered notification
+        ///   (`UNNotificationResponse.notification.request.identifier`), which separates a second
+        ///   notification from a second report of one tap. Only the `response:` overload has one; a caller
+        ///   passing raw fields does not, which is why this stays off the public API. Not `private`
+        ///   because `UNNotificationResponse` has no initializer, so tests reach the delivery-id paths
+        ///   only through here.
+        func capturePushNotificationOpened(
+            title: String?,
+            subtitle: String?,
+            body: String?,
+            payload: [AnyHashable: Any]?,
+            action: String?,
+            deliveryId: String?
+        ) {
             if !isEnabled() {
                 return
             }
@@ -3248,7 +3279,7 @@ let maxRetryDelay = 30.0
             }
 
             let posthogData = posthogPayload(from: payload?["posthog"])
-            if !recordPushOpen(posthogData) {
+            if !recordPushOpen(posthogData, deliveryId: deliveryId) {
                 return
             }
 
@@ -3305,15 +3336,22 @@ let maxRetryDelay = 30.0
         private static let maxRecentPushOpens = 20
 
         /// Captured PostHog push opens in insertion order — each capture is appended to the back, and the
-        /// cap evicts from the front — as `invocation_id/action_id` and the wall clock at capture.
-        /// Notification callbacks and manual calls arrive on different threads, so the buffer is only
-        /// touched under its lock. In memory only: both reports of one tap happen in the same launch.
-        private var recentPushOpens: [(key: String, capturedAt: Date)] = []
+        /// cap evicts from the front — as `invocation_id/action_id`, the wall clock at capture, and the id
+        /// of the delivery that was captured. Notification callbacks and manual calls arrive on different
+        /// threads, so the buffer is only touched under its lock. In memory only: both reports of one tap
+        /// happen in the same launch.
+        private var recentPushOpens: [RecentPushOpen] = []
         private let recentPushOpensLock = NSLock()
+
+        private struct RecentPushOpen {
+            let key: String
+            let capturedAt: Date
+            let deliveryId: String?
+        }
 
         /// Records a PostHog push open, returning `false` when the same notification was already captured
         /// inside the dedupe window and this report should be skipped.
-        private func recordPushOpen(_ posthogData: [String: Any]?) -> Bool {
+        private func recordPushOpen(_ posthogData: [String: Any]?, deliveryId: String?) -> Bool {
             guard let invocationId = posthogData?["invocation_id"] as? String, !invocationId.isEmpty else {
                 return true
             }
@@ -3325,18 +3363,30 @@ let maxRetryDelay = 30.0
                 if let index = recentPushOpens.firstIndex(where: { $0.key == key }) {
                     let elapsed = capturedAt.timeIntervalSince(recentPushOpens[index].capturedAt)
                     // A negative gap means the wall clock moved back; capture rather than risk dropping an open.
-                    if elapsed >= 0, elapsed < Self.pushOpenDedupeWindow {
+                    if elapsed >= 0, elapsed < Self.pushOpenDedupeWindow,
+                       !Self.isNewDelivery(recentPushOpens[index].deliveryId, deliveryId)
+                    {
                         hedgeLog("Skipped $push_notification_opened: notification \(key) was already captured.")
                         return false
                     }
                     recentPushOpens.remove(at: index)
                 }
-                recentPushOpens.append((key, capturedAt))
+                recentPushOpens.append(RecentPushOpen(key: key, capturedAt: capturedAt, deliveryId: deliveryId))
                 if recentPushOpens.count > Self.maxRecentPushOpens {
                     recentPushOpens.removeFirst()
                 }
                 return true
             }
+        }
+
+        /// Whether this report is a second notification rather than a second report of one tap. A rerun of
+        /// a workflow, or a loop back to its push step, re-sends the same `invocation_id`/`action_id` pair,
+        /// and only the delivery id tells that apart from the manual repeat the dedupe exists for — so the
+        /// two ids have to disagree, not merely be absent. A report without one (the field-based overload
+        /// never has one), or a first capture that had none, stays deduped.
+        private static func isNewDelivery(_ previous: String?, _ reported: String?) -> Bool {
+            guard let previous, let reported else { return false }
+            return previous != reported
         }
     #endif
 }

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -3304,9 +3304,10 @@ let maxRetryDelay = 30.0
         /// API in bulk.
         private static let maxRecentPushOpens = 20
 
-        /// Captured PostHog push opens, oldest first, as `invocation_id/action_id` and the wall clock at
-        /// capture. Notification callbacks and manual calls arrive on different threads, so the buffer is
-        /// only touched under its lock. In memory only: both reports of one tap happen in the same launch.
+        /// Captured PostHog push opens in insertion order — each capture is appended to the back, and the
+        /// cap evicts from the front — as `invocation_id/action_id` and the wall clock at capture.
+        /// Notification callbacks and manual calls arrive on different threads, so the buffer is only
+        /// touched under its lock. In memory only: both reports of one tap happen in the same launch.
         private var recentPushOpens: [(key: String, capturedAt: Date)] = []
         private let recentPushOpensLock = NSLock()
 

--- a/PostHog/PostHogSDK.swift
+++ b/PostHog/PostHogSDK.swift
@@ -3187,6 +3187,12 @@ let maxRetryDelay = 30.0
         /// PostHog (a `posthog` key in its `userInfo`); unattributed pushes capture the open event
         /// without content. Use the field-based overload to capture content explicitly.
         ///
+        /// A notification sent by PostHog is captured once: when the `posthog` entry of `userInfo`
+        /// carries an `invocation_id`, a repeat with the same `invocation_id` and `action_id` within
+        /// 5 minutes of the first capture is skipped, whether that first capture came from this
+        /// method, from the field-based overload, or from the SDK's automatic capture. Notifications
+        /// without a `posthog.invocation_id` are always captured.
+        ///
         /// - Parameter response: The `UNNotificationResponse` received from the system.
         @available(iOS 14.0, macOS 11.0, *)
         @objc public func capturePushNotificationOpened(response: UNNotificationResponse) {
@@ -3210,6 +3216,12 @@ let maxRetryDelay = 30.0
         /// Use this when no `UNNotificationResponse` is available — for example when you handle a push
         /// yourself in `application(_:didReceiveRemoteNotification:fetchCompletionHandler:)` or relay it
         /// from a cross-platform layer.
+        ///
+        /// A notification sent by PostHog is captured once: when `payload["posthog"]` carries an
+        /// `invocation_id`, a repeat with the same `invocation_id` and `action_id` within 5 minutes
+        /// of the first capture is skipped, whether that first capture came from this method or from
+        /// the SDK's automatic capture. Payloads without a `posthog.invocation_id` are always
+        /// captured.
         ///
         /// - Parameters:
         ///   - title: The notification title; omitted from the event when `nil` or empty.
@@ -3235,6 +3247,11 @@ let maxRetryDelay = 30.0
                 return
             }
 
+            let posthogData = posthogPayload(from: payload?["posthog"])
+            if !recordPushOpen(posthogData) {
+                return
+            }
+
             var properties: [String: Any] = [:]
 
             if let title, !title.isEmpty {
@@ -3249,7 +3266,7 @@ let maxRetryDelay = 30.0
                 properties["$notification_body"] = body
             }
 
-            if let posthogData = posthogPayload(from: payload?["posthog"]) {
+            if let posthogData {
                 for (key, value) in posthogData {
                     properties["$notification_\(key)"] = value
                 }
@@ -3275,6 +3292,50 @@ let maxRetryDelay = 30.0
                 hedgeLog("Push notification 'posthog' payload is not a JSON object; ignoring.")
             }
             return nil
+        }
+
+        /// A duplicate report of one tap arrives within the same launch: milliseconds after a warm tap,
+        /// seconds after a cold start while the host's JS/Dart handlers register. The window stays finite
+        /// because a workflow that loops back to a push step re-sends the same `invocation_id`/`action_id`
+        /// pair as a new notification, and that later open must still count.
+        private static let pushOpenDedupeWindow: TimeInterval = 5 * 60
+
+        /// Only the opens of the last few minutes matter; the cap bounds memory for a host that calls the
+        /// API in bulk.
+        private static let maxRecentPushOpens = 20
+
+        /// Captured PostHog push opens, oldest first, as `invocation_id/action_id` and the wall clock at
+        /// capture. Notification callbacks and manual calls arrive on different threads, so the buffer is
+        /// only touched under its lock. In memory only: both reports of one tap happen in the same launch.
+        private var recentPushOpens: [(key: String, capturedAt: Date)] = []
+        private let recentPushOpensLock = NSLock()
+
+        /// Records a PostHog push open, returning `false` when the same notification was already captured
+        /// inside the dedupe window and this report should be skipped.
+        private func recordPushOpen(_ posthogData: [String: Any]?) -> Bool {
+            guard let invocationId = posthogData?["invocation_id"] as? String, !invocationId.isEmpty else {
+                return true
+            }
+            // Every step of one workflow run shares the run's invocation_id, so action_id tells the steps apart.
+            let key = "\(invocationId)/\(posthogData?["action_id"] as? String ?? "")"
+            let capturedAt = now()
+
+            return recentPushOpensLock.withLock {
+                if let index = recentPushOpens.firstIndex(where: { $0.key == key }) {
+                    let elapsed = capturedAt.timeIntervalSince(recentPushOpens[index].capturedAt)
+                    // A negative gap means the wall clock moved back; capture rather than risk dropping an open.
+                    if elapsed >= 0, elapsed < Self.pushOpenDedupeWindow {
+                        hedgeLog("Skipped $push_notification_opened: notification \(key) was already captured.")
+                        return false
+                    }
+                    recentPushOpens.remove(at: index)
+                }
+                recentPushOpens.append((key, capturedAt))
+                if recentPushOpens.count > Self.maxRecentPushOpens {
+                    recentPushOpens.removeFirst()
+                }
+                return true
+            }
         }
     #endif
 }

--- a/PostHogTests/PostHogPushNotificationTest.swift
+++ b/PostHogTests/PostHogPushNotificationTest.swift
@@ -149,9 +149,16 @@
             capturePushNotificationOpened: Bool = false,
             capturePushNotificationSubscriptions: Bool = false,
             reuseAnonymousId: Bool = false,
-            pushIdentityProvider: ((String, String, @escaping (String?) -> Void) -> Void)? = nil
+            pushIdentityProvider: ((String, String, @escaping (String?) -> Void) -> Void)? = nil,
+            recordOpens: PushOpenRecorder? = nil
         ) -> PostHogSDK {
             let config = PostHogConfig(projectToken: testProjectToken, host: "http://localhost:9001")
+            if let recordOpens {
+                config.setBeforeSend { event in
+                    if event.event == "$push_notification_opened" { recordOpens.record(event) }
+                    return nil
+                }
+            }
             config.flushAt = 1
             config.optOut = optOut
             config.reuseAnonymousId = reuseAnonymousId
@@ -1688,6 +1695,150 @@
             let event = try #require(events.first)
             #expect(event.event == "$push_notification_opened")
             #expect(event.properties["$notification_title"] as? String == "Hello")
+        }
+
+        // MARK: - Open capture dedupe (parity with posthog-android#783)
+
+        /// Collects `$push_notification_opened` events from `beforeSend`, which runs on the calling thread.
+        private final class PushOpenRecorder {
+            private let lock = NSLock()
+            private var events: [PostHogEvent] = []
+
+            func record(_ event: PostHogEvent) {
+                lock.withLock { events.append(event) }
+            }
+
+            var count: Int { lock.withLock { events.count } }
+            var titles: [String?] { property("$notification_title") }
+            func property(_ key: String) -> [String?] {
+                lock.withLock { events.map { $0.properties[key] as? String } }
+            }
+        }
+
+        private let stepOne = #"{"workflow_id":"wf-1","invocation_id":"inv-1","action_id":"step-1"}"#
+        private let stepTwo = #"{"workflow_id":"wf-1","invocation_id":"inv-1","action_id":"step-2"}"#
+
+        private func captureAutomaticOpen(_ sut: PostHogSDK, _ posthog: Any) {
+            sut.capturePushNotificationOpened(
+                title: "Auto",
+                payload: ["posthog": posthog],
+                action: UNNotificationDefaultActionIdentifier
+            )
+        }
+
+        private func captureManualOpen(_ sut: PostHogSDK, _ posthog: Any) {
+            sut.capturePushNotificationOpened(title: "Manual", payload: ["posthog": posthog])
+        }
+
+        @Test("skips a manual repeat of an automatically captured PostHog push")
+        func openDedupeSkipsManualRepeatOfAutomatic() {
+            let opens = PushOpenRecorder()
+            let sut = getSDK(recordOpens: opens)
+            defer { sut.close() }
+
+            captureAutomaticOpen(sut, stepOne)
+            captureManualOpen(sut, stepOne)
+
+            #expect(opens.titles == ["Auto"])
+            #expect(opens.property("$notification_invocation_id") == ["inv-1"])
+        }
+
+        @Test("skips an automatic repeat of a manually captured PostHog push")
+        func openDedupeSkipsAutomaticRepeatOfManual() {
+            let opens = PushOpenRecorder()
+            let sut = getSDK(recordOpens: opens)
+            defer { sut.close() }
+
+            captureManualOpen(sut, ["workflow_id": "wf-1", "invocation_id": "inv-1", "action_id": "step-1"])
+            captureAutomaticOpen(sut, stepOne)
+            captureManualOpen(sut, stepOne)
+
+            #expect(opens.titles == ["Manual"])
+        }
+
+        @Test("keys PostHog pushes by invocation and action")
+        func openDedupeKeysByInvocationAndAction() {
+            let opens = PushOpenRecorder()
+            let sut = getSDK(recordOpens: opens)
+            defer { sut.close() }
+            let noAction = #"{"workflow_id":"wf-1","invocation_id":"inv-1"}"#
+            let otherRun = #"{"workflow_id":"wf-1","invocation_id":"inv-2","action_id":"step-1"}"#
+            let payloads = [stepOne, stepTwo, noAction, otherRun]
+
+            payloads.forEach { captureAutomaticOpen(sut, $0) }
+            payloads.forEach { captureManualOpen(sut, $0) }
+
+            #expect(opens.property("$notification_invocation_id") == ["inv-1", "inv-1", "inv-1", "inv-2"])
+            #expect(opens.property("$notification_action_id") == ["step-1", "step-2", nil, "step-1"])
+        }
+
+        @Test("never dedupes a push without a posthog entry")
+        func openDedupeIgnoresPushWithoutPosthogEntry() {
+            let opens = PushOpenRecorder()
+            let sut = getSDK(recordOpens: opens)
+            defer { sut.close() }
+
+            sut.capturePushNotificationOpened(payload: ["aps": ["alert": "hi"]])
+            sut.capturePushNotificationOpened(title: "Manual", payload: ["aps": ["alert": "hi"]])
+            sut.capturePushNotificationOpened()
+            sut.capturePushNotificationOpened()
+
+            #expect(opens.count == 4)
+        }
+
+        @Test("never dedupes a push with a malformed posthog entry")
+        func openDedupeIgnoresMalformedPosthogEntry() {
+            let opens = PushOpenRecorder()
+            let sut = getSDK(recordOpens: opens)
+            defer { sut.close() }
+            let malformed: [Any] = [
+                "{not json",
+                #"{"action_id":"step-1"}"#,
+                #"{"invocation_id":""}"#,
+                #"{"invocation_id":42}"#,
+                #"["inv-1"]"#,
+                42,
+            ]
+
+            for entry in malformed {
+                captureAutomaticOpen(sut, entry)
+                captureManualOpen(sut, entry)
+            }
+
+            #expect(opens.count == malformed.count * 2)
+        }
+
+        @Test("captures a repeat once the dedupe window has passed")
+        func openDedupeExpiresAfterTheWindow() async {
+            let opens = PushOpenRecorder()
+            await withMockedClock { clock in
+                let start = clock.date
+                let sut = getSDK(recordOpens: opens)
+                defer { sut.close() }
+
+                captureAutomaticOpen(sut, stepOne)
+                clock.date = start.addingTimeInterval(5 * 60 - 1)
+                captureManualOpen(sut, stepOne)
+                clock.date = start.addingTimeInterval(5 * 60)
+                captureManualOpen(sut, stepOne)
+                captureAutomaticOpen(sut, stepOne)
+            }
+
+            #expect(opens.titles == ["Auto", "Manual"])
+        }
+
+        @Test("records nothing for a push dropped while opted out")
+        func openDedupeRecordsNothingWhileOptedOut() {
+            let opens = PushOpenRecorder()
+            let sut = getSDK(optOut: true, recordOpens: opens)
+            defer { sut.close() }
+
+            captureAutomaticOpen(sut, stepOne)
+            sut.optIn()
+            captureManualOpen(sut, stepOne)
+            captureAutomaticOpen(sut, stepOne)
+
+            #expect(opens.titles == ["Manual"])
         }
 
         // MARK: - Opt-in re-registration (posthog-ios#746)

--- a/PostHogTests/PostHogPushNotificationTest.swift
+++ b/PostHogTests/PostHogPushNotificationTest.swift
@@ -1827,6 +1827,38 @@
             #expect(opens.titles == ["Auto", "Manual"])
         }
 
+        @Test("captures a repeat once the wall clock has moved backwards")
+        func openDedupeCapturesRepeatAfterBackwardClock() async {
+            let opens = PushOpenRecorder()
+            await withMockedClock { clock in
+                let start = clock.date
+                let sut = getSDK(recordOpens: opens)
+                defer { sut.close() }
+
+                captureAutomaticOpen(sut, stepOne)
+                clock.date = start.addingTimeInterval(-60)
+                captureManualOpen(sut, stepOne)
+            }
+
+            #expect(opens.titles == ["Auto", "Manual"])
+        }
+
+        @Test("evicts the oldest open at the cap, so its repeat is captured again")
+        func openDedupeEvictsOldestAtCap() {
+            let opens = PushOpenRecorder()
+            let sut = getSDK(recordOpens: opens)
+            defer { sut.close() }
+
+            for i in 0 ..< 21 {
+                captureAutomaticOpen(sut, #"{"invocation_id":"inv-\#(i)","action_id":"step-1"}"#)
+            }
+            captureManualOpen(sut, #"{"invocation_id":"inv-0","action_id":"step-1"}"#)
+            captureManualOpen(sut, #"{"invocation_id":"inv-20","action_id":"step-1"}"#)
+
+            #expect(opens.count == 22)
+            #expect(opens.property("$notification_invocation_id").last == "inv-0")
+        }
+
         @Test("records nothing for a push dropped while opted out")
         func openDedupeRecordsNothingWhileOptedOut() {
             let opens = PushOpenRecorder()

--- a/PostHogTests/PostHogPushNotificationTest.swift
+++ b/PostHogTests/PostHogPushNotificationTest.swift
@@ -1718,11 +1718,16 @@
         private let stepOne = #"{"workflow_id":"wf-1","invocation_id":"inv-1","action_id":"step-1"}"#
         private let stepTwo = #"{"workflow_id":"wf-1","invocation_id":"inv-1","action_id":"step-2"}"#
 
-        private func captureAutomaticOpen(_ sut: PostHogSDK, _ posthog: Any) {
+        /// `UNNotificationResponse` has no initializer, so the automatic path is driven through the
+        /// internal overload the `response:` one funnels into, with the identifier it would read.
+        private func captureAutomaticOpen(_ sut: PostHogSDK, _ posthog: Any, deliveryId: String = "n-1") {
             sut.capturePushNotificationOpened(
                 title: "Auto",
+                subtitle: nil,
+                body: nil,
                 payload: ["posthog": posthog],
-                action: UNNotificationDefaultActionIdentifier
+                action: UNNotificationDefaultActionIdentifier,
+                deliveryId: deliveryId
             )
         }
 
@@ -1754,6 +1759,43 @@
             captureManualOpen(sut, stepOne)
 
             #expect(opens.titles == ["Manual"])
+        }
+
+        @Test("captures a resend of the same workflow step")
+        func openDedupeCapturesResend() {
+            let opens = PushOpenRecorder()
+            let sut = getSDK(recordOpens: opens)
+            defer { sut.close() }
+
+            captureAutomaticOpen(sut, stepOne, deliveryId: "n-1")
+            captureAutomaticOpen(sut, stepOne, deliveryId: "n-2")
+            captureManualOpen(sut, stepOne)
+
+            #expect(opens.count == 2)
+        }
+
+        @Test("skips a repeat report of the same delivery")
+        func openDedupeSkipsRepeatOfSameDelivery() {
+            let opens = PushOpenRecorder()
+            let sut = getSDK(recordOpens: opens)
+            defer { sut.close() }
+
+            captureAutomaticOpen(sut, stepOne, deliveryId: "n-1")
+            captureAutomaticOpen(sut, stepOne, deliveryId: "n-1")
+
+            #expect(opens.count == 1)
+        }
+
+        @Test("skips a resend when the first capture carried no delivery id")
+        func openDedupeSkipsResendAfterManualFirstCapture() {
+            let opens = PushOpenRecorder()
+            let sut = getSDK(recordOpens: opens)
+            defer { sut.close() }
+
+            captureManualOpen(sut, stepOne)
+            captureAutomaticOpen(sut, stepOne, deliveryId: "n-2")
+
+            #expect(opens.count == 1)
         }
 
         @Test("keys PostHog pushes by invocation and action")


### PR DESCRIPTION
## :bulb: Motivation and Context

PostHog/posthog-android#783 made Android capture each PostHog push open once, no matter which path reports it. iOS has the same double-counting problem and, until this lands, the two platforms behave differently for the same public API.

An iOS app double counts when:

- its Firebase `onMessageOpenedApp` / `onNotificationOpenedApp` handler isn't guarded to Android — Firebase fires it on iOS too — and it calls the manual API next to the SDK's automatic capture. That snippet is what the docs used to recommend; PostHog/posthog.com#20102 fixes the docs going forward, this PR covers the apps that already shipped it;
- someone added a `getInitialNotification()` workaround for the iOS cold-start gap that PostHog/posthog-js#4921 now fixes properly — the workaround then fires alongside the real capture.

Every one of those extra events also becomes a `push_opened` app metric server-side with no dedupe, so Workflows open rates are inflated too.

Related: PostHog/posthog-js#4919 and PostHog/posthog-flutter#578 raise each plugin's posthog-android floor to pick up the Android fix.

## Changes

- **One choke point.** iOS already funnels everything into `PostHogSDK.capturePushNotificationOpened(title:subtitle:body:payload:action:)`:
  - the automatic capture in `PostHogPushNotificationOpenIntegration`, which calls `capturePushNotificationOpened(response:)`;
  - `capturePushNotificationOpened(response:)` itself, called directly by apps that own their `UNUserNotificationCenterDelegate`;
  - the field-based overload, called by native apps and by the Flutter / React Native plugins.

  `$push_notification_opened` is emitted in exactly one place, so the check goes there — right after the `isEnabled()` and `isOptOutState()` gates, before the event is built. It doesn't matter which path reports first.
- **Match key: `invocation_id` + `action_id`** from the payload's `posthog` entry, read through the existing `posthogPayload(from:)` — a dictionary on direct APNs, a JSON string when relayed through FCM. The server stamps that entry on every push it sends (`pushCorrelationData` in `push-notification.service.ts`). Every step of one workflow run shares the run's `invocation_id`, so the key includes `action_id`. A missing `action_id` is allowed. With no usable `invocation_id` there's no key and the call behaves exactly as today, which covers pushes from other senders and any malformed entry.
- **Skip and record.** A repeat of a key captured in the last 5 minutes is skipped and logged through `hedgeLog` (the SDK's debug logger, matching the level Android logs at). Otherwise the key is recorded and the event is captured. The opted-out and disabled checks run first, so a call they drop records nothing.
- **A resend is a different notification.** Each entry also remembers the delivery id of the report that captured it: `UNNotificationResponse.notification.request.identifier`, which iOS assigns per delivered notification. A report whose delivery id disagrees with the stored one is a second notification, not a second report of one tap, so it is captured and the entry is updated. The delivery id is never part of the key, because the field-based overload has no `UNNotificationResponse` to take one from, so keying on it would break the manual-repeat dedupe this PR exists for. A report with no delivery id, or one against an entry that stored none, stays deduped. Threading it down adds one internal overload of `capturePushNotificationOpened`, not a public one.
- **Memory.** Keys live in memory on the `PostHogSDK` instance, oldest first, capped at 20 entries, behind an `NSLock` because notification callbacks and manual calls arrive on different threads. Timing uses the SDK's existing wall-clock source (the global `now()`), and only a gap in `0 ..< 5 minutes` counts as a repeat, so a backward clock change lets the open through rather than dropping it.
  - *In memory only:* both reports of one tap happen in the same process, during the same launch.
  - *Why 5 minutes:* a workflow graph can loop back to a push step and a rerun reuses the run's `invocation_id`, so the same key can legitimately arrive again as a new notification — the window has to be finite. The duplicate itself arrives much sooner (milliseconds after a warm tap; seconds after a cold start while a Dart/JS handler registers). Five minutes leaves room for an app that calls `getInitialNotification()` late, e.g. after a splash screen.
  - *Why 20:* an entry only matters inside that window, and a person opens a handful of notifications at most in 5 minutes. The cap only bounds memory for a host that calls the API in bulk.
- **Public API.** No new API — `make apiCheck` reports the snapshot is up to date. The doc comments on both public `capturePushNotificationOpened` overloads now describe the skip, matching what `PostHogInterface`'s KDoc says on Android, and `PostHogConfig.capturePushNotificationOpened` mentions it too.

### Behavior change (minor)

The manual `capturePushNotificationOpened` changes behavior for native apps as well. A call is now skipped if its payload carries the same `posthog.invocation_id` and `action_id` as an open captured in the last 5 minutes, whether that open came from the automatic capture or an earlier manual call. This affects:

- Apps that capture one tap twice — automatic plus manual, or manual from both a tap handler and a `getInitialNotification()`-style call. These now count once, which is the intent of this PR.
- Two different notifications that share a key, when both are opened within 5 minutes. That needs a workflow loop or rerun. Both opens are counted when each tap arrives as its own `UNNotificationResponse`, which is every real tap. Only a report through the field-based overload, which carries no notification identifier, is dropped in that case.

Nothing changes for payloads without a `posthog.invocation_id`. The changeset is `minor`; the next release should be **posthog-ios 3.75.0** unless another changeset lands first.

### Cross-SDK

`sdk-specs` covers this in the open proposal `openspec/changes/add-push-notification-opens`. This matches PostHog/posthog-android#783 exactly: same key, same window, same first-report-wins, same skip-and-log, same no-op without `posthog.invocation_id`, and the same resend rule — including the no-delivery-id case, where neither SDK treats a missing id as a new delivery. Only the source of the delivery id differs, because each platform puts it somewhere else: `request.identifier` here, the `google.message_id` intent extra on Android.

The proposal's "Exactly one open per tap" requirement does not yet mention resends inside the window; it needs amending to match what both SDKs now do.

### Doc-comment fix (unrelated to the dedupe)

`PostHogConfig.capturePushNotificationOpened` told you to capture locally-scheduled notifications with `capturePushNotificationOpened(response:)`. That overload reads title/subtitle/body only from notifications PostHog sent (a `posthog` key in `userInfo`), so a local notification captured that way produces an event with no content at all — measured as an empty property set. The comment now points at the field-based overload and says why. The gate itself is unchanged.

Plugin floors, once 3.75.0 ships:

| Plugin | Current constraint | Picks this up? |
| --- | --- | --- |
| `@posthog/react-native-plugin` | `posthog_ios_version = '3.73.3'` → `~> 3.73.3` | No — the pin caps at `< 3.74.0`, so it needs a bump to `3.75.0` |
| `posthog_flutter` | `>= 3.74.0`, `< 4.0.0` | Yes, resolves automatically; raise the floor to `3.75.0` to guarantee it |

## :green_heart: How did you test it?

**Unit tests.** `make test` (SPM, macOS) passes: 811 Swift Testing tests in 139 suites, 0 failures. `make lint` passes (29 SwiftLint warnings, 0 serious — one more than the 28 on `main`, the added-parameter overload). `make apiCheck` reports the public API snapshot is up to date, so nothing public moved.

Ten new tests in `PostHogPushNotificationTest`: manual after automatic; automatic after manual (map form and JSON-string form); the four keys of one run vs. another run, including a missing `action_id`; no `posthog` entry; six malformed entries; the window boundary (4:59 skipped, 5:00 captured); opted out; a resend of one step (two deliveries, one key) captured twice; a repeat report of the same delivery captured once; and a resend after a first capture that carried no delivery id, captured once.

With the whole check removed, 5 of the 10 fail. Reverting only the delivery-id comparison (`isNewDelivery` forced to `false`) fails exactly 1: the resend test. Every other test, including all the manual-repeat ones, still passes both ways, which is the regression risk this change had to clear.

**Simulator.** A dedicated iPhone 17 / iOS 26.4 simulator created with `xcrun simctl create` and targeted by UDID. Every count below is the number of `$push_notification_opened` events in the SDK's `/batch` bodies, sent to a local stand-in server (the harness from PostHog/posthog-ios#792 and PostHog/posthog-flutter#556). The app is `PostHogExample` with a temporary, uncommitted harness: it sets `UNUserNotificationCenter.current().delegate`, requests notification authorization, and — as the old docs snippet did — also calls the manual `capturePushNotificationOpened` from `userNotificationCenter(_:didReceive:withCompletionHandler:)`. Notifications were delivered with `xcrun simctl push` (the `posthog` entry as a JSON string, the way the server sends it) and tapped as real banner taps with the app backgrounded. The app was terminated between rows.

| Scenario | `main` | This PR |
| --- | --- | --- |
| Tap, then manual call with the same `posthog` entry | 2 | **1** (the automatic capture survives) |
| Manual call at launch, then the tap, same entry | 2 | **1** (the manual call survives) |
| Tap `step-1`, manual call `step-2` (same run) | 2 | 2 |
| Tap + manual call, no `posthog` entry | 2 | 2 |
| Tap alone | 1 | 1 |

The `main` column for the first two rows is the falsification: with only the `recordPushOpen` check removed and nothing else changed, both go back to 2, and both events carry the same `invocation_id`/`action_id`.

**Simulator, the resend case.** A dedicated iPhone 17 Pro / iOS 26.4 simulator, targeted by UDID. Two `xcrun simctl push` deliveries of the identical payload (`invocation_id` `inv-1`, `action_id` `step-1`), each tapped as a real banner tap. iOS gave them different request identifiers, logged from the harness delegate.

| Scenario | Delivery ids | This PR |
| --- | --- | --- |
| Two notifications, one `invocation_id`/`action_id`, both tapped | `11F73E74…`, `CE768A36…` | **2** |
| One tap, automatic capture plus a manual field-based call | `E789383B…` | **1** (skip logged) |

Both events in the first row carry `$notification_title` "Dedupe Test" and `$notification_body` "Tap me", so a resend keeps its own content.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed. — the docs change is PostHog/posthog.com#20102, which is Android-only today and should be extended to iOS.
- [x] No breaking change or entry added to the changelog.

## If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote this, directed by @turnipdabeets, with posthog-android#783 as the reference to mirror. Tools used: local shell (`swift test`, `xcodebuild`, `xcrun simctl`), `gh`, and `cliclick` to drive the simulator's banner taps.

Decisions along the way: I first checked whether iOS needed the check in more than one place, the way the plugin PRs each had their own copy — it doesn't, `$push_notification_opened` is emitted from exactly one method and both public overloads and the automatic integration end there, so the check went in that one method. I reused the existing `posthogPayload(from:)` parser rather than writing a second one, and hoisted its single call above the check so the payload isn't parsed twice. For the clock I used the SDK's existing global `now()` (wall clock) rather than a monotonic source, matching Android's `dateProvider.currentTimeMillis()` — the backward-clock case is handled by only treating a non-negative gap as a repeat. State is per-`PostHogSDK` instance, as on Android, not process-wide. I considered persisting the keys and decided against it: both reports of one tap happen in the same launch.

## Related PRs

One push-open capture effort across the mobile SDKs: count every notification tap exactly once, and stop losing taps the SDK starts too late to see.

| PR | What it does | Blocked by |
| --- | --- | --- |
| PostHog/posthog-android#783 | Core: capture each PostHog push open once, whichever path reports it (ships as 3.65.0) | – |
| **PostHog/posthog-ios#828** (this PR) | Same rule on iOS, so both platforms behave identically (ships as 3.75.0) | – |
| PostHog/posthog-js#4921 | React Native on iOS: capture a tap that launches the app | – |
| PostHog/posthog-js#4929 | React Native on Android: capture a tap lost when the process was killed but the task stayed in recents | – |
| PostHog/posthog-flutter#579 | Flutter: replay a tap that arrives before the SDK is set up, instead of relying on `firebase_messaging` | – |
| PostHog/posthog-js#4919 | React Native plugin: take the core dedupe, drop the plugin-level copy | posthog-android 3.65.0 |
| PostHog/posthog-flutter#578 | Flutter plugin: take the core dedupe, drop the plugin-level copy | posthog-android 3.65.0 |
| PostHog/posthog.com#20114 | Docs corrections that are wrong today, independent of any release | – |
| PostHog/posthog.com#20102 | Docs for the release-dependent behavior changes | the SDK releases above |

**Merge order:** posthog-android#783 and posthog-ios#828 first, then their releases. #4921, #4929 and #579 are independent and can go any time. #4919 and #578 go green once posthog-android 3.65.0 is published. Docs: #20114 can go now; #20102 last, after the releases.

**Earlier work this builds on:** PostHog/posthog-android#753, PostHog/posthog-ios#792, PostHog/posthog-js#4858, PostHog/posthog-flutter#556, PostHog/posthog-flutter#557, PostHog/posthog.com#19905.

